### PR TITLE
feat: further EDA prep for preprocessing, add neg comment counts, empty title check, etc. Add Milestone 3 notebook

### DIFF
--- a/notebooks/Milestone2_Pushshift.ipynb
+++ b/notebooks/Milestone2_Pushshift.ipynb
@@ -22,7 +22,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Matplotlib created a temporary cache directory at /scratch/ekim18/job_48642568/matplotlib-8iikkyx4 because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
+      "Matplotlib created a temporary cache directory at /scratch/ekim18/job_48745163/matplotlib-p05ie7z6 because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
      ]
     },
     {
@@ -30,7 +30,7 @@
      "output_type": "stream",
      "text": [
       "Spark version: 3.5.0\n",
-      "Spark UI: http://exp-16-56.expanse.sdsc.edu:4040\n"
+      "Spark UI: http://exp-5-54.expanse.sdsc.edu:4040\n"
      ]
     }
    ],
@@ -47,8 +47,8 @@
     "# 16 CPUS / 128 GB Memory\n",
     "spark = SparkSession.builder \\\n",
     "    .appName(\"PushshiftRedditEDA\") \\\n",
-    "    .config(\"spark.driver.memory\", \"8g\") \\\n",
-    "    .config(\"spark.driver.maxResultSize\", \"4g\") \\\n",
+    "    .config(\"spark.driver.memory\", \"120g\") \\\n",
+    "    .config(\"spark.driver.maxResultSize\", \"8g\") \\\n",
     "    .config(\"spark.executor.memory\", \"16g\") \\\n",
     "    .config(\"spark.executor.instances\", 6) \\\n",
     "    .config(\"spark.sql.shuffle.partitions\", \"200\") \\\n",
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "b0874edf-f471-4369-8ea7-6e8ca7b6368e",
    "metadata": {},
    "outputs": [],
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "3ffd34ff-f02c-4c5c-b4c1-2bcb8116830e",
    "metadata": {},
    "outputs": [
@@ -163,6 +163,8 @@
     }
    ],
    "source": [
+    "# DataFrame Schema \n",
+    "\n",
     "df.printSchema()"
    ]
   },
@@ -191,6 +193,8 @@
     }
    ],
    "source": [
+    "# Full Dataset Row Count\n",
+    "\n",
     "row_count = df.count()\n",
     "print(f\"Total observations: {row_count:,}\")"
    ]
