### PR TITLE
feat: XGBoost model configuration, persisted to disk

### DIFF
--- a/notebooks/Milestone3_Pushshift.ipynb
+++ b/notebooks/Milestone3_Pushshift.ipynb
@@ -12,10 +12,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 1,
    "id": "8a9bf756-fc26-40ed-83e9-515d38cb7a0e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Matplotlib created a temporary cache directory at /scratch/ekim18/job_48857266/matplotlib-pl60bq54 because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
+     ]
+    }
+   ],
    "source": [
     "# Dependencies \n",
     "\n",
@@ -37,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 2,
    "id": "b2646d4d-b832-49a0-b91a-c38ec0286fd1",
    "metadata": {},
    "outputs": [
@@ -46,7 +54,7 @@
      "output_type": "stream",
      "text": [
       "Spark version: 3.5.0\n",
-      "Spark UI: http://exp-6-33.expanse.sdsc.edu:4040\n"
+      "Spark UI: http://exp-1-07.expanse.sdsc.edu:4040\n"
      ]
     }
    ],
@@ -169,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "0b489152-f0d9-4dd3-a6e2-738c58386ab8",
    "metadata": {},
    "outputs": [],
@@ -1923,10 +1931,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "6e76885c-5411-49d2-a332-cbeaa34f3451",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Reloading splits from disk...\n",
+      "Train rows: 276,442,594\n",
+      "Val rows:   114,089,205\n",
+      "Test rows:  144,949,019\n"
+     ]
+    }
+   ],
    "source": [
     "# Reloading train val and test dfs\n",
     "# Note: This is checkpoint for model fitting; data load is done in persist cell\n",
@@ -1946,6 +1966,460 @@
     "print(f\"Val rows:   {val_df.count():,}\")\n",
     "print(f\"Test rows:  {test_df.count():,}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d87f0b0-3843-4043-a059-6cdf231df745",
+   "metadata": {},
+   "source": [
+    "## Milestone 3: Model Training\n",
+    "\n",
+    "We use `SparkXGBClassifier` from the `xgboost.spark` module, which ships with XGBoost ≥ 1.6. The cell below verifies availability and installs if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "49c11962-97db-4aee-ac72-7ebf837d9402",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGBoost 2.0.3 available — SparkXGBClassifier ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check for XGBoost and Install if needed\n",
+    "\n",
+    "try:\n",
+    "    from xgboost.spark import SparkXGBClassifier\n",
+    "    import xgboost as xgb\n",
+    "    print(f\"XGBoost {xgb.__version__} available — SparkXGBClassifier ready\")\n",
+    "except ImportError:\n",
+    "    import subprocess, sys\n",
+    "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"xgboost>=1.7\"])\n",
+    "    from xgboost.spark import SparkXGBClassifier\n",
+    "    import xgboost as xgb\n",
+    "    print(f\"Installed XGBoost {xgb.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd8d97b-7f45-4c92-bd37-c7f6025241f4",
+   "metadata": {},
+   "source": [
+    "### Class Weight Computation\n",
+    "\n",
+    "To address label imbalance (low-engagement 44.3%, viral 29.9%, crowd-pleaser 14.0%, debate-starter 11.8%), we compute inverse-frequency weights from the training set only, then broadcast and join to all three splits. This prevents information leakage from val/test distributions into the weight values.\n",
+    "\n",
+    "Weights are computed as `N / (num_classes * class_count)`, the normalized inverse frequency formulation used by scikit-learn, which keeps the effective total sample weight equal to N regardless of class distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e088e77a-3f1e-46dc-8f59-3dcda38131b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------------+------------------+\n",
+      "|label_4class_idx|     weight_4class|\n",
+      "+----------------+------------------+\n",
+      "|             0.0|0.5301268182465868|\n",
+      "|             1.0|0.9731065704183982|\n",
+      "|             2.0|1.6904547488515607|\n",
+      "|             3.0| 2.022386046668015|\n",
+      "+----------------+------------------+\n",
+      "\n",
+      "+----------------+------------------+\n",
+      "|label_binary_idx|     weight_binary|\n",
+      "+----------------+------------------+\n",
+      "|             0.0|0.9462264655073706|\n",
+      "|             1.0|1.0602536364931736|\n",
+      "+----------------+------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "NUM_CLASSES_4 = 4\n",
+    "NUM_CLASSES_2 = 2\n",
+    "\n",
+    "N_train = train_df.count()\n",
+    "\n",
+    "# Compute per-class counts from train only\n",
+    "class_counts_4 = (\n",
+    "    train_df.groupBy(\"label_4class_idx\")\n",
+    "            .agg(F.count(\"*\").alias(\"class_count\"))\n",
+    ")\n",
+    "\n",
+    "class_counts_2 = (\n",
+    "    train_df.groupBy(\"label_binary_idx\")\n",
+    "            .agg(F.count(\"*\").alias(\"class_count\"))\n",
+    ")\n",
+    "\n",
+    "# Normalize: weight = N / (num_classes * class_count)\n",
+    "weight_map_4 = (\n",
+    "    class_counts_4\n",
+    "    .withColumn(\"weight_4class\", F.lit(N_train) / (F.lit(NUM_CLASSES_4) * F.col(\"class_count\")))\n",
+    "    .select(\"label_4class_idx\", \"weight_4class\")\n",
+    ")\n",
+    "\n",
+    "weight_map_2 = (\n",
+    "    class_counts_2\n",
+    "    .withColumn(\"weight_binary\", F.lit(N_train) / (F.lit(NUM_CLASSES_2) * F.col(\"class_count\")))\n",
+    "    .select(\"label_binary_idx\", \"weight_binary\")\n",
+    ")\n",
+    "\n",
+    "weight_map_4.orderBy(\"label_4class_idx\").show()\n",
+    "weight_map_2.orderBy(\"label_binary_idx\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eb930a0-9d16-481f-924f-dacb58190fb9",
+   "metadata": {},
+   "source": [
+    "### Class Weight Results\n",
+    "\n",
+    "The 4-class weights reflect the label imbalance introduced by the per-subreddit 75th-percentile thresholding scheme. Low-engagement (class 0) receives the smallest weight (0.530) because it is the majority class at 44.3% of the training set. Viral (class 1) is nearly balanced at 0.973, while crowd-pleaser (class 2, 14.0%) and debate-starter (class 3, 11.8%) receive the largest upweights (1.690 and 2.022 respectively) to compensate for their underrepresentation. The binary weights are close to 1.0 for both classes (0.946 and 1.060), consistent with a near-balanced binary split of 44.3% / 55.7% — the binary task requires minimal correction.\n",
+    "\n",
+    "These weights will be passed to `SparkXGBClassifier` via `weight_col` so that the boosting objective penalizes misclassification of minority classes proportionally during tree construction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24e66f58-a91b-48a7-b870-77d547b4f498",
+   "metadata": {},
+   "source": [
+    "### Joining Class Weights to Splits\n",
+    "\n",
+    "We broadcast-join the 4-class and binary weight maps onto all three splits. The join is essentially free, both weight maps are 4 rows and 2 rows respectively, so Spark resolves them as broadcast hash joins with no shuffle.\n",
+    "\n",
+    "After joining, we project each split down to only the three columns XGBoost needs (`features`, `label_4class_idx`, `weight_4class`). This avoids loading the full wide DataFrame which preserves all original columns including raw text and metadata into the XGBoost DMatrix during training, significantly reducing memory pressure on the JVM. The full-width `train_w`, `val_w`, and `test_w` are retained as lazy DataFrames for any post-hoc analysis in evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ce0a55a4-e268-4f41-9e64-90f9c18bdc58",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Weight join complete. Projected splits ready for training.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def attach_weights(df, wmap_4, wmap_2):\n",
+    "    return (\n",
+    "        df\n",
+    "        .join(F.broadcast(wmap_4), on=\"label_4class_idx\", how=\"left\")\n",
+    "        .join(F.broadcast(wmap_2), on=\"label_binary_idx\", how=\"left\")\n",
+    "    )\n",
+    "\n",
+    "train_w = attach_weights(train_df, weight_map_4, weight_map_2)\n",
+    "val_w   = attach_weights(val_df,   weight_map_4, weight_map_2)\n",
+    "test_w  = attach_weights(test_df,  weight_map_4, weight_map_2)\n",
+    "\n",
+    "# Project down to only what XGBoost needs — avoids loading wide DataFrame into DMatrix\n",
+    "train_xgb = train_w.select(\"features\", \"label_4class_idx\", \"weight_4class\").repartition(16)\n",
+    "val_xgb   = val_w.select(\"features\", \"label_4class_idx\", \"weight_4class\").repartition(16)\n",
+    "test_xgb  = test_w.select(\"features\", \"label_4class_idx\", \"weight_4class\").repartition(16)\n",
+    "\n",
+    "print(\"Weight join complete. Projected splits ready for training.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b333d291-06d7-4450-bfe6-922066e4605b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "train_xgb partitions: 16\n",
+      "val_xgb partitions:   16\n",
+      "test_xgb partitions:  16\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"train_xgb partitions: {train_xgb.rdd.getNumPartitions()}\")\n",
+    "print(f\"val_xgb partitions:   {val_xgb.rdd.getNumPartitions()}\")\n",
+    "print(f\"test_xgb partitions:  {test_xgb.rdd.getNumPartitions()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8494758-9695-4c43-bd64-f39f9fde354b",
+   "metadata": {},
+   "source": [
+    "### XGBoost Model Configurations\n",
+    "\n",
+    "We train two configurations on the 4-class problem to analyze the underfitting/overfitting tradeoff.\n",
+    "\n",
+    "**Config A — Conservative (shallow, regularized):** `max_depth=4`, low learning rate, strong L2 regularization. Prioritizes stability; expected to underfit slightly given the complexity of 19 features across 102K subreddits.\n",
+    "\n",
+    "**Config B — Aggressive (deep, fast learning):** `max_depth=8`, higher learning rate, light regularization. Risks overfitting on subreddit-level aggregation features that may encode training-period-specific behavior given the temporal train/val/test split.\n",
+    "\n",
+    "Both configs target the 4-class label. `SparkXGBClassifier` sets the multiclass objective internally and uses `mlogloss` as the default evaluation metric — neither is passed explicitly. To avoid JVM OOM in `local[*]` mode, we use `num_workers=1` with `nthread=16` so XGBoost runs as a single worker using all 16 cores via multithreaded tree-building rather than 16 concurrent booster instances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6fa83ce9-a934-483c-85d0-d3eebdd7142e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config A and Config B defined.\n"
+     ]
+    }
+   ],
+   "source": [
+    "COMMON_PARAMS = dict(\n",
+    "    features_col=\"features\",\n",
+    "    label_col=\"label_4class_idx\",\n",
+    "    weight_col=\"weight_4class\",\n",
+    "    num_class=4,\n",
+    "    num_workers=16, # Match partition size / core config\n",
+    "    device=\"cpu\",\n",
+    "    seed=42,\n",
+    ")\n",
+    "\n",
+    "# Config A: conservative — shallow trees, strong regularization\n",
+    "config_A = SparkXGBClassifier(\n",
+    "    **COMMON_PARAMS,\n",
+    "    max_depth=4,\n",
+    "    n_estimators=200,\n",
+    "    learning_rate=0.05,\n",
+    "    subsample=0.8,\n",
+    "    colsample_bytree=0.8,\n",
+    "    reg_lambda=5.0,\n",
+    "    reg_alpha=1.0,\n",
+    "    min_child_weight=50,\n",
+    ")\n",
+    "\n",
+    "# Config B: aggressive — deep trees, faster learning, light regularization\n",
+    "config_B = SparkXGBClassifier(\n",
+    "    **COMMON_PARAMS,\n",
+    "    max_depth=8,\n",
+    "    n_estimators=300,\n",
+    "    learning_rate=0.1,\n",
+    "    subsample=0.7,\n",
+    "    colsample_bytree=0.7,\n",
+    "    reg_lambda=1.0,\n",
+    "    reg_alpha=0.0,\n",
+    "    min_child_weight=10,\n",
+    ")\n",
+    "\n",
+    "print(\"Config A and Config B defined.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9362aa81-c6cc-430e-9db6-ea0d3a3de1a8",
+   "metadata": {},
+   "source": [
+    "### Training Config A (Conservative)\n",
+    "\n",
+    "SparkXGBClassifier distributes tree-building across 16 Spark workers, each processing ~17M rows in parallel within the single JVM. Open the Spark UI at port 4040 during training to capture the parallelism screenshot required by the milestone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "58345041-2282-4e9f-9d5c-03eed1d2d035",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create directories\n",
+    "\n",
+    "import os\n",
+    "os.makedirs(\"../outputs/models/xgb_config_A_checkpoints\", exist_ok=True)\n",
+    "os.makedirs(\"../outputs/models\", exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "46bcacdd-0fe1-4ce0-af9d-20ed7a8bf5f5",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training Config A...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-09 01:33:24,408 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'multi:softprob', 'colsample_bytree': 0.8, 'device': 'cpu', 'learning_rate': 0.05, 'max_depth': 4, 'min_child_weight': 50, 'reg_alpha': 1.0, 'reg_lambda': 5.0, 'subsample': 0.8, 'num_class': 4, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 200}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n",
+      "2026-05-09 02:32:05,254 INFO XGBoost-PySpark: _fit Finished xgboost training!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config A training time: 3610.9s\n",
+      "Config A saved.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "print(\"Training Config A...\")\n",
+    "t0 = time.time()\n",
+    "\n",
+    "model_A = config_A.fit(train_xgb)\n",
+    "elapsed_A = time.time() - t0\n",
+    "print(f\"Config A training time: {elapsed_A:.1f}s\")\n",
+    "\n",
+    "model_A.write().overwrite().save(\"../outputs/models/xgb_config_A\")\n",
+    "print(\"Config A saved.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26d61a53-2a29-4147-97d6-e194777a348d",
+   "metadata": {},
+   "source": [
+    "#### Spark UI — Executor Summary\n",
+    "\n",
+    "Querying the Spark REST API to document executor configuration and confirm distributed execution for Config A."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "3ba3a96f-759e-4182-8397-814572fab32e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       id  totalCores    maxMemory  activeTasks  isActive  maxMemory_GB\n",
+      "0  driver          16  77120667648            0      True         71.82\n",
+      "\n",
+      "Spark master: local[*]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import requests\n",
+    "import pandas as pd\n",
+    "\n",
+    "sc = spark.sparkContext\n",
+    "url = f\"{sc.uiWebUrl}/api/v1/applications/{sc.applicationId}/executors\"\n",
+    "\n",
+    "executors = requests.get(url).json()\n",
+    "\n",
+    "sparkUI_df = pd.DataFrame(executors)[['id', 'totalCores', 'maxMemory', 'activeTasks', 'isActive']]\n",
+    "sparkUI_df['maxMemory_GB'] = (sparkUI_df['maxMemory'] / (1024**3)).round(2)\n",
+    "print(sparkUI_df)\n",
+    "print(f\"\\nSpark master: {sc.master}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1653c4f-5e4a-47c0-8be9-fdda3462a7e0",
+   "metadata": {},
+   "source": [
+    "### Training Config B (Aggressive)\n",
+    "\n",
+    "Same distributed setup as Config A w/ 16 workers each processing ~17M rows. Deeper trees and faster learning rate are expected to produce a larger model with longer training time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "667afab3-f03d-478f-93f7-7e8f27acefa5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training Config B...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-09 03:47:32,161 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'multi:softprob', 'colsample_bytree': 0.7, 'device': 'cpu', 'learning_rate': 0.1, 'max_depth': 8, 'min_child_weight': 10, 'reg_alpha': 0.0, 'reg_lambda': 1.0, 'subsample': 0.7, 'num_class': 4, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 300}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n",
+      "2026-05-09 05:43:11,075 INFO XGBoost-PySpark: _fit Finished xgboost training!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config B training time: 7059.0s\n",
+      "Config B saved.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "print(\"Training Config B...\")\n",
+    "t0 = time.time()\n",
+    "\n",
+    "model_B = config_B.fit(train_xgb)\n",
+    "elapsed_B = time.time() - t0\n",
+    "print(f\"Config B training time: {elapsed_B:.1f}s\")\n",
+    "\n",
+    "model_B.write().overwrite().save(\"../outputs/models/xgb_config_B\")\n",
+    "print(\"Config B saved.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40541d1a-7931-4052-884c-ff930dccec80",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f56cb4f0-5a98-4b53-8d15-b6b7e329b68c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Overview
Implements Milestone 3 model training using SparkXGBClassifier on the full 276M row training split of the Pushshift Reddit Submissions dataset. Two XGBoost configurations are trained and persisted for evaluation. 

## Changes
- Added class weight computation using normalized inverse frequency (N / num_classes * class_count) derived from the training set only to prevent leakage
- Added broadcast join of 4-class and binary weight maps to all three splits
- Projected train/val/test splits down to the three columns XGBoost requires (features, label_4class_idx, weight_4class), avoiding loading the full wide DataFrame into the XGBoost DMatrix
- Repartitioned all splits to 16 partitions matching num_workers=16 to distribute DMatrix construction across workers rather than collapsing 276M rows into a single mapInPandas call
- Defined and trained two SparkXGBClassifier configurations on the full training set:
  - Config A (Conservative): max_depth=4, 200 rounds, lr=0.05, strong L2/L1 regularization — trained in 3610.9s
  - Config B (Aggressive): max_depth=8, 300 rounds, lr=0.1, light regularization — trained in 7059.0s
- Added Spark UI executor summary cell confirming 16-core distributed execution in local[*] mode
- Both models persisted to outputs/models/ (gitignored per project convention)

## Engineering Notes
SparkXGBClassifier 2.0.3 does not allow explicit objective or eval_metric parameters — both are set internally for multiclass problems. The num_workers/partition alignment was critical: with num_workers=1 and 578 partitions, all 276M rows were collapsed into a single DMatrix allocation causing repeated JVM OOM kills. Setting num_workers=16 with 16 partitions distributes ~17M rows per worker, keeping each DMatrix allocation within the memory budget of the 128GB node.

## Models Trained
- outputs/models/xgb_config_A (gitignored)
- outputs/models/xgb_config_B (gitignored)

## Next Steps
Milestone 3 evaluation: load persisted models, score all three splits, compute weighted F1 and per-class metrics, produce results summary table, and write conclusion section covering over/underfitting analysis and distributed computing impact.