### PR TITLE
feat: add data_download utility notebook, update final notebook data path, and clean repo structure

### DIFF
--- a/notebooks/Milestone2_Notes/Loading_Parquets
+++ b/notebooks/Milestone2_Notes/Loading_Parquets
@@ -1,0 +1,14 @@
+# Load into the terminal from the SDSC Expanse
+
+cd /expanse/lustre/scratch/[USERNAME]/temp_project
+
+module load cpu/0.15.4
+module load gcc/10.2.0
+module load anaconda3
+
+pip install -U "huggingface_hub[cli]" --quiet
+
+huggingface-cli download fddemarco/pushshift-reddit --repo-type dataset --local-dir ./pushshift-reddit
+
+# use this line to check in on data load, should be 28G and 220 files
+ls /expanse/lustre/scratch/[USERNAME]/temp_project/pushshift-reddit/data/ | wc -l

--- a/notebooks/Milestone2_Notes/Milestone2_Pushshift.ipynb
+++ b/notebooks/Milestone2_Notes/Milestone2_Pushshift.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "974b06c6-f1e1-4daa-99ab-696b5c6b4681",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Matplotlib created a temporary cache directory at /scratch/jkeeton/job_48220095/matplotlib-jyslefj0 because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spark version: 3.5.0\n",
+      "Spark UI: http://exp-2-37.expanse.sdsc.edu:4040\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.types import *\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.dates as mdates\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from datetime import datetime\n",
+    "\n",
+    "# 16 CPUS\n",
+    "# 128 GB Memory\n",
+    "\n",
+    "spark = SparkSession.builder \\\n",
+    "    .appName(\"PushshiftRedditEDA\") \\\n",
+    "    .config(\"spark.driver.memory\", \"2g\") \\\n",
+    "    .config(\"spark.executor.memory\", \"8g\") \\\n",
+    "    .config(\"spark.executor.instances\", 15) \\\n",
+    "    .config(\"spark.driver.maxResultSize\", \"2g\") \\\n",
+    "    .config(\"spark.sql.shuffle.partitions\", \"64\") \\\n",
+    "    .config(\"spark.sql.parquet.enableVectorizedReader\", \"false\") \\\n",
+    "    .getOrCreate()\n",
+    "\n",
+    "spark.sparkContext.setLogLevel(\"WARN\")\n",
+    "print(f\"Spark version: {spark.version}\")\n",
+    "print(f\"Spark UI: {spark.sparkContext.uiWebUrl}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b0874edf-f471-4369-8ea7-6e8ca7b6368e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Files loaded: 218\n",
+      "Partitions: 3339\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import glob\n",
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "DATA_DIR = \"/expanse/lustre/scratch/jkeeton/temp_project/pushshift-reddit/data/\"\n",
+    "files = sorted(glob.glob(DATA_DIR + \"*.parquet\"))\n",
+    "\n",
+    "COLS = [\"author\", \"created_utc\", \"id\", \"num_comments\", \"score\", \n",
+    "        \"selftext\", \"subreddit\", \"subreddit_id\", \"title\"]\n",
+    "\n",
+    "def read_one(path):\n",
+    "    return spark.read.parquet(path) \\\n",
+    "        .select(*[F.col(c) for c in COLS if c != \"created_utc\"],\n",
+    "                F.col(\"created_utc\").cast(\"long\").alias(\"created_utc\"))\n",
+    "\n",
+    "# Read and union all files\n",
+    "dfs = [read_one(f) for f in files]\n",
+    "df = dfs[0]\n",
+    "for d in dfs[1:]:\n",
+    "    df = df.unionByName(d)\n",
+    "\n",
+    "print(f\"Files loaded: {len(files)}\")\n",
+    "print(f\"Partitions: {df.rdd.getNumPartitions()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6943f13c-d589-45f1-872e-498d859a1f0a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root\n",
+      " |-- author: string (nullable = true)\n",
+      " |-- id: string (nullable = true)\n",
+      " |-- num_comments: long (nullable = true)\n",
+      " |-- score: long (nullable = true)\n",
+      " |-- selftext: string (nullable = true)\n",
+      " |-- subreddit: string (nullable = true)\n",
+      " |-- subreddit_id: string (nullable = true)\n",
+      " |-- title: string (nullable = true)\n",
+      " |-- created_utc: long (nullable = true)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.printSchema()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c20e83cc-a03e-4900-a8bb-c6a1394c037f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total observations: 549,662,955\n"
+     ]
+    }
+   ],
+   "source": [
+    "row_count = df.count()\n",
+    "print(f\"Total observations: {row_count:,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2233c43e-850d-4da6-9621-5e5d9304da17",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-------+-----------------+-----------------+\n",
+      "|summary|            score|     num_comments|\n",
+      "+-------+-----------------+-----------------+\n",
+      "|  count|        549662934|        549662955|\n",
+      "|   mean| 44.8390808193008|8.358100421739355|\n",
+      "| stddev|707.3788392973761|93.11190659178932|\n",
+      "|    min|                0|             -117|\n",
+      "|    max|           270469|           517003|\n",
+      "+-------+-----------------+-----------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.select(\"score\", \"num_comments\").summary(\"count\", \"mean\", \"stddev\", \"min\", \"max\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6b149670-2a3a-4df0-b5e5-231b7fc404a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+-------------------+-------------------+\n",
+      "| non_null|            min_utc|            max_utc|\n",
+      "+---------+-------------------+-------------------+\n",
+      "|549662955|2012-01-01 00:00:01|2018-12-31 23:59:59|\n",
+      "+---------+-------------------+-------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.select(\n",
+    "    F.count(\"created_utc\").alias(\"non_null\"),\n",
+    "    F.to_timestamp(F.min(\"created_utc\")).alias(\"min_utc\"),\n",
+    "    F.to_timestamp(F.max(\"created_utc\")).alias(\"max_utc\"),\n",
+    ").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d0a08706-cd8c-4447-b431-8352a1a38658",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "author\n",
+      "+-------------+\n",
+      "|count(author)|\n",
+      "+-------------+\n",
+      "|    549662955|\n",
+      "+-------------+\n",
+      "\n",
+      "created_utc\n",
+      "+------------------+\n",
+      "|count(created_utc)|\n",
+      "+------------------+\n",
+      "|         549662955|\n",
+      "+------------------+\n",
+      "\n",
+      "id\n",
+      "+---------+\n",
+      "|count(id)|\n",
+      "+---------+\n",
+      "|549662955|\n",
+      "+---------+\n",
+      "\n",
+      "num_comments\n",
+      "+-------------------+\n",
+      "|count(num_comments)|\n",
+      "+-------------------+\n",
+      "|          549662955|\n",
+      "+-------------------+\n",
+      "\n",
+      "score\n",
+      "+------------+\n",
+      "|count(score)|\n",
+      "+------------+\n",
+      "|   549662934|\n",
+      "+------------+\n",
+      "\n",
+      "selftext\n",
+      "+---------------+\n",
+      "|count(selftext)|\n",
+      "+---------------+\n",
+      "|      549662955|\n",
+      "+---------------+\n",
+      "\n",
+      "subreddit\n",
+      "+----------------+\n",
+      "|count(subreddit)|\n",
+      "+----------------+\n",
+      "|       549356476|\n",
+      "+----------------+\n",
+      "\n",
+      "subreddit_id\n",
+      "+-------------------+\n",
+      "|count(subreddit_id)|\n",
+      "+-------------------+\n",
+      "|          549356476|\n",
+      "+-------------------+\n",
+      "\n",
+      "title\n",
+      "+------------+\n",
+      "|count(title)|\n",
+      "+------------+\n",
+      "|   549662955|\n",
+      "+------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for c in COLS:\n",
+    "    print(c)\n",
+    "    df.select(F.count(c)).show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Milestone2_Notes/Milestone2_Pushshift_Updated.ipynb
+++ b/notebooks/Milestone2_Notes/Milestone2_Pushshift_Updated.ipynb
@@ -1,18 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "id": "8e18b88e-d886-43cf-b79b-0bc99001abea",
-   "metadata": {},
-   "source": [
-    "# Milestone 2 Pushshift Reddit EDA\n",
-    "\n",
-    "This notebook performs exploratory data analysis on a Pushshift Reddit dataset stored as\n",
-    "Parquet files on Expanse. The dataset covers Reddit submissions from 2012–2018 across\n",
-    "all subreddits. We examine schema, distributions, data quality, and temporal trends."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "974b06c6-f1e1-4daa-99ab-696b5c6b4681",
@@ -22,7 +10,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Matplotlib created a temporary cache directory at /scratch/jkeeton/job_48517196/matplotlib-vkba4ftu because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
+      "Matplotlib created a temporary cache directory at /scratch/jkeeton/job_48249424/matplotlib-h8o_9jf3 because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
      ]
     },
     {
@@ -30,7 +18,7 @@
      "output_type": "stream",
      "text": [
       "Spark version: 3.5.0\n",
-      "Spark UI: http://exp-8-15.expanse.sdsc.edu:4040\n"
+      "Spark UI: http://exp-13-17.expanse.sdsc.edu:4040\n"
      ]
     }
    ],
