### PR TITLE
feat: refresh preprocessing pipeline with updated feature engineering

### DIFF
--- a/notebooks/Milestone3_Pushshift.ipynb
+++ b/notebooks/Milestone3_Pushshift.ipynb
@@ -12,18 +12,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 16,
    "id": "8a9bf756-fc26-40ed-83e9-515d38cb7a0e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Matplotlib created a temporary cache directory at /scratch/ekim18/job_48811653/matplotlib-tdsq4ogr because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Dependencies \n",
     "\n",
@@ -45,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 17,
    "id": "b2646d4d-b832-49a0-b91a-c38ec0286fd1",
    "metadata": {},
    "outputs": [
@@ -54,7 +46,7 @@
      "output_type": "stream",
      "text": [
       "Spark version: 3.5.0\n",
-      "Spark UI: http://exp-17-54.expanse.sdsc.edu:4040\n"
+      "Spark UI: http://exp-6-33.expanse.sdsc.edu:4040\n"
      ]
     }
    ],
@@ -95,10 +87,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "58c4a5bf-4422-41fc-9e57-919c108a0d21",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Files loaded: 218\n",
+      "Partitions: 683\n"
+     ]
+    }
+   ],
    "source": [
     "# Data Load \n",
     "\n",
@@ -132,10 +133,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "bfd0a882-4660-45a4-82c7-d152f194c569",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       id  totalCores    maxMemory  activeTasks  isActive  maxMemory_GB\n",
+      "0  driver          16  77120667648            0      True         71.82\n",
+      "local[*]\n"
+     ]
+    }
+   ],
    "source": [
     "# SparkUI Screenshot\n",
     "\n",
@@ -158,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "0b489152-f0d9-4dd3-a6e2-738c58386ab8",
    "metadata": {},
    "outputs": [],
@@ -190,10 +201,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "475c5273-ce0f-40e2-9098-9067756584e7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original row count:      549,662,955\n",
+      "Row count after filters: 549,355,365\n",
+      "Rows removed:            307,590\n"
+     ]
+    }
+   ],
    "source": [
     "# ── FILTERING & CLEANING ─────────────────────────────────────────────────────\n",
     "\n",
@@ -225,10 +246,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "81b2031c-d02f-47dc-ac13-defa61abb333",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Author type features added.\n",
+      "+------------+-------------------+---------+\n",
+      "|is_known_bot|is_anonymous_author|has_title|\n",
+      "+------------+-------------------+---------+\n",
+      "|           0|                  1|        1|\n",
+      "|           0|                  1|        1|\n",
+      "|           0|                  0|        1|\n",
+      "|           0|                  1|        1|\n",
+      "|           0|                  0|        1|\n",
+      "+------------+-------------------+---------+\n",
+      "only showing top 5 rows\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# ── BOT AUTHOR FLAGGING ───────────────────────────────────────────────────────\n",
     "\n",
@@ -367,10 +407,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "c4ac963d-1951-47d9-973f-6962260210b7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rows after subreddit filter: 535,480,818\n",
+      "Rows removed:                13,874,547\n",
+      "Posts retained:              97.5%\n"
+     ]
+    }
+   ],
    "source": [
     "# ── SUBREDDIT MINIMUM POST COUNT FILTER ──────────────────────────────────────\n",
     "\n",
@@ -428,10 +478,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "4e664a21-f4ff-4f07-8cd2-270e53798c40",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4-class label distribution:\n",
+      "+--------------+---------+----+\n",
+      "|  label_4class|    count| pct|\n",
+      "+--------------+---------+----+\n",
+      "|low-engagement|236954268|44.3|\n",
+      "|         viral|160168118|29.9|\n",
+      "| crowd-pleaser| 74916114|14.0|\n",
+      "|debate-starter| 63442318|11.8|\n",
+      "+--------------+---------+----+\n",
+      "\n",
+      "Binary label distribution:\n",
+      "+---------------+---------+----+\n",
+      "|   label_binary|    count| pct|\n",
+      "+---------------+---------+----+\n",
+      "|high-engagement|298526550|55.7|\n",
+      "| low-engagement|236954268|44.3|\n",
+      "+---------------+---------+----+\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# ── LABEL GENERATION — 75TH PERCENTILE THRESHOLD ─────────────────────────────\n",
     "\n",
@@ -491,14 +566,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "b95d3e47-1f92-4be7-b184-cfc12cae4ffd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Write complete. Reloading from disk...\n",
+      "Rows in persisted df_labeled: 535,480,818\n"
+     ]
+    }
+   ],
    "source": [
     "# ── PERSIST df_labeled TO data/processed/ ─────────────────────────────────────────────\n",
     "\n",
-    "PROCESSED_DIR = \"../data/processed/\"\n",
+    "PROCESSED_DIR = \"../data/processed/labeled/\"\n",
     "\n",
     "# Drop threshold columns before persisting — not needed downstream\n",
     "df_labeled = df_labeled.drop(\"score_thresh\", \"comments_thresh\")\n",
@@ -518,27 +602,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "de6dac76-ed1a-4ef3-8e91-3444774e5af6",
-   "metadata": {},
-   "source": [
-    "## Feature Engineering\n",
-    "\n",
-    "All features are derived from pre-publication information only to prevent data leakage and no features use `score`, `num_comments`, or the derived label columns.\n",
-    "\n",
-    "### Title and Post Type Features\n",
-    "\n",
-    "Simple structural features extracted from the `title` and `selftext` columns using PySpark string functions. These require no aggregations or UDFs and are computed directly as column transformations.\n",
-    "\n",
-    "- `title_len`: character count of the post title\n",
-    "- `title_word_count`: number of whitespace-delimited words in the title\n",
-    "- `has_question`: binary flag indicating the presence of `?` in the title\n",
-    "- `has_exclamation`: binary flag indicating the presence of `!` in the title\n",
-    "- `is_text_post`: binary flag, 1 if the post has a non-empty selftext body\n",
-    "- `selftext_len`: character length of selftext (0 for link posts)"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "fb9c0def-41cd-4240-a14c-ba5e4f19f1a8",
@@ -549,37 +612,82 @@
     "# Note: df_labeled is loaded in persist cell just for count validation\n",
     "# This cell begins checkpoint for feature engineering\n",
     "\n",
-    "PROCESSED_DIR = \"../data/processed/\"\n",
+    "PROCESSED_DIR = \"../data/processed/labeled/\"\n",
     "df_labeled = spark.read.parquet(PROCESSED_DIR)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "de6dac76-ed1a-4ef3-8e91-3444774e5af6",
+   "metadata": {},
+   "source": [
+    "## Feature Engineering\n",
+    "\n",
+    "All features are derived from pre-publication information only to prevent data leakage and no features use `score`, `num_comments`, or the derived label columns.\n",
+    "\n",
+    "### Title and Post Type Features\n",
+    "\n",
+    "Simple structural features extracted from the `title` and `selftext` columns using PySpark string functions. These require no aggregations or UDFs and are computed directly as column transformations. Both text length features use character count for consistency.\n",
+    "\n",
+    "- `title_len`: character count of the post title\n",
+    "- `has_question`: binary flag indicating the presence of `?` in the title\n",
+    "- `has_exclamation`: binary flag indicating the presence of `!` in the title\n",
+    "- `title_has_number`: binary flag indicating the presence of a digit in the title, captures listicle-style titles (\"10 things...\") which are a known Reddit engagement pattern\n",
+    "- `title_is_allcaps`: binary flag indicating the entire title is uppercase, captures high emotional register posts\n",
+    "- `is_text_post`: binary flag, 1 if the post has a non-empty selftext body\n",
+    "- `selftext_len`: character length of selftext (0 for link posts)"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "e356ff68-942e-4e03-bec3-604ea6ae50a8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------------------------------------+---------+------------+---------------+----------------+----------------+------------+------------+\n",
+      "|                                   title|title_len|has_question|has_exclamation|title_has_number|title_is_allcaps|is_text_post|selftext_len|\n",
+      "+----------------------------------------+---------+------------+---------------+----------------+----------------+------------+------------+\n",
+      "|                                        |        1|           0|              0|               0|               1|           0|           0|\n",
+      "|                          post video pls|       14|           0|              0|               0|               0|           0|           0|\n",
+      "| that would put you a basic because e...|       53|           0|              0|               0|               0|           0|           0|\n",
+      "|                  i love to call the epa|       22|           0|              0|               0|               0|           0|           0|\n",
+      "|                                        |        1|           0|              0|               0|               1|           0|           0|\n",
+      "+----------------------------------------+---------+------------+---------------+----------------+----------------+------------+------------+\n",
+      "only showing top 5 rows\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# ── TITLE AND POST TYPE FEATURES ─────────────────────────────────────────────\n",
     "\n",
     "df_features = df_labeled \\\n",
     "    .withColumn(\"title_len\",\n",
     "        F.length(F.col(\"title\"))) \\\n",
-    "    .withColumn(\"title_word_count\",\n",
-    "        F.when(F.length(F.col(\"title\")) == 0, 0)\n",
-    "         .otherwise(F.size(F.split(F.trim(F.col(\"title\")), r\"\\s+\")))) \\\n",
     "    .withColumn(\"has_question\",\n",
     "        F.when(F.col(\"title\").contains(\"?\"), 1).otherwise(0)) \\\n",
     "    .withColumn(\"has_exclamation\",\n",
     "        F.when(F.col(\"title\").contains(\"!\"), 1).otherwise(0)) \\\n",
+    "    .withColumn(\"title_has_number\",\n",
+    "        F.when(F.col(\"title\").rlike(r\"\\d+\"), 1).otherwise(0)) \\\n",
+    "    .withColumn(\"title_is_allcaps\",\n",
+    "        F.when(\n",
+    "            (F.length(F.col(\"title\")) > 0) &\n",
+    "            (F.col(\"title\") == F.upper(F.col(\"title\"))), 1\n",
+    "        ).otherwise(0)) \\\n",
     "    .withColumn(\"is_text_post\",\n",
     "        F.when(F.col(\"selftext\") != \"\", 1).otherwise(0)) \\\n",
     "    .withColumn(\"selftext_len\",\n",
     "        F.when(F.col(\"selftext\") != \"\", F.length(F.col(\"selftext\"))).otherwise(0))\n",
     "\n",
     "df_features.select(\n",
-    "    \"title\", \"title_len\", \"title_word_count\",\n",
+    "    \"title\", \"title_len\",\n",
     "    \"has_question\", \"has_exclamation\",\n",
+    "    \"title_has_number\", \"title_is_allcaps\",\n",
     "    \"is_text_post\", \"selftext_len\"\n",
     ").show(5, truncate=40)"
    ]
@@ -599,10 +707,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "e42595d2-c05b-4daa-a796-3dffd069f777",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----------+-----------+-----------+\n",
+      "|created_utc|hour_of_day|day_of_week|\n",
+      "+-----------+-----------+-----------+\n",
+      "| 1420223155|         18|          6|\n",
+      "| 1420226784|         19|          6|\n",
+      "| 1420230432|         20|          6|\n",
+      "| 1420665577|         21|          4|\n",
+      "| 1420669208|         22|          4|\n",
+      "+-----------+-----------+-----------+\n",
+      "only showing top 5 rows\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# ── TEMPORAL FEATURES ────────────────────────────────────────────────────────\n",
     "\n",
@@ -633,10 +759,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "530edbfe-50d7-4059-861d-e81986b0263e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+--------------------+----------------------+-------------------------+\n",
+      "|subreddit|subreddit_post_count|subreddit_median_score|subreddit_median_comments|\n",
+      "+---------+--------------------+----------------------+-------------------------+\n",
+      "| 101Wicca|                 283|                     3|                        1|\n",
+      "| 101Wicca|                 283|                     3|                        1|\n",
+      "| 101Wicca|                 283|                     3|                        1|\n",
+      "| 101Wicca|                 283|                     3|                        1|\n",
+      "| 101Wicca|                 283|                     3|                        1|\n",
+      "+---------+--------------------+----------------------+-------------------------+\n",
+      "only showing top 5 rows\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# ── SUBREDDIT CONTEXT FEATURES ───────────────────────────────────────────────\n",
     "\n",
@@ -671,10 +815,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "95a57967-3367-40b6-a433-1ea5ed590027",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------------+-----------------+------------------+\n",
+      "|         author|author_post_count| author_mean_score|\n",
+      "+---------------+-----------------+------------------+\n",
+      "|       3up3down|                1|               1.0|\n",
+      "|      AaadamPgh|              210|14.933333333333334|\n",
+      "|   Aerodactyl_x|                9|11.333333333333334|\n",
+      "|   Aerodactyl_x|                9|11.333333333333334|\n",
+      "|ArmoredTricycle|               91|222.93406593406593|\n",
+      "+---------------+-----------------+------------------+\n",
+      "only showing top 5 rows\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# ── AUTHOR HISTORY FEATURES ──────────────────────────────────────────────────\n",
     "\n",
@@ -704,10 +866,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "22a3e376-da31-433a-a96b-f7714f3450e6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Write complete. Reloading from disk...\n",
+      "Rows in persisted df_features: 535,480,818\n",
+      "Columns: 28\n",
+      "['author', 'subreddit', 'id', 'num_comments', 'score', 'selftext', 'subreddit_id', 'title', 'created_utc', 'is_known_bot', 'is_anonymous_author', 'has_title', 'label_4class', 'label_binary', 'title_len', 'has_question', 'has_exclamation', 'title_has_number', 'title_is_allcaps', 'is_text_post', 'selftext_len', 'hour_of_day', 'day_of_week', 'subreddit_post_count', 'subreddit_median_score', 'subreddit_median_comments', 'author_post_count', 'author_mean_score']\n"
+     ]
+    }
+   ],
    "source": [
     "# ── PERSIST df_features ───────────────────────────────────────────────────────\n",
     "\n",
@@ -727,7 +900,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 18,
    "id": "94dc42a8-4975-4dc4-b8f3-6c2f71e8190e",
    "metadata": {},
    "outputs": [
@@ -736,7 +909,7 @@
      "output_type": "stream",
      "text": [
       "Rows: 535,480,818\n",
-      "Columns: 27\n"
+      "Columns: 28\n"
      ]
     }
    ],
