### PR TITLE
feat: XGBoost evaluation

### DIFF
--- a/notebooks/Milestone3_Pushshift.ipynb
+++ b/notebooks/Milestone3_Pushshift.ipynb
@@ -20,7 +20,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Matplotlib created a temporary cache directory at /scratch/ekim18/job_48857266/matplotlib-pl60bq54 because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
+      "Matplotlib created a temporary cache directory at /scratch/ekim18/job_48871723/matplotlib-xqunyz71 because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
      ]
     }
    ],
@@ -54,7 +54,7 @@
      "output_type": "stream",
      "text": [
       "Spark version: 3.5.0\n",
-      "Spark UI: http://exp-1-07.expanse.sdsc.edu:4040\n"
+      "Spark UI: http://exp-1-18.expanse.sdsc.edu:4040\n"
      ]
     }
    ],
@@ -1931,7 +1931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "6e76885c-5411-49d2-a332-cbeaa34f3451",
    "metadata": {},
    "outputs": [
@@ -1979,7 +1979,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "49c11962-97db-4aee-ac72-7ebf837d9402",
    "metadata": {},
    "outputs": [
@@ -2020,7 +2020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "e088e77a-3f1e-46dc-8f59-3dcda38131b2",
    "metadata": {},
    "outputs": [
@@ -2109,7 +2109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "ce0a55a4-e268-4f41-9e64-90f9c18bdc58",
    "metadata": {},
    "outputs": [
@@ -2143,7 +2143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "id": "b333d291-06d7-4450-bfe6-922066e4605b",
    "metadata": {},
    "outputs": [
@@ -2406,17 +2406,200 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40541d1a-7931-4052-884c-ff930dccec80",
+   "cell_type": "markdown",
+   "id": "eebe1e08-e51b-4265-84fb-ffd06b176800",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "### Reloading Persisted Models\n",
+    "\n",
+    "Both configs trained and saved in the previous session. Loading directly from disk to proceed with evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f56cb4f0-5a98-4b53-8d15-b6b7e329b68c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config A and Config B loaded successfully.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from xgboost.spark import SparkXGBClassifierModel\n",
+    "\n",
+    "model_A = SparkXGBClassifierModel.load(\"../outputs/models/xgb_config_A\")\n",
+    "model_B = SparkXGBClassifierModel.load(\"../outputs/models/xgb_config_B\")\n",
+    "\n",
+    "print(\"Config A and Config B loaded successfully.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be8cecb5-d77a-4e4d-a354-50d8bcc14372",
+   "metadata": {},
+   "source": [
+    "### Evaluation\n",
+    "\n",
+    "We evaluate both models across all three splits using weighted F1, accuracy, weighted precision, and weighted recall. Per-class precision, recall, and F1 are derived from the confusion matrix directly, which is reliable across all Spark versions. The train/val/test error gap is the primary diagnostic for over and underfitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4f45e661-0a23-4e5e-872f-bef9358b6526",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "====== Config A ======\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/spark/python/pyspark/sql/context.py:158: FutureWarning: Deprecated in 3.0.0. Use SparkSession.builder.getOrCreate() instead.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Train ---\n",
+      "  Weighted F1:    0.5283\n",
+      "  Accuracy:       0.5049\n",
+      "  W-Precision:    0.5911\n",
+      "  W-Recall:       0.5049\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7309  R=0.5075  F1=0.599\n",
+      "    viral                P=0.6517  R=0.504  F1=0.5684\n",
+      "    crowd-pleaser        P=0.3324  R=0.5345  F1=0.4099\n",
+      "    debate-starter       P=0.2417  R=0.4615  F1=0.3172\n",
+      "\n",
+      "--- Val ---\n",
+      "  Weighted F1:    0.5759\n",
+      "  Accuracy:       0.5531\n",
+      "  W-Precision:    0.6270\n",
+      "  W-Recall:       0.5531\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7287  R=0.5146  F1=0.6032\n",
+      "    viral                P=0.747  R=0.6574  F1=0.6993\n",
+      "    crowd-pleaser        P=0.3408  R=0.487  F1=0.401\n",
+      "    debate-starter       P=0.2364  R=0.4555  F1=0.3113\n",
+      "\n",
+      "--- Test ---\n",
+      "  Weighted F1:    0.5689\n",
+      "  Accuracy:       0.5463\n",
+      "  W-Precision:    0.6111\n",
+      "  W-Recall:       0.5463\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7059  R=0.5393  F1=0.6115\n",
+      "    viral                P=0.7402  R=0.6538  F1=0.6943\n",
+      "    crowd-pleaser        P=0.2935  R=0.3767  F1=0.3299\n",
+      "    debate-starter       P=0.2301  R=0.4339  F1=0.3007\n",
+      "\n",
+      "====== Config B ======\n",
+      "\n",
+      "--- Train ---\n",
+      "  Weighted F1:    0.5767\n",
+      "  Accuracy:       0.5564\n",
+      "  W-Precision:    0.6317\n",
+      "  W-Recall:       0.5564\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7557  R=0.5722  F1=0.6513\n",
+      "    viral                P=0.7051  R=0.5162  F1=0.5961\n",
+      "    crowd-pleaser        P=0.4072  R=0.6035  F1=0.4863\n",
+      "    debate-starter       P=0.2743  R=0.523  F1=0.3599\n",
+      "\n",
+      "--- Val ---\n",
+      "  Weighted F1:    0.6089\n",
+      "  Accuracy:       0.5868\n",
+      "  W-Precision:    0.6590\n",
+      "  W-Recall:       0.5868\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7527  R=0.5608  F1=0.6428\n",
+      "    viral                P=0.7809  R=0.6522  F1=0.7107\n",
+      "    crowd-pleaser        P=0.3927  R=0.5603  F1=0.4618\n",
+      "    debate-starter       P=0.2669  R=0.5134  F1=0.3512\n",
+      "\n",
+      "--- Test ---\n",
+      "  Weighted F1:    0.5866\n",
+      "  Accuracy:       0.5642\n",
+      "  W-Precision:    0.6309\n",
+      "  W-Recall:       0.5642\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7261  R=0.5597  F1=0.6321\n",
+      "    viral                P=0.7527  R=0.6415  F1=0.6927\n",
+      "    crowd-pleaser        P=0.3295  R=0.4571  F1=0.3829\n",
+      "    debate-starter       P=0.2525  R=0.4649  F1=0.3272\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.ml.evaluation import MulticlassClassificationEvaluator\n",
+    "from pyspark.mllib.evaluation import MulticlassMetrics\n",
+    "\n",
+    "def evaluate_model(model, df, label_col=\"label_4class_idx\", split_name=\"\"):\n",
+    "    preds = model.transform(df)\n",
+    "    \n",
+    "    # Overall metrics via MLlib evaluator\n",
+    "    evaluator = MulticlassClassificationEvaluator(\n",
+    "        labelCol=label_col,\n",
+    "        predictionCol=\"prediction\",\n",
+    "    )\n",
+    "    metrics = {}\n",
+    "    for metric in (\"f1\", \"accuracy\", \"weightedPrecision\", \"weightedRecall\"):\n",
+    "        evaluator.setMetricName(metric)\n",
+    "        metrics[metric] = evaluator.evaluate(preds)\n",
+    "\n",
+    "    # Per-class metrics via confusion matrix — reliable across all Spark versions\n",
+    "    preds_and_labels = preds.select(\"prediction\", label_col) \\\n",
+    "                            .rdd.map(lambda r: (float(r[0]), float(r[1])))\n",
+    "    mm = MulticlassMetrics(preds_and_labels)\n",
+    "    \n",
+    "    per_class = {}\n",
+    "    for cls in range(4):\n",
+    "        per_class[cls] = {\n",
+    "            \"precision\": round(mm.precision(float(cls)), 4),\n",
+    "            \"recall\":    round(mm.recall(float(cls)), 4),\n",
+    "            \"f1\":        round(mm.fMeasure(float(cls)), 4),\n",
+    "        }\n",
+    "\n",
+    "    print(f\"\\n--- {split_name} ---\")\n",
+    "    print(f\"  Weighted F1:    {metrics['f1']:.4f}\")\n",
+    "    print(f\"  Accuracy:       {metrics['accuracy']:.4f}\")\n",
+    "    print(f\"  W-Precision:    {metrics['weightedPrecision']:.4f}\")\n",
+    "    print(f\"  W-Recall:       {metrics['weightedRecall']:.4f}\")\n",
+    "    print(f\"  Per-class metrics:\")\n",
+    "    for cls, m in per_class.items():\n",
+    "        label = {0: \"low-engagement\", 1: \"viral\", 2: \"crowd-pleaser\", 3: \"debate-starter\"}[cls]\n",
+    "        print(f\"    {label:20s} P={m['precision']}  R={m['recall']}  F1={m['f1']}\")\n",
+    "    \n",
+    "    return metrics, per_class\n",
+    "\n",
+    "results = {}\n",
+    "for name, model in [(\"A\", model_A), (\"B\", model_B)]:\n",
+    "    print(f\"\\n====== Config {name} ======\")\n",
+    "    tr_m,  tr_pc  = evaluate_model(model, train_xgb, split_name=\"Train\")\n",
+    "    val_m, val_pc = evaluate_model(model, val_xgb,   split_name=\"Val\")\n",
+    "    te_m,  te_pc  = evaluate_model(model, test_xgb,  split_name=\"Test\")\n",
+    "    results[name] = {\"train\": tr_m, \"val\": val_m, \"test\": te_m}"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f56cb4f0-5a98-4b53-8d15-b6b7e329b68c",
+   "id": "835d9cc8-a6c3-478c-87a0-398fcf7bde29",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
## Overview
Adds model evaluation cells for both XGBoost configurations across all three splits (train/val/test). Replaces the originally planned setMetricLabel-based per-class F1 computation with a confusion matrix approach using MulticlassMetrics, which is reliable across all Spark versions.

## Changes
- Added evaluate_model() helper function computing weighted F1, accuracy, weighted precision, weighted recall, and per-class precision/recall/F1 via MulticlassMetrics confusion matrix
- Evaluated Config A and Config B across train, val, and test splits
- Stored all results in a results dict for downstream summary table and analysis cells
- Fixed broken per-class F1 computation from original design — setMetricLabel on MulticlassClassificationEvaluator returns weighted F1 regardless of label in this Spark version, confirmed via identical per-class values across all classes

## Key Results
Config A (conservative): Train WF1=0.5283, Val WF1=0.5759, Test WF1=0.5689
Config B (aggressive): Train WF1=0.5767, Val WF1=0.6089, Test WF1=0.5866
Both configs show val/test performance exceeding train — consistent with underfitting driven by temporal distribution shift across the 2012-2016 train / 2017 val / 2018 test split.

## Notes
Model artifacts remain gitignored per project convention. Cell outputs are saved in the notebook and do not require re-running to view results.

## Next Steps
Results summary table, fitting analysis section, conclusion section, sample predictions cell, README update, and Milestone3 branch creation.