@@ -61,16 +49,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "50df9b30-96e2-4965-b950-367ef7c0da0c",
-   "metadata": {},
-   "source": [
-    "## 1. Data Loading\r\n",
-    "\r\n",
-    "We read all Parquet files from `DATA_DIR` and union them into a single Spark DataFrame."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "b0874edf-f471-4369-8ea7-6e8ca7b6368e",
@@ -90,8 +68,8 @@
     "import glob\n",
     "from pyspark.sql import functions as F\n",
     "\n",
-    "DATA_DIR = \"../data/raw/\"\n",
-    "files = sorted(glob.glob(os.path.join(DATA_DIR, \"*.parquet\")))\n",
+    "DATA_DIR = \"/expanse/lustre/scratch/jkeeton/temp_project/pushshift-reddit/data/\"\n",
+    "files = sorted(glob.glob(DATA_DIR + \"*.parquet\"))\n",
     "\n",
     "COLS = [\"author\", \"created_utc\", \"id\", \"num_comments\", \"score\", \n",
     "        \"selftext\", \"subreddit\", \"subreddit_id\", \"title\"]\n",
@@ -109,16 +87,6 @@
     "\n",
     "print(f\"Files loaded: {len(files)}\")\n",
     "print(f\"Partitions: {df.rdd.getNumPartitions()}\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "be8dd24f-4155-4f24-b31c-22eba2155fb1",
-   "metadata": {},
-   "source": [
-    "## 2. Schema & Column Descriptions\r\n",
-    "\r\n",
-    "We retain 9 columns from the raw Pushshift data:"
    ]
   },
   {
@@ -150,18 +118,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "5585f585-6f5e-45ea-bcbd-57bf873d71cd",
-   "metadata": {},
-   "source": [
-    "## 3. Dataset Size\r\n",
-    "\r\n",
-    "We cache the total row count here as `row_count` "
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "id": "c20e83cc-a03e-4900-a8bb-c6a1394c037f",
    "metadata": {},
    "outputs": [
@@ -176,21 +134,6 @@
    "source": [
     "row_count = df.count()\n",
     "print(f\"Total observations: {row_count:,}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f593bd34-ba41-48ad-9eab-06c626ecf8bb",
-   "metadata": {},
-   "source": [
-    "## 4. Numeric Summary Statistics\n",
-    "\n",
-    "Summary statistics for `score` and `num_comments`. Both columns follow a heavily\n",
-    "right-skewed distribution typical of social media engagement: the vast majority of posts\n",
-    "receive little attention while a small number go viral. The `min` value for `num_comments`\n",
-    "may be negative this is a known data artifact in Pushshift where comment counts were\n",
-    "recorded before Reddit's counters fully settled, or reflect moderation-related adjustments.\n",
-    "Negative values should be treated as 0 in any downstream modeling."
    ]
   },
   {
@@ -223,17 +166,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "fdc87f02-3cd3-40b6-841f-47fa2119e763",
-   "metadata": {},
-   "source": [
-    "### Temporal Coverage\r\n",
-    "\r\n",
-    "Verifies the date range of the dataset. The `min_utc` and `max_utc` valueshowrm the\r\n",
-    "years cove.rds."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "6b149670-2a3a-4df0-b5e5-231b7fc404a5",
@@ -261,21 +193,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "d4628980-81c0-4e52-a040-c93ee8318aa5",
-   "metadata": {},
-   "source": [
-    "## 5. Categorical Analysis\n",
-    "\n",
-    "\r\n",
-    "We use `approx_count_distinct`, ~2% relative error) rather than exact\r\n",
-    "distinct counts to avoid expensive full shuffles on hundreds of millions of rows.\r\n",
-    "If `id_approx_distinct ≈ row_count`, duplicate posts are negligible."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "78fd7689-3637-4cf8-8879-3495ec20f7b2",
    "metadata": {},
    "outputs": [
@@ -295,7 +214,7 @@
     }
    ],
    "source": [
-    "\n",
+    "# Categorical cardinality — use approx_count_distinct to avoid OOM/shuffle death\n",
     "cardinality = df.agg(\n",
     "    F.approx_count_distinct(\"author\",       rsd=0.02).alias(\"author_approx_distinct\"),\n",
     "    F.approx_count_distinct(\"subreddit\",    rsd=0.02).alias(\"subreddit_approx_distinct\"),\n",
@@ -305,25 +224,12 @@
     "\n",
     "print(cardinality.T.to_string())\n",
     "print(\"\\nNote: approx_count_distinct uses HyperLogLog with ~2% relative error.\")\n",
-    "print(f\"Total rows: {row_count:,} if id_approx_distinct ≈ total rows, duplicates are minimal.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b5333194-9dbc-4acd-86a6-91725436fc03",
-   "metadata": {},
-   "source": [
-    "### Top 20 Subreddits by Post Count\r\n",
-    "\r\n",
-    "The most-posted subreddits reveal which communities dominate the corpus.\r\n",
-    "General-interest subreddits (e.g. r/AskReddit, r/pics) are expected to lead.\r\n",
-    "A high concentration in the top 20 would indicate class imbalance relevant to\r\n",
-    "subreddit-level modeling tasks."
+    "print(f\"Total rows: {row_count:,} — if id_approx_distinct ≈ total rows, duplicates are minimal.\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "bea14f9d-3336-47c2-a50e-8ea5f1034d54",
    "metadata": {},
    "outputs": [
@@ -361,6 +267,7 @@
     }
    ],
    "source": [
+    "# Method A: Using approx_count_distinct (if id is available)\n",
     "df.groupBy(\"subreddit\") \\\n",
     "   .agg(F.approx_count_distinct(\"id\").alias(\"approx_post_count\")) \\\n",
     "   .orderBy(F.desc(\"approx_post_count\")) \\\n",
@@ -368,20 +275,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "0b8189dd-d659-4782-aafe-84d305c20585",
-   "metadata": {},
-   "source": [
-    "### Most Prolific Authors\r\n",
-    "\r\n",
-    "Identifies users responsible for the largest share of submissions. Automated or\r\n",
-    "bot accounts often appear here. High post counts from a single author may warrant\r\n",
-    "deduplication or author-level stratification in train/test splits."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "c846abda-8b1b-4c45-af8d-0e852e84f005",
    "metadata": {},
    "outputs": [
@@ -424,19 +319,6 @@
     "   .agg(F.approx_count_distinct(\"id\").alias(\"approx_post_count\")) \\\n",
     "   .orderBy(F.desc(\"approx_post_count\")) \\\n",
     "   .show(20, truncate=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cacbb2ec-9b1f-4ff2-a67d-874645ff697e",
-   "metadata": {},
-   "source": [
-    "## 6. Text Length Distributions\r\n",
-    "\r\n",
-    "Character-level length of `selftext` and `title`. Link posts and image posts have\r\n",
-    "no body text, so a large share of `selftext` will be null or placeholder strings.\r\n",
-    "Title length is bounded by Reddit's 300-character limit; very short titles (< 10 chars)\r\n",
-    "may indicate low-quality or spam submissions."
    ]
   },
   {
@@ -485,21 +367,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "352bd672-e585-4045-ace5-0c66afa13789",
-   "metadata": {},
-   "source": [
-    "## 7. Missing Value Analysis\n",
-    "\n",
-    "NULL counts per column as a percentage of total rows. For this dataset we expect:\n",
-    "- `selftext` to have a high null/placeholder rate (link-only posts have no body)\n",
-    "- `score` and `num_comments` to be nearly complete\n",
-    "- `author` nulls to be rare but non-zero (deleted accounts)\n",
-    "\n",
-    "Note that Reddit encodes absence with sentinel strings like `[removed]` and `[deleted]`."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "8c1bc25d-4cdb-4cba-a514-91e0521e20bd",
@@ -524,7 +391,7 @@
    ],
    "source": [
     "# Missing values per column (NULL counts)\n",
-    "total = row_count\n",
+    "total = df.count()\n",
     "missing_exprs = [\n",
     "    F.sum(F.when(F.col(c).isNull(), 1).otherwise(0)).alias(c)\n",
     "    for c in COLS\n",
@@ -534,17 +401,6 @@
     "missing_pd.columns = [\"null_count\"]\n",
     "missing_pd[\"pct_missing\"] = (missing_pd[\"null_count\"] / total * 100).round(4)\n",
     "print(missing_pd.to_string())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2291729f-d656-4dd9-94ca-42bf52101283",
-   "metadata": {},
-   "source": [
-    "### Sentinel Strings in `selftext`\n",
-    "\n",
-    "Reddit uses `[removed]` (moderator action) and `[deleted]` (user deletion) as\n",
-    "placeholder strings instead of NULLs."
    ]
   },
   {
@@ -580,19 +436,6 @@
     ").agg(F.count(\"*\").alias(\"count\")) \\\n",
     " .orderBy(F.desc(\"count\")) \\\n",
     " .show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cb480579-3872-4e5e-af73-868590760b68",
-   "metadata": {},
-   "source": [
-    "### Author Type Breakdown\r\n",
-    "\r\n",
-    "Categorises authors into real users, deleted accounts, AutoModerator, and nulls.\r\n",
-    "`[deleted]` authors are common in historical Reddit data; these posts lose their\r\n",
-    "attribution but the content may still be present. AutoModerator posts are bot-generated\r\n",
-    "and are typically excluded from engagement analysis."
    ]
   },
   {
@@ -632,17 +475,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "de16ee9b-2d31-4294-bac2-e082e0e9a240",
-   "metadata": {},
-   "source": [
-    "### Duplicate Post Check\n",
-    "\n",
-    "Counts rows whose `id` appears more than once. Duplicates can arise from overlapping\n",
-    "Pushshift crawl windows."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "2be2638b-2eea-49f8-8b72-0462e16f5d65",
@@ -658,44 +490,13 @@
    ],
    "source": [
     "# Duplicate check: count posts with duplicate IDs\n",
-    "dup_count = row_count - df.select(\"id\"W).distinct().count()\n",
-    "print(f\"Rows with duplicate IDs: {dup_count:,}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c9698382-1260-4e8d-9415-f9c54f444c6f",
-   "metadata": {},
-   "source": [
-    "## 8. Visualisations\n",
-    "\n",
-    "We set the FIGURES_DIR dynamically, assuming the github repo is cloned in the working directory."
+    "dup_count = df.count() - df.select(\"id\").distinct().count()\n",
+    "print(f\"Rows with duplicate IDs: {dup_count:,}\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "e2c9e752-5ade-4e66-b49d-82baada504de",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "FIGURES_DIR = os.getcwd().split('reddit-engagement-classifier')[0] +\\\n",
-    "            'reddit-engagement-classifier/outputs/figures/'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3d9fe2cf-c004-4c21-a7fa-f8712ff745cc",
-   "metadata": {},
-   "source": [
-    "### Plot 1 Monthly Post Volume (2012–2018)\n",
-    "\n",
-    "Bar chart of the number of Reddit submissions per calendar month. This reveals the overall growth trajectory of the platform over the study period and highlights any seasonal patterns or anomalies (e.g. a sudden drop may indicate a gap in Pushshift coverage rather than a real decline in activity)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "id": "04e99941-9cf5-469c-ac5e-67a4d139a081",
    "metadata": {},
    "outputs": [
@@ -732,23 +533,13 @@
     "ax.xaxis.set_major_formatter(mdates.DateFormatter(\"%Y\"))\n",
     "ax.grid(axis=\"y\", linestyle=\"--\", alpha=0.4)\n",
     "plt.tight_layout()\n",
-    "plt.savefig(os.path.join(FIGURES_DIR,\"plot1_posts_over_time.png\"), dpi=150)\n",
+    "plt.savefig(\"plot1_posts_over_time.png\", dpi=150)\n",
     "plt.show()"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "a1d9c3df-6595-4c39-8954-4ef2fb617072",
-   "metadata": {},
-   "source": [
-    "### Plot 2  Top 20 Subreddits by Post Count\n",
-    "\n",
-    "Horizontal bar chart of the 20 highest-volume subredditasks. Illustrates the long-tail distribution of community activity: a small number of subreddits account for a disproportionate share of all posts, which has implications for class balance in subreddit-classification tasks."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "id": "2607987a-5bba-46ff-935f-0271895a7538",
    "metadata": {},
    "outputs": [
@@ -777,23 +568,13 @@
     "ax.set_title(\"Top 20 Subreddits by Post Count (2012–2018)\", fontsize=14, fontweight=\"bold\")\n",
     "ax.grid(axis=\"x\", linestyle=\"--\", alpha=0.4)\n",
     "plt.tight_layout()\n",
-    "plt.savefig(os.path.join(FIGURES_DIR,\"plot2_top_subreddits.png\"), dpi=150)\n",
+    "plt.savefig(\"plot2_top_subreddits.png\", dpi=150)\n",
     "plt.show()"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "f783dfde-e1bb-4ef8-9636-8cbe5bee93d8",
-   "metadata": {},
-   "source": [
-    "### Plot 3 Post Score Distribution (Log-Bucketed)\n",
-    "\n",
-    "Posts are bucketed by order of magnitude of their score (0, 1–9, 10–99, etc.). The expected pattern is a right skewed distribution showing that only a fraction of posts reach virality."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "id": "5ed32131-12af-49ea-a582-f3cd1c1dd051",
    "metadata": {},
    "outputs": [
@@ -827,24 +608,13 @@
     "ax.set_title(\"Post Score Distribution (Log-Bucketed)\", fontsize=14, fontweight=\"bold\")\n",
     "ax.grid(axis=\"y\", linestyle=\"--\", alpha=0.4)\n",
     "plt.tight_layout()\n",
-    "plt.savefig(os.path.join(FIGURES_DIR,\"plot3_score_distribution.png\"), dpi=150)\n",
+    "plt.savefig(\"plot3_score_distribution.png\", dpi=150)\n",
     "plt.show()"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "4270baa9-8020-4ca8-a702-56c4ac9e6e33",
-   "metadata": {},
-   "source": [
-    "### Plot 4 Score vs. Comments (log-log scatter, n=50k sample)\n",
-    "\n",
-    "Scatter plot of log₁₀(score+1) vs. log₁₀(num_comments+1) on a 50,000-row sample. A positive OLS trend line indicates that higher-scored posts tend to attract more \n",
-    "comments, though the relationship has substantial variace.e"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "id": "9f4b728e-bdd4-4e6c-9ffd-2c0551169e57",
    "metadata": {},
    "outputs": [
@@ -887,24 +657,13 @@
     "ax.legend()\n",
     "ax.grid(linestyle=\"--\", alpha=0.3)\n",
     "plt.tight_layout()\n",
-    "plt.savefig(os.path.join(FIGURES_DIR,\"plot4_score_vs_comments.png\"), dpi=150)\n",
+    "plt.savefig(\"plot4_score_vs_comments.png\", dpi=150)\n",
     "plt.show()"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "98d9b6a7-0482-41b0-9890-01cf26fec43e",
-   "metadata": {},
-   "source": [
-    "### Plot 5 Post Volume by Day of Week\n",
-    "\n",
-    "Total submissions aggregated by day of week (UTC).. A midweek peak is typical \r\n",
-    "lower weekend volume suggests the platform skews toward office/school hours browsing."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "id": "7dd67554-43c2-4112-a04f-5012cca4bfe4",
    "metadata": {},
    "outputs": [
@@ -938,25 +697,13 @@
     "ax.set_title(\"Post Volume by Day of Week\", fontsize=14, fontweight=\"bold\")\n",
     "ax.grid(axis=\"y\", linestyle=\"--\", alpha=0.4)\n",
     "plt.tight_layout()\n",
-    "plt.savefig(os.path.join(FIGURES_DIR,\"plot5_posts_by_dow.png\"), dpi=150)\n",
+    "plt.savefig(\"plot5_posts_by_dow.png\", dpi=150)\n",
     "plt.show()"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "3cd3dfd1-81d8-47cf-9ab9-12665be03727",
-   "metadata": {},
-   "source": [
-    "### Plot 6 Mean vs. Median Post Score by Year\n",
-    "\n",
-    "Grouped bar chart comparing mean and median score for each year. The persistent\r\n",
-    "gap between mean and median confirms a right-skewed score distribution in every yean). Any year-over-year trend in t e\r\n",
-    "median reflects a genuine shift in typical engagement, unaffected by outliers."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "id": "9aa0ad6d-edfa-4e6d-9e3b-b684a4343f20",
    "metadata": {},
    "outputs": [
@@ -998,7 +745,7 @@
     "ax.legend()\n",
     "ax.grid(axis=\"y\", linestyle=\"--\", alpha=0.4)\n",
     "plt.tight_layout()\n",
-    "plt.savefig(os.path.join(FIGURES_DIR,\"plot6_avg_score_by_year.png\"), dpi=150)\n",
+    "plt.savefig(\"plot7_avg_score_by_year.png\", dpi=150)\n",
     "plt.show()"
    ]
   }

--- a/notebooks/Milestone2_Notes/Problem_1_Work.ipynb
+++ b/notebooks/Milestone2_Notes/Problem_1_Work.ipynb
@@ -1,0 +1,217 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "df2c85f5-647d-4156-b4a6-f66269b458cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Matplotlib created a temporary cache directory at /scratch/asanchez9/job_48453220/matplotlib-zc0zncly because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spark version: 3.5.0\n",
+      "Spark UI: http://exp-1-16.expanse.sdsc.edu:4040\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.types import *\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.dates as mdates\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from datetime import datetime\n",
+    "\n",
+    "# 16 CPUS / 128 GB Memory\n",
+    "spark = SparkSession.builder \\\n",
+    "    .appName(\"PushshiftRedditEDA\") \\\n",
+    "    .config(\"spark.driver.memory\", \"8g\") \\\n",
+    "    .config(\"spark.driver.maxResultSize\", \"4g\") \\\n",
+    "    .config(\"spark.executor.memory\", \"16g\") \\\n",
+    "    .config(\"spark.executor.instances\", 6) \\\n",
+    "    .config(\"spark.sql.shuffle.partitions\", \"200\") \\\n",
+    "    .config(\"spark.sql.parquet.enableVectorizedReader\", \"true\") \\\n",
+    "    .getOrCreate()\n",
+    "\n",
+    "spark.sparkContext.setLogLevel(\"WARN\")\n",
+    "print(f\"Spark version: {spark.version}\")\n",
+    "print(f\"Spark UI: {spark.sparkContext.uiWebUrl}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8faeab51-0fc3-4ba2-8a44-7b95a227bec9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df823710fa8743d6962ef2b9729342f0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Fetching 220 files:   0%|          | 0/220 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloaded dataset to: /expanse/lustre/projects/uci157/asanchez9/data/raw\n",
+      "Hugging Face cache: /expanse/lustre/projects/uci157/asanchez9/data/hf_cache\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "from huggingface_hub import snapshot_download\n",
+    "\n",
+    "#Setting the data and Hugging Face cache directories\n",
+    "DATA_DIR = Path(os.environ.get(\"PUSHSHIFT_DATA_DIR\", \"data/raw\")).expanduser()\n",
+    "HF_HOME = Path(os.environ.get(\"HF_HOME\", \"data/hf_cache\")).expanduser()\n",
+    "\n",
+    "#Create directories\n",
+    "DATA_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "HF_HOME.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "# Set Hugging Face cache directory path\n",
+    "os.environ[\"HF_HOME\"] = str(HF_HOME)\n",
+    "\n",
+    "# Download dataset from Hugging Face to local data directory using specified cache\n",
+    "snapshot_download(\n",
+    "    repo_id=\"fddemarco/pushshift-reddit\",\n",
+    "    repo_type=\"dataset\",\n",
+    "    local_dir=str(DATA_DIR),\n",
+    "    cache_dir=str(HF_HOME),\n",
+    "    token=False,\n",
+    ")\n",
+    "\n",
+    "#Print downloaded data directories\n",
+    "print(f\"Downloaded dataset to: {DATA_DIR.resolve()}\")\n",
+    "print(f\"Hugging Face cache: {HF_HOME.resolve()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b5a882bd-1265-42d4-ac53-53c6fc362868",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data directory: /expanse/lustre/projects/uci157/asanchez9/data/raw\n",
+      "Files loaded: 218\n",
+      "Partitions: 3339\n"
+     ]
+    }
+   ],
+   "source": [
+    "files = sorted(DATA_DIR.rglob(\"*.parquet\"))\n",
+    "\n",
+    "if not files:\n",
+    "    raise FileNotFoundError(\n",
+    "        f\"No parquet files found under {DATA_DIR.resolve()}. \"\n",
+    "        \"Check that the download completed successfully.\"\n",
+    "    )\n",
+    "\n",
+    "COLS = [\n",
+    "    \"author\", \"created_utc\", \"id\", \"num_comments\", \"score\",\n",
+    "    \"selftext\", \"subreddit\", \"subreddit_id\", \"title\"\n",
+    "]\n",
+    "\n",
+    "def read_one(path):\n",
+    "    return (\n",
+    "        spark.read.parquet(str(path))\n",
+    "        .select(\n",
+    "            *[F.col(c) for c in COLS if c != \"created_utc\"],\n",
+    "            F.col(\"created_utc\").cast(\"long\").alias(\"created_utc\")\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "dfs = [read_one(f) for f in files]\n",
+    "df = dfs[0]\n",
+    "for d in dfs[1:]:\n",
+    "    df = df.unionByName(d)\n",
+    "\n",
+    "print(f\"Data directory: {DATA_DIR.resolve()}\")\n",
+    "print(f\"Files loaded: {len(files)}\")\n",
+    "print(f\"Partitions: {df.rdd.getNumPartitions()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "017f7ee4-ae6c-49f1-acd9-fdf15ef68f16",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root\n",
+      " |-- author: string (nullable = true)\n",
+      " |-- id: string (nullable = true)\n",
+      " |-- num_comments: long (nullable = true)\n",
+      " |-- score: long (nullable = true)\n",
+      " |-- selftext: string (nullable = true)\n",
+      " |-- subreddit: string (nullable = true)\n",
+      " |-- subreddit_id: string (nullable = true)\n",
+      " |-- title: string (nullable = true)\n",
+      " |-- created_utc: long (nullable = true)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.printSchema()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03028ae3-fc2d-4ced-bb8a-8818f6d02ed8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/data_download.ipynb
+++ b/notebooks/data_download.ipynb
@@ -1,0 +1,138 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "82f517cc-ce84-49ef-bd00-217c4007de93",
+   "metadata": {},
+   "source": [
+    "# Data Download\n",
+    "\n",
+    "Run this notebook once from a JupyterLab compute node session on the SDSC Expanse cluster before running any notebooks. Do not run from the login node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3b27e5d-08b5-47e4-94fd-62453e8a208c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load modules and install HuggingFace CLI\n",
+    "!module load cpu/0.15.4\n",
+    "!module load gcc/10.2.0  \n",
+    "!module load anaconda3\n",
+    "!pip install -U \"huggingface_hub[cli]\" --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6366cc09-38e6-496a-87a6-2997ae7894ab",
+   "metadata": {},
+   "source": [
+    "## Download Dataset\n",
+    "\n",
+    "Downloads the Pushshift Reddit dataset from HuggingFace into a temporary directory `data/raw/tmp/`. The HuggingFace repository contains a nested `data/` subfolder and a `README.md` — we use a temp location so we can extract only the Parquet files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b289a17-8ac0-4db0-b61d-76df75a72b6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download dataset to data/raw/\n",
+    "\n",
+    "import os\n",
+    "os.environ[\"PATH\"] = os.path.expanduser(\"~/.local/bin\") + \":\" + os.environ[\"PATH\"]\n",
+    "os.environ[\"HF_HOME\"] = os.path.expanduser(\"~/.cache/huggingface\")\n",
+    "os.environ[\"HUGGINGFACE_HUB_CACHE\"] = os.path.expanduser(\"~/.cache/huggingface\")\n",
+    "\n",
+    "!hf download fddemarco/pushshift-reddit \\\n",
+    "    --repo-type dataset \\\n",
+    "    --local-dir ../data/raw/tmp/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3b126b1-5dba-4713-bb9c-b0ad1ba8173a",
+   "metadata": {},
+   "source": [
+    "## Move Parquet Files to data/raw/\n",
+    "\n",
+    "Moves only the Parquet files from the nested `tmp/data/` subfolder into `data/raw/`, discarding the dataset README and any other non-data files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7267f6df-07dd-4ec6-80e6-92f463731458",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mv ../data/raw/tmp/data/*.parquet ../data/raw/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a916170e-5bad-40fc-9bba-059956f146fe",
+   "metadata": {},
+   "source": [
+    "## Clean Up\n",
+    "\n",
+    "Removes the temporary download directory now that all Parquet files have been moved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3255bf0b-e129-4147-a873-542a9f43d9fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -rf ../data/raw/tmp/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad3d7391-377b-4066-bc50-cef5a0acb032",
+   "metadata": {},
+   "source": [
+    "## Verify Download\n",
+    "\n",
+    "The download is complete when the file count returns 220."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc7ac940-5c2c-4691-87ee-504985c85c14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls ../data/raw/ | wc -l"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Updates the canonical EDA notebook with a relative data path and adds a utility notebook for downloading the dataset.

## Changes
- Updated `DATA_DIR` in `Milestone2_Pushshift.ipynb` from hardcoded personal scratch path to `../data/raw/` — works for any team member with data downloaded via `data_download.ipynb`
- Added `notebooks/data_download.ipynb` — one-time utility script for downloading the 89GB Pushshift dataset from HuggingFace into `data/raw/`
- Added `notebooks/Milestone2_Notes/` — working notes and scratch notebooks

## Notes
Data now loads from `data/raw/` relative to the notebooks directory. All team members must run `data_download.ipynb` once before running the EDA notebook.