@@ -751,10 +924,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "27c3b5e2-5dda-4d6d-8872-20475a066831",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TextBlob: NOT available\n",
+      "NLTK: NOT available\n",
+      "textstat: NOT available\n",
+      "spaCy: NOT available\n",
+      "vaderSentiment: available\n"
+     ]
+    }
+   ],
    "source": [
     "# Check NLP library availability\n",
     "try:\n",
@@ -828,10 +1013,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "584018cb-f766-4784-af75-78384c51ddfa",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This is the most amazing thing I've ever seen!!!   → compound: +0.716\n",
+      "Why does nobody care about this?                   → compound: +0.494\n",
+      "I hate everything about this                       → compound: -0.572\n",
+      "lol this is hilarious                              → compound: +0.670\n",
+      "Breaking news: major disaster strikes              → compound: -0.800\n"
+     ]
+    }
+   ],
    "source": [
     "# ── VERIFY VADER INSTALLATION ─────────────────────────────────────────────────\n",
     "from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer\n",
@@ -864,7 +1061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 21,
    "id": "a9ec8462-5c56-4785-89f2-f1944f34dda2",
    "metadata": {},
    "outputs": [
@@ -873,9 +1070,9 @@
      "output_type": "stream",
      "text": [
       "Sample size:         10,000 rows\n",
-      "Elapsed:             0.32 seconds\n",
-      "Throughput:          30,890 rows/sec\n",
-      "Estimated full run:  4.8 hours for 535M rows\n"
+      "Elapsed:             0.26 seconds\n",
+      "Throughput:          38,114 rows/sec\n",
+      "Estimated full run:  3.9 hours for 535M rows\n"
      ]
     }
    ],