@@ -246,8 +250,7 @@
    "source": [
     "### Temporal Coverage\r\n",
     "\r\n",
-    "Verifies the date range of the dataset. The `min_utc` and `max_utc` valueshowrm the\r\n",
-    "years cove.rds."
+    "Verifies the date range of the dataseds."
    ]
   },
   {
@@ -312,7 +315,6 @@
     }
    ],
    "source": [
-    "\n",
     "cardinality = df.agg(\n",
     "    F.approx_count_distinct(\"author\",       rsd=0.02).alias(\"author_approx_distinct\"),\n",
     "    F.approx_count_distinct(\"subreddit\",    rsd=0.02).alias(\"subreddit_approx_distinct\"),\n",
@@ -566,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "73d63749-4fff-4373-a515-58e07b57e6a7",
    "metadata": {},
    "outputs": [
@@ -614,7 +616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "14e09928-ed5d-4d8b-a727-f4768860e10e",
    "metadata": {},
    "outputs": [
@@ -650,13 +652,57 @@
   },
   {
    "cell_type": "markdown",
+   "id": "efa12e75-e08d-4a9b-8d0c-32a4ba949ada",
+   "metadata": {},
+   "source": [
+    "Next, we check post count, average comment count, and average score for rows with \"real users\" (we will analyze bot authors later) vs. deleted or empty authors.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "474b98dc-f6b5-4723-a230-01d3231431b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----------+---------+------------------+-----------------+\n",
+      "|author_type|    count|         avg_score|     avg_comments|\n",
+      "+-----------+---------+------------------+-----------------+\n",
+      "|    deleted| 73272560|14.060048686711642|3.336374831178275|\n",
+      "|  real_user|446133521| 51.96279854796826|9.407189981135716|\n",
+      "|      empty| 30256874|14.337891416013433|5.050444470899406|\n",
+      "+-----------+---------+------------------+-----------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Row count, average comment count, and average score by real vs. empty/deleted users\n",
+    "\n",
+    "df.withColumn(\"author_type\", \n",
+    "    F.when(F.col(\"author\") == \"[deleted]\", \"deleted\")\n",
+    "     .when(F.col(\"author\") == \"\", \"empty\")\n",
+    "     .otherwise(\"real_user\")\n",
+    ") \\\n",
+    ".groupBy(\"author_type\") \\\n",
+    ".agg(\n",
+    "    F.count(\"*\").alias(\"count\"),\n",
+    "    F.mean(\"score\").alias(\"avg_score\"),\n",
+    "    F.mean(\"num_comments\").alias(\"avg_comments\")\n",
+    ").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "de16ee9b-2d31-4294-bac2-e082e0e9a240",
    "metadata": {},
    "source": [
     "### Duplicate Post Check\n",
     "\n",
-    "Counts rows whose `id` appears more than once. Duplicates can arise from overlapping\n",
-    "Pushshift crawl windows."
+    "Counts rows whose `id` appears more than once. Duplicates can arise from overlapping Pushshift crawl windows."
    ]
   },
   {
@@ -681,6 +727,166 @@
   },
   {
    "cell_type": "markdown",
+   "id": "511aa874-5d65-4ad0-8a71-8e7c2e543afa",
+   "metadata": {},
+   "source": [
+    "### Negative Comment Check\n",
+    "\n",
+    "Count rows with negative `num_comment` values which is a known Pushshift issue when data was recorded. Since we cannot attribute true comment count from negative comment values, they will likely be dropped in preprocessing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "0084fd06-9c52-4463-bda1-6c9a39ffd568",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rows with negative num_comments: 1,090\n",
+      "Percentage of total: 0.0002%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Negative Comment Count\n",
+    "\n",
+    "neg_comments = df.filter(F.col(\"num_comments\") < 0).count()\n",
+    "print(f\"Rows with negative num_comments: {neg_comments:,}\")\n",
+    "print(f\"Percentage of total: {neg_comments / row_count * 100:.4f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d298841a-6820-4ddf-bc0c-70d0bda345bd",
+   "metadata": {},
+   "source": [
+    "### Zero-Length Title Check\n",
+    "\n",
+    "Rows with `title` length of zero may not have any usable signal so we further analyze these rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "17ae19fe-0c3b-481c-baae-3584485ab258",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Zero-length titles: 912,556\n",
+      "Percentage: 0.1660%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Zero-Length Title Count\n",
+    "\n",
+    "zero_titles = df.filter(F.length(F.col(\"title\")) == 0).count()\n",
+    "print(f\"Zero-length titles: {zero_titles:,}\")\n",
+    "print(f\"Percentage: {zero_titles / row_count * 100:.4f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd378c01-253c-4a6d-b692-13c18fc2778a",
+   "metadata": {},
+   "source": [
+    "There are 912,556 rows with `title` length of zero which makes up 1.66% of the dataset so we dive deeper into what these rows actually look like and confirm if these rows contain usable signal. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "7617ca7a-9b52-4714-88e5-5c442d2697d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------------+------+------------+-----+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------+------------+-----+-----------+\n",
+      "|author      |id    |num_comments|score|selftext                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |subreddit       |subreddit_id|title|created_utc|\n",
+      "+------------+------+------------+-----+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------+------------+-----+-----------+\n",
+      "|arideout12  |2qys8u|10          |3    |laptop questionnaire country of purchaseusa budget rangelt1200 usd purpose netbook ultraportable mainstream gaming desktop replacement etci will need to be able to use it for school and leisure i will also be doing programming and maybe some gaming but nothing too intense main use will be for internet browsing and word processing  screen size preference13 inches up os preference windows mac linuxwindows gaming requirements example games and desired fpssettingsi would like to be able to run steam games without serious functional issues 30fps is fine  performance requirements video cad etc method of computer support office supplier college bookstore self support brand preferences and reasons already owned accessories familiarity business compatibility any particular style that you like examples are greati like laptops with real keyboards not like the ones on the surface pro which of the following qualities would you prefer choose one the other or balanced long battery life vs low weightlong battery life is prefereable build quality vs low pricebuild quality low noiseheat vs high performancebalanced  would you pay a premium for something that has high resolution screennot super important a great keyboardjust needs to be functional a great touchpadmouse buttonswould like a good touchpad great audionot neccecarylist any features that are critical eg optical drive usb 30 sd card slot ethernet port hdmi port bluetooth vga port removable battery glossy screen matte screen etc  for sure need usb would prefer to have a cd drive but not necessary not opposed to a touchscreen or 2 in 1 either|SuggestALaptop  |t5_2s4k5    |     |1420070420 |\n",
+      "|Novawolx    |2qytaj|7           |1    |add me please ill add u                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |friendsafari    |t5_2yt52    |     |1420070996 |\n",
+      "|[deleted]   |2qyu04|0           |1    |the hellenic diplomat who went to far and spilled pau private information has been arrested by the heart of darknesshis diplomatic immunity has been wasted by his own mistake of following a government that apparently doesnt respect simple and basic rulesthe pau is holding an emergency voting session deciding on the expulsion of greece next month we will come with resultsthe current stance is 10 in favour 1 against in this vote members count as 3 and observers as 1ofcourse no hellenic will be allowed into the headquarters even though they are technically still a member                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |worldpowers     |t5_30yfr    |     |1420071439 |\n",
+      "|Shadoxfix   |2qyv6j|1           |14   |myanimelist previous episodesepisodereddit linkepisodereddit linkepisodereddit linkepisodereddit linkepisode 1 14 27 40episode 2 15 28 41episode 3 16 29 42episode 4 17 30 43episode 5 18 31 44episode 6 19 32 45episode 7 20 33 46episode 8 21 34 47episode 9 22 35 48episode 10 23 36 49episode 11 24 37 50episode 12 25 38 51episode 13 26 39 52episodereddit linkepisode 53episode 54episode 55episode 56episode 57episode 58episode 59episode 60episode 61episode 62reminder please do not discuss any plot points which havent appeared in the anime yet try not to confirm or deny any theories encourage people to read the source material instead minor spoilers are generally ok but should be tagged accordingly failing to comply with the rules may result in your comment being removed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |anime           |t5_2qh22    |     |1420072153 |\n",
+      "|[deleted]   |2qyvdf|1           |1    |can you help me improve the performance and lower the price as well  typeitempricecpu    29900  ple computers cpu cooler    14900  ple computers motherboard    27500  ple computers storage    9200  ple computers storage    17600  ple computers video card    76900  ple computers case    19900  cpl online power supply    33400  ple computers optical drive   monitor    59900  cpl online    total  prices include shipping taxes and discounts when available  289200  generated by pcpartpicker 20150101 1157 est1100                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |buildapc        |t5_2rnve    |     |1420072268 |\n",
+      "|MehGustaa   |2qyvf0|0           |1    |looking for a spvp guild preferably in aurora glade                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |guildrecruitment|t5_2thc3    |     |1420072296 |\n",
+      "|Gredstinue  |2qyvpt|6           |1    |id like to figure out what pokemon are in my safari                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |friendsafari    |t5_2yt52    |     |1420072510 |\n",
+      "|Aznblaze    |2qyvus|1           |3    |feel free to talk about anything i know the holidays can be a low point for a lot of people im here to let people know they arent alone and offer any helpful advice just be honest plus it makes me feel productive the world isnt as pleasant of a place as some people like to pretend the only way to stay sane is to look out for one another nobody likes to be vulnerable but were only human                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |KindVoice       |t5_2xjrr    |     |1420072596 |\n",
+      "|ICANZ_MURICA|2qyw0f|3           |3    |samson manufacturing star c 7 ff quad rail  it is in essentially new condition taken off a new stag arms carbine upper  the twopiece design allows for easy installation without removal of any gas system or barrel components  also installs on standard mill spec barrel nut so would make for a good choice to easily install on an upper with a fixed fsb asking 100 plus shipping                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |Gunsforsale     |t5_2sdvv    |     |1420072698 |\n",
+      "|[deleted]   |2qywab|5           |2    |tried scandal couldnt stand anything paste the first seasonenjoyed weeds for what it was its wasnt greatprefer if available on netflix hbo go or amazon instant                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |ifyoulikeblank  |t5_2sekf    |     |1420072868 |\n",
+      "+------------+------+------------+-----+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------+------------+-----+-----------+\n",
+      "only showing top 10 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# What do zero-length title rows look like?\n",
+    "\n",
+    "df.filter(F.length(F.col(\"title\")) == 0).show(10, truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b83fac79-044d-43f9-b195-eb9600da0be7",
+   "metadata": {},
+   "source": [
+    "These are real posts, not corrupted data. Rows have legitimate selftext content, subreddits, real authors, scores, and comment counts. It seems like the titles might have been stored in `selftext` instead. However, the engagement signals seem to be intact. \n",
+    "\n",
+    "This brings up another question though: Do zero-length title posts have a distinct engagement pattern compared to other posts? We analyze below by querying count, average score, and average comment conunt for posts with and without titles. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "ee66de7f-ad0d-4560-8195-b54dc24978eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+---------+------------------+-----------------+\n",
+      "|has_title|    count|         avg_score|     avg_comments|\n",
+      "+---------+---------+------------------+-----------------+\n",
+      "|has_title|548750399| 44.89572037069285|8.359162609009784|\n",
+      "| no_title|   912556|10.779828306427222|7.719371742665656|\n",
+      "+---------+---------+------------------+-----------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Count, Average Score, and Average Comment Count for Posts w/ Titles vs. No Title\n",
+    "\n",
+    "df.withColumn(\"has_title\", F.when(F.length(F.col(\"title\")) == 0, \"no_title\")\n",
+    "                             .otherwise(\"has_title\")) \\\n",
+    "  .groupBy(\"has_title\") \\\n",
+    "  .agg(\n",
+    "      F.count(\"*\").alias(\"count\"),\n",
+    "      F.mean(\"score\").alias(\"avg_score\"),\n",
+    "      F.mean(\"num_comments\").alias(\"avg_comments\")\n",
+    "  ).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b8e11ed-c2b2-4ccf-b74f-c4fd05e317f3",
+   "metadata": {},
+   "source": [
+    "Posts with titles have a higher average score (about 4x higher). Comment counts are similar but this is a meaningful finding nonetheless. We will likely keep these rows in our model df."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c9698382-1260-4e8d-9415-f9c54f444c6f",
    "metadata": {},
    "source": [
@@ -691,7 +897,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "id": "e2c9e752-5ade-4e66-b49d-82baada504de",
    "metadata": {},
    "outputs": [],
@@ -973,7 +1179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 7,
    "id": "9aa0ad6d-edfa-4e6d-9e3b-b684a4343f20",
    "metadata": {},
    "outputs": [
@@ -1015,7 +1221,7 @@
     "ax.legend()\n",
     "ax.grid(axis=\"y\", linestyle=\"--\", alpha=0.4)\n",
     "plt.tight_layout()\n",
-    "plt.savefig(os.path.join(FIGURES_DIR,\"plot6_avg_score_by_year.png\"), dpi=150)\n",
+    "plt.savefig(os.path.join(FIGURES_DIR,\"plot6_mean_median_score_by_year.png\"), dpi=150)\n",
     "plt.show()"
    ]
   },

--- a/notebooks/Milestone3_Pushshift.ipynb
+++ b/notebooks/Milestone3_Pushshift.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8a9bf756-fc26-40ed-83e9-515d38cb7a0e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Matplotlib created a temporary cache directory at /scratch/ekim18/job_48716776/matplotlib-875m8fpa because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Dependencies \n",
+    "\n",
+    "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.types import *\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.dates as mdates\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from datetime import datetime\n",
+    "import os\n",
+    "import glob\n",
+    "from functools import reduce\n",
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.types import LongType\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b2646d4d-b832-49a0-b91a-c38ec0286fd1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spark version: 3.5.0\n",
+      "Spark UI: http://exp-1-02.expanse.sdsc.edu:4040\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SparkSession Configuration\n",
+    "\n",
+    "# 16 cores, 128GB total memory — local[*] mode\n",
+    "# In local mode there are no separate executor processes — all task execution\n",
+    "# runs as threads within a single JVM. Executor config parameters have no effect\n",
+    "# and are omitted. Driver memory is set to 120GB to give the JVM nearly the\n",
+    "# full node allocation.\n",
+    "spark = SparkSession.builder \\\n",
+    "    .appName(\"PushshiftRedditPreprocessing\") \\\n",
+    "    .config(\"spark.driver.memory\", \"120g\") \\\n",
+    "    .config(\"spark.driver.maxResultSize\", \"8g\") \\\n",
+    "    .config(\"spark.sql.shuffle.partitions\", \"200\") \\\n",
+    "    .config(\"spark.sql.parquet.enableVectorizedReader\", \"true\") \\\n",
+    "    .getOrCreate()\n",
+    "\n",
+    "spark.sparkContext.setLogLevel(\"WARN\")\n",
+    "print(f\"Spark version: {spark.version}\")\n",
+    "print(f\"Spark UI: {spark.sparkContext.uiWebUrl}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "58c4a5bf-4422-41fc-9e57-919c108a0d21",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Files loaded: 218\n",
+      "Partitions: 683\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Data Load \n",
+    "\n",
+    "DATA_DIR = \"../data/raw/\"\n",
+    "files = sorted(glob.glob(os.path.join(DATA_DIR, \"*.parquet\")))\n",
+    "\n",
+    "COLS = [\"author\", \"created_utc\", \"id\", \"num_comments\", \"score\",\n",
+    "        \"selftext\", \"subreddit\", \"subreddit_id\", \"title\"]\n",
+    "\n",
+    "pre_cutoff = [f for f in files if os.path.basename(f) >= \"RS_2015-01\"]\n",
+    "post_cutoff = [f for f in files if os.path.basename(f) < \"RS_2015-01\"]\n",
+    "\n",
+    "# Files where created_utc is STRING - need to cast\n",
+    "df_pre = spark.read.parquet(*pre_cutoff) \\\n",
+    "    .select(*[F.col(c) for c in COLS if c != 'created_utc'],\n",
+    "            F.col('created_utc').cast('long').alias('created_utc'))\n",
+    "\n",
+    "df_post = spark.read.parquet(*post_cutoff) \\\n",
+    "    .select(*[F.col(c) for c in COLS if c != 'created_utc'],\n",
+    "            F.col('created_utc').cast('long').alias('created_utc'))\n",
+    "\n",
+    "MIN_TS = 1119398400  # June 2005\n",
+    "MAX_TS = 1700000000  # Nov 2023\n",
+    "\n",
+    "df = df_pre.union(df_post) \\\n",
+    "    .filter(F.col('created_utc').between(MIN_TS, MAX_TS))\n",
+    "\n",
+    "print(f\"Files loaded: {len(files)}\")\n",
+    "print(f\"Partitions: {df.rdd.getNumPartitions()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bfd0a882-4660-45a4-82c7-d152f194c569",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       id  totalCores    maxMemory  activeTasks  isActive  maxMemory_GB\n",
+      "0  driver          16  77120667648            0      True         71.82\n",
+      "local[*]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SparkUI Screenshot\n",
+    "\n",
+    "# Get the active Spark Context and URL\n",
+    "sc = spark.sparkContext\n",
+    "url = f\"{sc.uiWebUrl}/api/v1/applications/{sc.applicationId}/executors\"\n",
+    "\n",
+    "# Fetch the executor data from the API\n",
+    "response = requests.get(url)\n",
+    "executors = response.json()\n",
+    "\n",
+    "# Format into a readable DataFrame\n",
+    "sparkUI_df = pd.DataFrame(executors)[['id', 'totalCores', 'maxMemory', 'activeTasks', 'isActive']]\n",
+    "sparkUI_df['maxMemory_GB'] = (sparkUI_df['maxMemory'] / (1024**3)).round(2)\n",
+    "print(sparkUI_df)\n",
+    "\n",
+    "# Spark context master check\n",
+    "print(spark.sparkContext.master)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0b489152-f0d9-4dd3-a6e2-738c58386ab8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hardcode row_count to dataset size for count verifications\n",
+    "\n",
+    "row_count = 549662955"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "475c5273-ce0f-40e2-9098-9067756584e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original row count:      549,662,955\n",
+      "Row count after filters: 549,355,364\n",
+      "Rows removed:            307,591\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── FILTERING & CLEANING ─────────────────────────────────────────────────────\n",
+    "\n",
+    "df_clean = df \\\n",
+    "    .filter(F.col(\"subreddit\").isNotNull()) \\\n",
+    "    .filter(F.col(\"subreddit_id\").isNotNull()) \\\n",
+    "    .filter(F.col(\"score\").isNotNull()) \\\n",
+    "    .filter(F.col(\"num_comments\") >= 0) \\\n",
+    "    .dropDuplicates([\"id\"])\n",
+    "\n",
+    "print(f\"Original row count:      {row_count:,}\")\n",
+    "clean_count = df_clean.count()\n",
+    "print(f\"Row count after filters: {clean_count:,}\")\n",
+    "print(f\"Rows removed:            {row_count - clean_count:,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7345f3e8-d1c3-4919-8291-204ce32cf3b3",
+   "metadata": {},
+   "source": [
+    "## Bot Author Handling\n",
+    "\n",
+    "Rather than attempting frequency-based bot detection (which would require a full groupBy on author + date across 549M rows to compute per-author daily post rates), we take a simpler and more interpretable approach: flagging known high-volume bot accounts identified in EDA as a binary feature `is_known_bot`.\n",
+    "\n",
+    "This preserves all bot-authored posts in the dataset — bot posts have real and consistent engagement patterns (clustering heavily in low-engagement) that the model can learn from. Filtering them out would discard genuine signal. The `is_known_bot` flag gives the model explicit information about author type without requiring expensive per-author temporal aggregations.\n",
+    "\n",
+    "The known bot list is seeded from the top authors output in EDA. Frequency-based detection can be revisited in as feature engineering improvement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "81b2031c-d02f-47dc-ac13-defa61abb333",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Author type features added.\n"
+     ]
+    },
+    {
+     "ename": "Py4JJavaError",
+     "evalue": "An error occurred while calling o143.showString.\n: org.apache.spark.SparkException: Job aborted due to stage failure: Task 351 in stage 10.0 failed 1 times, most recent failure: Lost task 351.0 in stage 10.0 (TID 1322) (exp-1-02.expanse.sdsc.edu executor driver): java.io.IOException: No space left on device\n\tat java.base/java.io.FileOutputStream.writeBytes(Native Method)\n\tat java.base/java.io.FileOutputStream.write(FileOutputStream.java:349)\n\tat org.apache.spark.storage.TimeTrackingOutputStream.write(TimeTrackingOutputStream.java:59)\n\tat org.apache.spark.io.MutableCheckedOutputStream.write(MutableCheckedOutputStream.scala:43)\n\tat java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)\n\tat java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:127)\n\tat net.jpountz.lz4.LZ4BlockOutputStream.flushBufferedData(LZ4BlockOutputStream.java:225)\n\tat net.jpountz.lz4.LZ4BlockOutputStream.write(LZ4BlockOutputStream.java:178)\n\tat java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)\n\tat java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:127)\n\tat java.base/java.io.DataOutputStream.write(DataOutputStream.java:112)\n\tat org.apache.spark.sql.catalyst.expressions.UnsafeRow.writeToStream(UnsafeRow.java:519)\n\tat org.apache.spark.sql.execution.UnsafeRowSerializerInstance$$anon$1.writeValue(UnsafeRowSerializer.scala:69)\n\tat org.apache.spark.storage.DiskBlockObjectWriter.write(DiskBlockObjectWriter.scala:312)\n\tat org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:171)\n\tat org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)\n\tat org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:104)\n\tat org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:54)\n\tat org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:161)\n\tat org.apache.spark.scheduler.Task.run(Task.scala:141)\n\tat org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:620)\n\tat org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)\n\tat org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)\n\tat org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)\n\tat org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:623)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\n\tat java.base/java.lang.Thread.run(Thread.java:833)\n\nDriver stacktrace:\n\tat org.apache.spark.scheduler.DAGScheduler.failJobAndIndependentStages(DAGScheduler.scala:2844)\n\tat org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2(DAGScheduler.scala:2780)\n\tat org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2$adapted(DAGScheduler.scala:2779)\n\tat scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)\n\tat scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)\n\tat scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)\n\tat org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:2779)\n\tat org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1(DAGScheduler.scala:1242)\n\tat org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1$adapted(DAGScheduler.scala:1242)\n\tat scala.Option.foreach(Option.scala:407)\n\tat org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:1242)\n\tat org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:3048)\n\tat org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2982)\n\tat org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2971)\n\tat org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)\nCaused by: java.io.IOException: No space left on device\n\tat java.base/java.io.FileOutputStream.writeBytes(Native Method)\n\tat java.base/java.io.FileOutputStream.write(FileOutputStream.java:349)\n\tat org.apache.spark.storage.TimeTrackingOutputStream.write(TimeTrackingOutputStream.java:59)\n\tat org.apache.spark.io.MutableCheckedOutputStream.write(MutableCheckedOutputStream.scala:43)\n\tat java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)\n\tat java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:127)\n\tat net.jpountz.lz4.LZ4BlockOutputStream.flushBufferedData(LZ4BlockOutputStream.java:225)\n\tat net.jpountz.lz4.LZ4BlockOutputStream.write(LZ4BlockOutputStream.java:178)\n\tat java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)\n\tat java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:127)\n\tat java.base/java.io.DataOutputStream.write(DataOutputStream.java:112)\n\tat org.apache.spark.sql.catalyst.expressions.UnsafeRow.writeToStream(UnsafeRow.java:519)\n\tat org.apache.spark.sql.execution.UnsafeRowSerializerInstance$$anon$1.writeValue(UnsafeRowSerializer.scala:69)\n\tat org.apache.spark.storage.DiskBlockObjectWriter.write(DiskBlockObjectWriter.scala:312)\n\tat org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:171)\n\tat org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)\n\tat org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:104)\n\tat org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:54)\n\tat org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:161)\n\tat org.apache.spark.scheduler.Task.run(Task.scala:141)\n\tat org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:620)\n\tat org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)\n\tat org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)\n\tat org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)\n\tat org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:623)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\n\tat java.base/java.lang.Thread.run(Thread.java:833)\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mPy4JJavaError\u001b[0m                             Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[8], line 22\u001b[0m\n\u001b[1;32m      9\u001b[0m df_clean \u001b[38;5;241m=\u001b[39m df_clean \\\n\u001b[1;32m     10\u001b[0m     \u001b[38;5;241m.\u001b[39mwithColumn(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mis_known_bot\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m     11\u001b[0m         F\u001b[38;5;241m.\u001b[39mwhen(F\u001b[38;5;241m.\u001b[39mcol(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mauthor\u001b[39m\u001b[38;5;124m\"\u001b[39m)\u001b[38;5;241m.\u001b[39misin(\u001b[38;5;28mlist\u001b[39m(KNOWN_BOTS)), \u001b[38;5;241m1\u001b[39m)\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     18\u001b[0m         F\u001b[38;5;241m.\u001b[39mwhen(F\u001b[38;5;241m.\u001b[39mlength(F\u001b[38;5;241m.\u001b[39mcol(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtitle\u001b[39m\u001b[38;5;124m\"\u001b[39m)) \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m)\n\u001b[1;32m     19\u001b[0m          \u001b[38;5;241m.\u001b[39motherwise(\u001b[38;5;241m1\u001b[39m))\n\u001b[1;32m     21\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAuthor type features added.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m---> 22\u001b[0m \u001b[43mdf_clean\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselect\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mis_known_bot\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mis_anonymous_author\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mhas_title\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshow\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m5\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/spark/python/pyspark/sql/dataframe.py:959\u001b[0m, in \u001b[0;36mDataFrame.show\u001b[0;34m(self, n, truncate, vertical)\u001b[0m\n\u001b[1;32m    953\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m PySparkTypeError(\n\u001b[1;32m    954\u001b[0m         error_class\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mNOT_BOOL\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    955\u001b[0m         message_parameters\u001b[38;5;241m=\u001b[39m{\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124marg_name\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvertical\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124marg_type\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;28mtype\u001b[39m(vertical)\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m},\n\u001b[1;32m    956\u001b[0m     )\n\u001b[1;32m    958\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(truncate, \u001b[38;5;28mbool\u001b[39m) \u001b[38;5;129;01mand\u001b[39;00m truncate:\n\u001b[0;32m--> 959\u001b[0m     \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_jdf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshowString\u001b[49m\u001b[43m(\u001b[49m\u001b[43mn\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m20\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvertical\u001b[49m\u001b[43m)\u001b[49m)\n\u001b[1;32m    960\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    961\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n",
+      "File \u001b[0;32m/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py:1322\u001b[0m, in \u001b[0;36mJavaMember.__call__\u001b[0;34m(self, *args)\u001b[0m\n\u001b[1;32m   1316\u001b[0m command \u001b[38;5;241m=\u001b[39m proto\u001b[38;5;241m.\u001b[39mCALL_COMMAND_NAME \u001b[38;5;241m+\u001b[39m\\\n\u001b[1;32m   1317\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcommand_header \u001b[38;5;241m+\u001b[39m\\\n\u001b[1;32m   1318\u001b[0m     args_command \u001b[38;5;241m+\u001b[39m\\\n\u001b[1;32m   1319\u001b[0m     proto\u001b[38;5;241m.\u001b[39mEND_COMMAND_PART\n\u001b[1;32m   1321\u001b[0m answer \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mgateway_client\u001b[38;5;241m.\u001b[39msend_command(command)\n\u001b[0;32m-> 1322\u001b[0m return_value \u001b[38;5;241m=\u001b[39m \u001b[43mget_return_value\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   1323\u001b[0m \u001b[43m    \u001b[49m\u001b[43manswer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mgateway_client\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtarget_id\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1325\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m temp_arg \u001b[38;5;129;01min\u001b[39;00m temp_args:\n\u001b[1;32m   1326\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(temp_arg, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_detach\u001b[39m\u001b[38;5;124m\"\u001b[39m):\n",
+      "File \u001b[0;32m/usr/local/spark/python/pyspark/errors/exceptions/captured.py:179\u001b[0m, in \u001b[0;36mcapture_sql_exception.<locals>.deco\u001b[0;34m(*a, **kw)\u001b[0m\n\u001b[1;32m    177\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mdeco\u001b[39m(\u001b[38;5;241m*\u001b[39ma: Any, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkw: Any) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Any:\n\u001b[1;32m    178\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 179\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mf\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43ma\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkw\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    180\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m Py4JJavaError \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m    181\u001b[0m         converted \u001b[38;5;241m=\u001b[39m convert_exception(e\u001b[38;5;241m.\u001b[39mjava_exception)\n",
+      "File \u001b[0;32m/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/protocol.py:326\u001b[0m, in \u001b[0;36mget_return_value\u001b[0;34m(answer, gateway_client, target_id, name)\u001b[0m\n\u001b[1;32m    324\u001b[0m value \u001b[38;5;241m=\u001b[39m OUTPUT_CONVERTER[\u001b[38;5;28mtype\u001b[39m](answer[\u001b[38;5;241m2\u001b[39m:], gateway_client)\n\u001b[1;32m    325\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m answer[\u001b[38;5;241m1\u001b[39m] \u001b[38;5;241m==\u001b[39m REFERENCE_TYPE:\n\u001b[0;32m--> 326\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m Py4JJavaError(\n\u001b[1;32m    327\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAn error occurred while calling \u001b[39m\u001b[38;5;132;01m{0}\u001b[39;00m\u001b[38;5;132;01m{1}\u001b[39;00m\u001b[38;5;132;01m{2}\u001b[39;00m\u001b[38;5;124m.\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;241m.\u001b[39m\n\u001b[1;32m    328\u001b[0m         \u001b[38;5;28mformat\u001b[39m(target_id, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m.\u001b[39m\u001b[38;5;124m\"\u001b[39m, name), value)\n\u001b[1;32m    329\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    330\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m Py4JError(\n\u001b[1;32m    331\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAn error occurred while calling \u001b[39m\u001b[38;5;132;01m{0}\u001b[39;00m\u001b[38;5;132;01m{1}\u001b[39;00m\u001b[38;5;132;01m{2}\u001b[39;00m\u001b[38;5;124m. Trace:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{3}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;241m.\u001b[39m\n\u001b[1;32m    332\u001b[0m         \u001b[38;5;28mformat\u001b[39m(target_id, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m.\u001b[39m\u001b[38;5;124m\"\u001b[39m, name, value))\n",
+      "\u001b[0;31mPy4JJavaError\u001b[0m: An error occurred while calling o143.showString.\n: org.apache.spark.SparkException: Job aborted due to stage failure: Task 351 in stage 10.0 failed 1 times, most recent failure: Lost task 351.0 in stage 10.0 (TID 1322) (exp-1-02.expanse.sdsc.edu executor driver): java.io.IOException: No space left on device\n\tat java.base/java.io.FileOutputStream.writeBytes(Native Method)\n\tat java.base/java.io.FileOutputStream.write(FileOutputStream.java:349)\n\tat org.apache.spark.storage.TimeTrackingOutputStream.write(TimeTrackingOutputStream.java:59)\n\tat org.apache.spark.io.MutableCheckedOutputStream.write(MutableCheckedOutputStream.scala:43)\n\tat java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)\n\tat java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:127)\n\tat net.jpountz.lz4.LZ4BlockOutputStream.flushBufferedData(LZ4BlockOutputStream.java:225)\n\tat net.jpountz.lz4.LZ4BlockOutputStream.write(LZ4BlockOutputStream.java:178)\n\tat java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)\n\tat java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:127)\n\tat java.base/java.io.DataOutputStream.write(DataOutputStream.java:112)\n\tat org.apache.spark.sql.catalyst.expressions.UnsafeRow.writeToStream(UnsafeRow.java:519)\n\tat org.apache.spark.sql.execution.UnsafeRowSerializerInstance$$anon$1.writeValue(UnsafeRowSerializer.scala:69)\n\tat org.apache.spark.storage.DiskBlockObjectWriter.write(DiskBlockObjectWriter.scala:312)\n\tat org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:171)\n\tat org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)\n\tat org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:104)\n\tat org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:54)\n\tat org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:161)\n\tat org.apache.spark.scheduler.Task.run(Task.scala:141)\n\tat org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:620)\n\tat org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)\n\tat org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)\n\tat org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)\n\tat org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:623)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\n\tat java.base/java.lang.Thread.run(Thread.java:833)\n\nDriver stacktrace:\n\tat org.apache.spark.scheduler.DAGScheduler.failJobAndIndependentStages(DAGScheduler.scala:2844)\n\tat org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2(DAGScheduler.scala:2780)\n\tat org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2$adapted(DAGScheduler.scala:2779)\n\tat scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)\n\tat scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)\n\tat scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)\n\tat org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:2779)\n\tat org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1(DAGScheduler.scala:1242)\n\tat org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1$adapted(DAGScheduler.scala:1242)\n\tat scala.Option.foreach(Option.scala:407)\n\tat org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:1242)\n\tat org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:3048)\n\tat org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2982)\n\tat org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2971)\n\tat org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)\nCaused by: java.io.IOException: No space left on device\n\tat java.base/java.io.FileOutputStream.writeBytes(Native Method)\n\tat java.base/java.io.FileOutputStream.write(FileOutputStream.java:349)\n\tat org.apache.spark.storage.TimeTrackingOutputStream.write(TimeTrackingOutputStream.java:59)\n\tat org.apache.spark.io.MutableCheckedOutputStream.write(MutableCheckedOutputStream.scala:43)\n\tat java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)\n\tat java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:127)\n\tat net.jpountz.lz4.LZ4BlockOutputStream.flushBufferedData(LZ4BlockOutputStream.java:225)\n\tat net.jpountz.lz4.LZ4BlockOutputStream.write(LZ4BlockOutputStream.java:178)\n\tat java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)\n\tat java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:127)\n\tat java.base/java.io.DataOutputStream.write(DataOutputStream.java:112)\n\tat org.apache.spark.sql.catalyst.expressions.UnsafeRow.writeToStream(UnsafeRow.java:519)\n\tat org.apache.spark.sql.execution.UnsafeRowSerializerInstance$$anon$1.writeValue(UnsafeRowSerializer.scala:69)\n\tat org.apache.spark.storage.DiskBlockObjectWriter.write(DiskBlockObjectWriter.scala:312)\n\tat org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:171)\n\tat org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)\n\tat org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:104)\n\tat org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:54)\n\tat org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:161)\n\tat org.apache.spark.scheduler.Task.run(Task.scala:141)\n\tat org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:620)\n\tat org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)\n\tat org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)\n\tat org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)\n\tat org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:623)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\n\tat java.base/java.lang.Thread.run(Thread.java:833)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── BOT AUTHOR FLAGGING ───────────────────────────────────────────────────────\n",
+    "\n",
+    "KNOWN_BOTS = {\n",
+    "    \"AutoModerator\", \"AutoNewsAdmin\", \"AutoNewspaperAdmin\",\n",
+    "    \"politicbot\", \"RPBot\", \"ImagesOfNetwork\", \"-en-\",\n",
+    "    \"KellyfromLeedsUK\"\n",
+    "}\n",
+    "\n",
+    "df_clean = df_clean \\\n",
+    "    .withColumn(\"is_known_bot\",\n",
+    "        F.when(F.col(\"author\").isin(list(KNOWN_BOTS)), 1)\n",
+    "         .otherwise(0)) \\\n",
+    "    .withColumn(\"is_anonymous_author\",\n",
+    "        F.when(\n",
+    "            (F.col(\"author\") == \"[deleted]\") | (F.col(\"author\") == \"\"), 1)\n",
+    "         .otherwise(0)) \\\n",
+    "    .withColumn(\"has_title\",\n",
+    "        F.when(F.length(F.col(\"title\")) == 0, 0)\n",
+    "         .otherwise(1))\n",
+    "\n",
+    "print(\"Author type features added.\")\n",
+    "df_clean.select(\"is_known_bot\", \"is_anonymous_author\", \"has_title\").show(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30ddfd13-d4b9-492a-a98a-8dcd70c0b293",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Milestone 3 Notebook Init + EDA Updates

### New
- Created `notebooks/Milestone3_Pushshift.ipynb` — preprocessing and model training notebook. Contains SparkSession  init, data load (Jack's pre/post 2015 cutoff fix), initial filtering cells, and binary feature derivations (`is_known_bot`, `is_anonymous_author`, `has_title`).

### Milestone 2 Notebook Updates
- Added zero-length title analysis cell — found 912,556 posts (0.166%) with empty titles. These are real posts with intact engagement signals; avg score is 10.8 vs 44.9 for titled posts, motivating `has_title` as a model feature rather than a drop filter.
- Added negative `num_comments` count cell — found 1,090 rows (0.0002%), confirmed as Pushshift artifact. These will be dropped in preprocessing.
- Added author type engagement breakdown cell — deleted and empty string authors score ~3.7x lower and receive ~2.8x fewer comments than real users, motivating `is_anonymous_author` as a model feature.
- Moved all exploratory cells above from Milestone 3 scratch work into Milestone 2 where they belong.

### SparkSession Configuration Update (Milestone 2)
- Dropped executor config parameters (`spark.executor.memory`, `spark.executor.instances`) which have no effect in `local[*]` mode per instructor confirmation
- Bumped `spark.driver.memory` to `120g` to give the single JVM nearly the full 128GB node allocation, which is the correct approach for local mode where all task execution runs in the driver JVM