@@ -927,7 +1124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 22,
    "id": "9591d994-f826-467b-9a9f-ca8ca3c4bce4",
    "metadata": {},
    "outputs": [
@@ -935,15 +1132,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Title sentiment run started at: 2026-05-07 01:40:56\n",
-      "Completed at:  2026-05-07 02:08:54\n",
-      "Total runtime: 0h 27m 58s\n",
-      "Throughput:    319,094 rows/sec\n",
-      "Rows: 535,480,818 | Columns: 28\n",
+      "Title sentiment run started at: 2026-05-07 22:09:57\n",
+      "Completed at:  2026-05-07 22:35:00\n",
+      "Total runtime: 0h 25m 2s\n",
+      "Throughput:    356,458 rows/sec\n",
+      "Rows: 535,480,818 | Columns: 29\n",
       "+-------------------+-------------+-------------+---------+---------+---------+\n",
       "|     mean_sentiment|min_sentiment|max_sentiment| positive| negative|  neutral|\n",
       "+-------------------+-------------+-------------+---------+---------+---------+\n",
-      "|0.04680778548004335|      -0.9998|       0.9999|150730614|100471690|284278514|\n",
+      "|0.04680778548004337|      -0.9998|       0.9999|150730614|100471690|284278514|\n",
       "+-------------------+-------------+-------------+---------+---------+---------+\n",
       "\n"
      ]
@@ -1070,7 +1267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 23,
    "id": "1ceabc2a-5d21-4d20-bd5f-0edaacbaaf4d",
    "metadata": {},
    "outputs": [
@@ -1079,10 +1276,10 @@
      "output_type": "stream",
      "text": [
       "Sample size:                    10,000 rows\n",
-      "Elapsed:                        2.52 seconds\n",
-      "Throughput:                     3,968 rows/sec (single thread)\n",
-      "Est. full run (single thread):  630.0 minutes\n",
-      "Est. full run (16-core par.):   78.8 minutes\n"
+      "Elapsed:                        1.73 seconds\n",
+      "Throughput:                     5,788 rows/sec (single thread)\n",
+      "Est. full run (single thread):  431.9 minutes\n",
+      "Est. full run (16-core par.):   54.0 minutes\n"
      ]
     }
    ],
@@ -1121,7 +1318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 24,
    "id": "8d688509-d877-415c-92cb-8aeea86e3057",
    "metadata": {},
    "outputs": [
@@ -1129,18 +1326,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Selftext sentiment run started at: 2026-05-07 02:11:54\n",
-      "Completed at:  2026-05-07 02:59:39\n",
-      "Total runtime: 0h 47m 44s\n",
-      "Throughput:    186,916 rows/sec\n",
-      "Rows: 535,480,818 | Columns: 29\n",
+      "Selftext sentiment run started at: 2026-05-07 22:37:25\n",
+      "Completed at:  2026-05-07 23:15:53\n",
+      "Total runtime: 0h 38m 28s\n",
+      "Throughput:    232,009 rows/sec\n",
+      "Rows: 535,480,818 | Columns: 30\n",
       "\n",
       "Writing final DataFrame to features_nlp...\n",
-      "Final rows: 535,480,818 | Columns: 29\n",
+      "Final rows: 535,480,818 | Columns: 30\n",
       "+--------------+-------------------+-------------+-------------+--------+--------+--------+\n",
       "|non_null_count|     mean_sentiment|min_sentiment|max_sentiment|positive|negative| neutral|\n",
       "+--------------+-------------------+-------------+-------------+--------+--------+--------+\n",
-      "|     146581291|0.23307564779035478|      -0.9999|          1.0|85438940|36451127|24691224|\n",
+      "|     146581291|0.23307564779035508|      -0.9999|          1.0|85438940|36451127|24691224|\n",
       "+--------------+-------------------+-------------+-------------+--------+--------+--------+\n",
       "\n"
      ]
@@ -1264,7 +1461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 25,
    "id": "523ca0e3-ec11-4ae5-aa5a-e8e03215ca76",
    "metadata": {},
    "outputs": [
@@ -1274,9 +1471,10 @@
      "text": [
       "-RECORD 0------------------------------\n",
       " title_len                 | 0         \n",
-      " title_word_count          | 0         \n",
       " has_question              | 0         \n",
       " has_exclamation           | 0         \n",
+      " title_has_number          | 0         \n",
+      " title_is_allcaps          | 0         \n",
       " is_text_post              | 0         \n",
       " selftext_len              | 0         \n",
       " hour_of_day               | 0         \n",
@@ -1299,7 +1497,8 @@
     "# ── NULL CHECK ON FEATURE COLUMNS ────────────────────────────────────────────\n",
     "\n",
     "feature_cols = [\n",
-    "    \"title_len\", \"title_word_count\", \"has_question\", \"has_exclamation\",\n",
+    "    \"title_len\", \"has_question\", \"has_exclamation\",\n",
+    "    \"title_has_number\", \"title_is_allcaps\",\n",
     "    \"is_text_post\", \"selftext_len\", \"hour_of_day\", \"day_of_week\",\n",
     "    \"subreddit_post_count\", \"subreddit_median_score\", \"subreddit_median_comments\",\n",
     "    \"author_post_count\", \"author_mean_score\",\n",
@@ -1340,7 +1539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 26,
    "id": "08f071c7-0603-41e9-8f1c-cb50e1afeee7",
    "metadata": {},
    "outputs": [
@@ -1351,9 +1550,10 @@
       "Null counts after imputation:\n",
       "-RECORD 0------------------------\n",
       " title_len                 | 0   \n",
-      " title_word_count          | 0   \n",
       " has_question              | 0   \n",
       " has_exclamation           | 0   \n",
+      " title_has_number          | 0   \n",
+      " title_is_allcaps          | 0   \n",
       " is_text_post              | 0   \n",
       " selftext_len              | 0   \n",
       " hour_of_day               | 0   \n",
@@ -1408,7 +1608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 27,
    "id": "3041001f-8a19-4f36-9dfb-007ade252b3b",
    "metadata": {},
    "outputs": [
@@ -1506,12 +1706,12 @@
    "source": [
     "### Step 4 — Feature Assembly\n",
     "\n",
-    "`VectorAssembler` combines all 18 numeric feature columns into a single dense vector column required by MLlib models. Raw text columns (`title`, `selftext`), identifier columns (`id`, `author`, `subreddit`, `subreddit_id`), timestamp (`created_utc`), raw engagement columns (`score`, `num_comments`), and string label columns are excluded. Only engineered numeric features enter the vector. `handleInvalid=\"skip\"` is set as a safety net though imputation above eliminated all nulls."
+    "`VectorAssembler` combines all 19 numeric feature columns into a single dense vector column required by MLlib models. Raw text columns (`title`, `selftext`), identifier columns (`id`, `author`, `subreddit`, `subreddit_id`), timestamp (`created_utc`), raw engagement columns (`score`, `num_comments`), and string label columns are excluded. Only engineered numeric features enter the vector. `handleInvalid=\"skip\"` is set as a safety net though imputation above eliminated all nulls."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 28,
    "id": "39bcb216-53d0-4773-8fe8-857bb0081adc",
    "metadata": {},
    "outputs": [
@@ -1519,13 +1719,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Feature vector assembled with 18 features.\n",
+      "Feature vector assembled with 19 features.\n",
       "+--------------------------------------------------------------------------------+\n",
       "|                                                                    features_raw|\n",
       "+--------------------------------------------------------------------------------+\n",
-      "|(18,[0,1,4,8,11,12,13,14,15,17],[8.0,2.0,1.0,5.0,6.0,10.333333333333334,13171...|\n",
-      "|(18,[0,1,4,7,8,11,12,13,14,17],[34.0,7.0,1.0,12.0,6.0,6.0,10.333333333333334,...|\n",
-      "|[38.0,5.0,0.0,0.0,1.0,1.0,1448.0,17.0,1.0,0.0,0.0,6.0,10.333333333333334,1607...|\n",
+      "|(19,[0,3,5,8,9,12,13,14,15,18],[36.0,1.0,1.0,11.0,3.0,30.0,3.4,2473.0,1.0,0.2...|\n",
+      "|(19,[0,5,8,9,12,13,14,15,18],[36.0,1.0,20.0,6.0,30.0,3.4,2473.0,1.0,0.2330756...|\n",
+      "|(19,[0,5,8,9,12,13,14,15,16,18],[50.0,1.0,9.0,7.0,30.0,3.4,175729.0,3.0,3.0,0...|\n",
       "+--------------------------------------------------------------------------------+\n",
       "only showing top 3 rows\n",
       "\n"
@@ -1538,7 +1738,8 @@
     "\n",
     "assembler_cols = [\n",
     "    # Title structural features\n",
-    "    \"title_len\", \"title_word_count\", \"has_question\", \"has_exclamation\",\n",
+    "    \"title_len\", \"has_question\", \"has_exclamation\",\n",
+    "    \"title_has_number\", \"title_is_allcaps\",\n",
     "    # Post type features\n",
     "    \"has_title\", \"is_text_post\", \"selftext_len\",\n",
     "    # Temporal features\n",
@@ -1578,7 +1779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 29,
    "id": "efb91f6f-3d34-4e02-9d75-334f3307becb",
    "metadata": {},
    "outputs": [
@@ -1597,9 +1798,9 @@
       "+--------------------------------------------------------------------------------+\n",
       "|                                                                        features|\n",
       "+--------------------------------------------------------------------------------+\n",
-      "|[-0.4351249531684931,-0.281142981195725,0.0,0.0,0.04656990046941844,-0.668849...|\n",
-      "|[-0.3238205244488481,-0.5866768351979457,0.0,0.0,0.04656990046941844,1.495105...|\n",
-      "|[1.0953109417266254,1.093759361814268,0.0,0.0,0.04656990046941844,1.495105584...|\n",
+      "|[-0.3794727388086728,0.0,0.0,1.8308506054916096,-0.07351652556800245,0.046569...|\n",
+      "|[-0.3794727388086728,0.0,0.0,-0.5461942079725822,-0.07351652556800245,0.04656...|\n",
+      "|[0.01009276171008487,0.0,0.0,-0.5461942079725822,-0.07351652556800245,0.04656...|\n",
       "+--------------------------------------------------------------------------------+\n",
       "only showing top 3 rows\n",
       "\n"
@@ -1677,7 +1878,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 30,
    "id": "01cef4c0-3da2-4a06-9561-ad3d23716d17",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
## Preprocessing Pipeline Refresh

Full end-to-end re-run of the preprocessing pipeline incorporating feature engineering improvements and correcting the labeled DataFrame persist path. All persisted splits in `data/processed/` have been updated.

### Feature Engineering Changes
- Added `title_has_number` — binary flag for digit presence in title, captures listicle-style posts which are a known Reddit engagement pattern
- Added `title_is_allcaps` — binary flag for all-caps titles, captures high emotional register posts
- Removed `title_word_count` — redundant with `title_len` (character count). Standardized both text length features to character count (`title_len`, `selftext_len`) for consistency
- Final feature set is 19 features including both VADER sentiment columns

### Bug Fix
- Fixed `df_labeled` persist cell to write to `data/processed/labeled/` instead of `data/processed/` root, which previously risked overwriting feature and split subdirectories on re-run

### Persisted DataFrames Updated
- `data/processed/labeled/` — filtered, labeled DataFrame (535,480,818 rows)
- `data/processed/features/` — non-NLP feature checkpoint (27 columns)
- `data/processed/features_nlp/` — full feature checkpoint including VADER title and selftext sentiment (29 columns)
- `data/processed/train/`, `val/`, `test/` — scaled train/val/test splits ready for model training
  - Train (2012-2016): 276,442,594 rows
  - Val (2017): 114,089,205 rows
  - Test (2018): 144,949,019 rows