### PR TITLE
feat: Milestone 3 features enrichment and leakage fixes

### DIFF
--- a/notebooks/Milestone3_Pushshift_v2.ipynb
+++ b/notebooks/Milestone3_Pushshift_v2.ipynb
@@ -1,0 +1,5639 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a407160e-5552-4827-9c22-e64330d12933",
+   "metadata": {},
+   "source": [
+    "# Milestone 3 Pushshift Reddit Preprocessing & First Model Building and Evaluation\n",
+    "\n",
+    "This notebook performs preprocessing and preliminary model building and evaluation on the Pushshift Reddit dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8a9bf756-fc26-40ed-83e9-515d38cb7a0e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Matplotlib created a temporary cache directory at /scratch/ekim18/job_49847123/matplotlib-5omjfp7l because the default path (/home/jovyan/.cache/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Dependencies \n",
+    "\n",
+    "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.types import *\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.dates as mdates\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from datetime import datetime\n",
+    "import os\n",
+    "import glob\n",
+    "from functools import reduce\n",
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.types import LongType\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b2646d4d-b832-49a0-b91a-c38ec0286fd1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spark version: 3.5.0\n",
+      "Spark UI: http://exp-4-48.expanse.sdsc.edu:4040\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SparkSession Configuration\n",
+    "\n",
+    "# 16 cores, 128GB total memory — local[*] mode\n",
+    "# In local mode there are no separate executor processes — all task execution\n",
+    "# runs as threads within a single JVM. Executor config parameters have no effect\n",
+    "# and are omitted. Driver memory is set to 120GB to give the JVM nearly the\n",
+    "# full node allocation.\n",
+    "spark = SparkSession.builder \\\n",
+    "    .appName(\"PushshiftRedditPreprocessing\") \\\n",
+    "    .master(\"local[*]\") \\\n",
+    "    .config(\"spark.driver.memory\", \"120g\") \\\n",
+    "    .config(\"spark.driver.maxResultSize\", \"8g\") \\\n",
+    "    .config(\"spark.sql.shuffle.partitions\", \"200\") \\\n",
+    "    .config(\"spark.sql.parquet.enableVectorizedReader\", \"true\") \\\n",
+    "    .config(\"spark.local.dir\", \"/expanse/lustre/projects/uci157/ekim18/spark-tmp\") \\\n",
+    "    .getOrCreate()\n",
+    "\n",
+    "spark.sparkContext.setLogLevel(\"WARN\")\n",
+    "print(f\"Spark version: {spark.version}\")\n",
+    "print(f\"Spark UI: {spark.sparkContext.uiWebUrl}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a34408bf-7525-46fa-8eb7-a68dbc82b0e3",
+   "metadata": {},
+   "source": [
+    "## Data Loading and Preprocessing Pipeline\n",
+    "\n",
+    "Raw data is loaded from `data/raw/` using the pre/post 2015 cutoff fix to handle the `created_utc` schema inconsistency across Parquet files (files before RS_2015-01 store `created_utc` as BINARY/STRING while later files store it as INT64). The two file groups are read separately with an explicit `.cast('long')` on `created_utc` then unioned into a single DataFrame.\n",
+    "\n",
+    "`row_count` is hardcoded from the EDA notebook to avoid re-triggering a full dataset scan on every kernel restart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "58c4a5bf-4422-41fc-9e57-919c108a0d21",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Files loaded: 218\n",
+      "Partitions: 683\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Data Load \n",
+    "\n",
+    "DATA_DIR = \"../data/raw/\"\n",
+    "files = sorted(glob.glob(os.path.join(DATA_DIR, \"*.parquet\")))\n",
+    "\n",
+    "COLS = [\"author\", \"created_utc\", \"id\", \"num_comments\", \"score\",\n",
+    "        \"selftext\", \"subreddit\", \"subreddit_id\", \"title\"]\n",
+    "\n",
+    "pre_cutoff = [f for f in files if os.path.basename(f) >= \"RS_2015-01\"]\n",
+    "post_cutoff = [f for f in files if os.path.basename(f) < \"RS_2015-01\"]\n",
+    "\n",
+    "# Files where created_utc is STRING - need to cast\n",
+    "df_pre = spark.read.parquet(*pre_cutoff) \\\n",
+    "    .select(*[F.col(c) for c in COLS if c != 'created_utc'],\n",
+    "            F.col('created_utc').cast('long').alias('created_utc'))\n",
+    "\n",
+    "df_post = spark.read.parquet(*post_cutoff) \\\n",
+    "    .select(*[F.col(c) for c in COLS if c != 'created_utc'],\n",
+    "            F.col('created_utc').cast('long').alias('created_utc'))\n",
+    "\n",
+    "MIN_TS = 1119398400  # June 2005\n",
+    "MAX_TS = 1700000000  # Nov 2023\n",
+    "\n",
+    "df = df_pre.union(df_post) \\\n",
+    "    .filter(F.col('created_utc').between(MIN_TS, MAX_TS))\n",
+    "\n",
+    "print(f\"Files loaded: {len(files)}\")\n",
+    "print(f\"Partitions: {df.rdd.getNumPartitions()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bfd0a882-4660-45a4-82c7-d152f194c569",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       id  totalCores    maxMemory  activeTasks  isActive  maxMemory_GB\n",
+      "0  driver          16  77120667648            0      True         71.82\n",
+      "local[*]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SparkUI Screenshot\n",
+    "\n",
+    "# Get the active Spark Context and URL\n",
+    "sc = spark.sparkContext\n",
+    "url = f\"{sc.uiWebUrl}/api/v1/applications/{sc.applicationId}/executors\"\n",
+    "\n",
+    "# Fetch the executor data from the API\n",
+    "response = requests.get(url)\n",
+    "executors = response.json()\n",
+    "\n",
+    "# Format into a readable DataFrame\n",
+    "sparkUI_df = pd.DataFrame(executors)[['id', 'totalCores', 'maxMemory', 'activeTasks', 'isActive']]\n",
+    "sparkUI_df['maxMemory_GB'] = (sparkUI_df['maxMemory'] / (1024**3)).round(2)\n",
+    "print(sparkUI_df)\n",
+    "\n",
+    "# Spark context master check\n",
+    "print(spark.sparkContext.master)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0b489152-f0d9-4dd3-a6e2-738c58386ab8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hardcode row_count to dataset size for count verifications\n",
+    "\n",
+    "row_count = 549662955"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07ba1feb-425e-400c-ab11-35a2bac79bcc",
+   "metadata": {},
+   "source": [
+    "## Filtering and Cleaning\n",
+    "\n",
+    "The following filters are applied to remove invalid records before any feature engineering or label generation. Decisions on what to filter and what to retain as features are documented in the EDA notebook (`notebooks/Milestone2_Pushshift.ipynb`).\n",
+    "\n",
+    "| Filter | Rows Removed | Reason |\n",
+    "|---|---|---|\n",
+    "| Null `subreddit` / `subreddit_id` | ~306,479 | Cannot contribute to per-subreddit features |\n",
+    "| Null `score` | 21 | Required for label generation |\n",
+    "| Negative `num_comments` | 1,090 | Pushshift artifact, value unverifiable |\n",
+    "\n",
+    "Zero-length titles, deleted/empty authors, and bot authors are **not** filtered. EDA showed these groups have distinct and meaningful engagement patterns that are captured as binary features (`has_title`, `is_anonymous_author`, `is_known_bot`) instead.\n",
+    "\n",
+    "EDA identified exactly 1 duplicate post ID across 549M rows. Deduplication was omitted from the preprocessing pipeline as `dropDuplicates` requires a full shuffle across the entire dataset which is an expensive operation that is not justified for removing a single row with no meaningful impact on model training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "475c5273-ce0f-40e2-9098-9067756584e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original row count:      549,662,955\n",
+      "Row count after filters: 549,355,365\n",
+      "Rows removed:            307,590\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── FILTERING & CLEANING ─────────────────────────────────────────────────────\n",
+    "\n",
+    "df_clean = df \\\n",
+    "    .filter(F.col(\"subreddit\").isNotNull()) \\\n",
+    "    .filter(F.col(\"subreddit_id\").isNotNull()) \\\n",
+    "    .filter(F.col(\"score\").isNotNull()) \\\n",
+    "    .filter(F.col(\"num_comments\") >= 0)\n",
+    "\n",
+    "print(f\"Original row count:      {row_count:,}\")\n",
+    "clean_count = df_clean.count()\n",
+    "print(f\"Row count after filters: {clean_count:,}\")\n",
+    "print(f\"Rows removed:            {row_count - clean_count:,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7345f3e8-d1c3-4919-8291-204ce32cf3b3",
+   "metadata": {},
+   "source": [
+    "## Bot Author Handling\n",
+    "\n",
+    "Rather than attempting frequency-based bot detection (which would require a full groupBy on author + date across 549M rows to compute per-author daily post rates), we take a simpler and more interpretable approach: flagging known high-volume bot accounts identified in EDA as a binary feature `is_known_bot`.\n",
+    "\n",
+    "This preserves all bot-authored posts in the dataset — bot posts have real and consistent engagement patterns (clustering heavily in low-engagement) that the model can learn from. Filtering them out would discard genuine signal. The `is_known_bot` flag gives the model explicit information about author type without requiring expensive per-author temporal aggregations.\n",
+    "\n",
+    "The known bot list is seeded from the top authors output in EDA. Frequency-based detection can be revisited in as feature engineering improvement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "81b2031c-d02f-47dc-ac13-defa61abb333",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Author type features added.\n",
+      "+------------+-------------------+---------+\n",
+      "|is_known_bot|is_anonymous_author|has_title|\n",
+      "+------------+-------------------+---------+\n",
+      "|           0|                  1|        1|\n",
+      "|           0|                  1|        1|\n",
+      "|           0|                  0|        1|\n",
+      "|           0|                  1|        1|\n",
+      "|           0|                  0|        1|\n",
+      "+------------+-------------------+---------+\n",
+      "only showing top 5 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── BOT AUTHOR FLAGGING ───────────────────────────────────────────────────────\n",
+    "\n",
+    "KNOWN_BOTS = {\n",
+    "    \"AutoModerator\", \"AutoNewsAdmin\", \"AutoNewspaperAdmin\",\n",
+    "    \"politicbot\", \"RPBot\", \"ImagesOfNetwork\", \"-en-\",\n",
+    "    \"KellyfromLeedsUK\"\n",
+    "}\n",
+    "\n",
+    "df_clean = df_clean \\\n",
+    "    .withColumn(\"is_known_bot\",\n",
+    "        F.when(F.col(\"author\").isin(list(KNOWN_BOTS)), 1)\n",
+    "         .otherwise(0)) \\\n",
+    "    .withColumn(\"is_anonymous_author\",\n",
+    "        F.when(\n",
+    "            (F.col(\"author\") == \"[deleted]\") | (F.col(\"author\") == \"\"), 1)\n",
+    "         .otherwise(0)) \\\n",
+    "    .withColumn(\"has_title\",\n",
+    "        F.when(F.length(F.col(\"title\")) == 0, 0)\n",
+    "         .otherwise(1))\n",
+    "\n",
+    "print(\"Author type features added.\")\n",
+    "df_clean.select(\"is_known_bot\", \"is_anonymous_author\", \"has_title\").show(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66ac75d2-e455-44ac-9784-bd49dfa71375",
+   "metadata": {},
+   "source": [
+    "#### Distribution of subreddit post counts\n",
+    "\n",
+    "First, we need to understand the shape of the subreddit post count distributions. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c205113c-a339-43d8-922f-3df23e07ee28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subreddit_post_counts = df_clean \\\n",
+    "    .groupBy(\"subreddit\") \\\n",
+    "    .count() \\\n",
+    "    .withColumnRenamed(\"count\", \"post_count\")\n",
+    "\n",
+    "subreddit_post_counts.select(\"post_count\").describe().show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e692ebb7-02da-4773-9cbf-826cf16289d6",
+   "metadata": {},
+   "source": [
+    "And the distribution at the low end specifically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efb0a670-80f8-4905-ae2c-c25b61d8cf78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subreddit_post_counts.groupBy(\n",
+    "    F.when(F.col(\"post_count\") < 10, \"<10\")\n",
+    "     .when(F.col(\"post_count\") < 50, \"10-49\")\n",
+    "     .when(F.col(\"post_count\") < 100, \"50-99\")\n",
+    "     .when(F.col(\"post_count\") < 500, \"100-499\")\n",
+    "     .when(F.col(\"post_count\") < 1000, \"500-999\")\n",
+    "     .otherwise(\"1000+\")\n",
+    "     .alias(\"post_count_bucket\")\n",
+    ") \\\n",
+    ".count() \\\n",
+    ".orderBy(\"post_count_bucket\") \\\n",
+    ".show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "899afe1b-6552-4d17-afcb-81887c2eaad9",
+   "metadata": {},
+   "source": [
+    "### What percentage of total posts would be excluded at various thresholds?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "155ef35a-e30b-45fd-bef0-330ec122dc32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for threshold in [10, 50, 100, 500, 1000]:\n",
+    "    kept = subreddit_post_counts.filter(F.col(\"post_count\") >= threshold)\n",
+    "    n_subreddits = kept.count()\n",
+    "    n_posts = kept.agg(F.sum(\"post_count\")).collect()[0][0]\n",
+    "    print(f\"Threshold {threshold:5d}: {n_subreddits:8,} subreddits kept, {n_posts:12,} posts kept ({n_posts/549355364*100:.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87d073c9-7a53-45d4-aa13-36260a2cc874",
+   "metadata": {},
+   "source": [
+    "## Subreddit Minimum Post Count Filter\n",
+    "\n",
+    "Per-subreddit percentile thresholds are only statistically meaningful when a subreddit\n",
+    "has enough posts for `percentile_approx` to produce a reliable estimate. Subreddits\n",
+    "with very few posts produce degenerate thresholds — for example, a subreddit with 5\n",
+    "posts all scoring 1 has a median of 1, meaning any post with score ≥ 1 clears the\n",
+    "\"high score\" threshold, which is essentially every post on Reddit.\n",
+    "\n",
+    "Analysis of the subreddit post count distribution reveals that 1,845,548 subreddits\n",
+    "(80.5% of all 2,291,802 subreddits) have fewer than 10 posts, and the distribution is\n",
+    "extremely long-tailed (mean: 239, stddev: 16,399). The vast majority of actual Reddit\n",
+    "activity is concentrated in a small number of active communities.\n",
+    "\n",
+    "Post retention at various minimum thresholds:\n",
+    "\n",
+    "| Min Posts | Subreddits Kept | Posts Kept |\n",
+    "|---|---|---|\n",
+    "| 10 | 446,254 | 99.2% |\n",
+    "| 50 | 154,388 | 98.1% |\n",
+    "| 100 | 102,739 | 97.5% |\n",
+    "| 500 | 40,045 | 95.0% |\n",
+    "| 1000 | 26,624 | 93.2% |\n",
+    "\n",
+    "We select a minimum of **100 posts per subreddit** as the threshold. At this cutoff,\n",
+    "`percentile_approx` has sufficient data to produce stable estimates, the jump from 50\n",
+    "to 100 costs only 0.6% of posts while eliminating 51,649 additional unreliable\n",
+    "subreddits, and 97.5% post retention ensures the dataset remains representative.\n",
+    "Subreddits below this threshold are excluded from label generation entirely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c4ac963d-1951-47d9-973f-6962260210b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rows after subreddit filter: 535,480,818\n",
+      "Rows removed:                13,874,547\n",
+      "Posts retained:              97.5%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── SUBREDDIT MINIMUM POST COUNT FILTER ──────────────────────────────────────\n",
+    "\n",
+    "MIN_SUBREDDIT_POSTS = 100\n",
+    "\n",
+    "# Compute per-subreddit post counts and filter to active subreddits\n",
+    "active_subreddits = df_clean \\\n",
+    "    .groupBy(\"subreddit\") \\\n",
+    "    .count() \\\n",
+    "    .filter(F.col(\"count\") >= MIN_SUBREDDIT_POSTS) \\\n",
+    "    .select(\"subreddit\")\n",
+    "\n",
+    "df_active = df_clean.join(active_subreddits, on=\"subreddit\", how=\"inner\")\n",
+    "\n",
+    "active_count = df_active.count()\n",
+    "print(f\"Rows after subreddit filter: {active_count:,}\")\n",
+    "print(f\"Rows removed:                {clean_count - active_count:,}\")\n",
+    "print(f\"Posts retained:              {active_count / clean_count * 100:.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "000862f9-dc99-49eb-b05b-2e8bd8aae529",
+   "metadata": {},
+   "source": [
+    "## Label Generation — Threshold Sensitivity Analysis\n",
+    "\n",
+    "Before committing to a percentile threshold for engagement archetype assignment, we\n",
+    "evaluated how the class distribution shifts across a range of thresholds. The goal is\n",
+    "to find a threshold that produces a label distribution that reflects the reality of\n",
+    "Reddit engagement — truly viral posts should be rare, and low-engagement posts should\n",
+    "be the majority.\n",
+    "\n",
+    "We ruled out standard deviation-based thresholds despite their statistical appeal\n",
+    "because Reddit score distributions are heavily right-skewed (global stddev: 707,\n",
+    "mean: 44.8), not normally distributed. Standard deviation thresholds assume roughly\n",
+    "normal distributions and behave unpredictably on skewed data. Percentile-based\n",
+    "thresholds are distribution-agnostic and more robust for this use case.\n",
+    "\n",
+    "Sensitivity analysis was run exploratorily across percentiles 0.5 through 0.6 before\n",
+    "hitting compute constraints. Results:\n",
+    "\n",
+    "| Percentile | viral | crowd-pleaser | debate-starter | low-engagement |\n",
+    "|---|---|---|---|---|\n",
+    "| 0.50 | 296,939,301 (55%) | 81,648,029 (15%) | 78,517,491 (15%) | 78,375,997 (15%) |\n",
+    "| 0.60 | 237,653,516 (44%) | 90,612,364 (17%) | 74,714,210 (14%) | 132,500,728 (25%) |\n",
+    "\n",
+    "At both thresholds the viral class is the dominant class — the opposite of expected.\n",
+    "The trend shows viral dropping ~11% and low-engagement growing ~10% per 0.1 increment.\n",
+    "We select **0.75** as the final threshold, extrapolating that it brings the distribution\n",
+    "to a more intuitive shape where low-engagement is the plurality class. The 0.75\n",
+    "threshold is also conceptually clean — a post must beat 3 out of 4 posts in its\n",
+    "subreddit on both axes simultaneously to qualify as viral."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4e664a21-f4ff-4f07-8cd2-270e53798c40",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4-class label distribution:\n",
+      "+--------------+---------+----+\n",
+      "|  label_4class|    count| pct|\n",
+      "+--------------+---------+----+\n",
+      "|low-engagement|236954268|44.3|\n",
+      "|         viral|160168118|29.9|\n",
+      "| crowd-pleaser| 74916114|14.0|\n",
+      "|debate-starter| 63442318|11.8|\n",
+      "+--------------+---------+----+\n",
+      "\n",
+      "Binary label distribution:\n",
+      "+---------------+---------+----+\n",
+      "|   label_binary|    count| pct|\n",
+      "+---------------+---------+----+\n",
+      "|high-engagement|298526550|55.7|\n",
+      "| low-engagement|236954268|44.3|\n",
+      "+---------------+---------+----+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── LABEL GENERATION — 75TH PERCENTILE THRESHOLD ─────────────────────────────\n",
+    "\n",
+    "SCORE_PERCENTILE = 0.75\n",
+    "COMMENTS_PERCENTILE = 0.75\n",
+    "\n",
+    "subreddit_thresholds = df_active \\\n",
+    "    .groupBy(\"subreddit\") \\\n",
+    "    .agg(\n",
+    "        F.expr(f\"percentile_approx(score, {SCORE_PERCENTILE})\").alias(\"score_thresh\"),\n",
+    "        F.expr(f\"percentile_approx(num_comments, {COMMENTS_PERCENTILE})\").alias(\"comments_thresh\")\n",
+    "    )\n",
+    "\n",
+    "df_labeled = df_active.join(subreddit_thresholds, on=\"subreddit\", how=\"left\") \\\n",
+    "    .withColumn(\"label_4class\",\n",
+    "        F.when(\n",
+    "            (F.col(\"score\") >= F.col(\"score_thresh\")) &\n",
+    "            (F.col(\"num_comments\") >= F.col(\"comments_thresh\")), \"viral\"\n",
+    "        ).when(\n",
+    "            (F.col(\"score\") >= F.col(\"score_thresh\")) &\n",
+    "            (F.col(\"num_comments\") < F.col(\"comments_thresh\")), \"crowd-pleaser\"\n",
+    "        ).when(\n",
+    "            (F.col(\"score\") < F.col(\"score_thresh\")) &\n",
+    "            (F.col(\"num_comments\") >= F.col(\"comments_thresh\")), \"debate-starter\"\n",
+    "        ).otherwise(\"low-engagement\")) \\\n",
+    "    .withColumn(\"label_binary\",\n",
+    "        F.when(\n",
+    "            (F.col(\"score\") >= F.col(\"score_thresh\")) |\n",
+    "            (F.col(\"num_comments\") >= F.col(\"comments_thresh\")),\n",
+    "            \"high-engagement\"\n",
+    "        ).otherwise(\"low-engagement\"))\n",
+    "\n",
+    "print(\"4-class label distribution:\")\n",
+    "df_labeled.groupBy(\"label_4class\") \\\n",
+    "    .count() \\\n",
+    "    .withColumn(\"pct\", F.round(F.col(\"count\") / F.lit(active_count) * 100, 1)) \\\n",
+    "    .orderBy(F.col(\"count\").desc()) \\\n",
+    "    .show()\n",
+    "\n",
+    "print(\"Binary label distribution:\")\n",
+    "df_labeled.groupBy(\"label_binary\") \\\n",
+    "    .count() \\\n",
+    "    .withColumn(\"pct\", F.round(F.col(\"count\") / F.lit(active_count) * 100, 1)) \\\n",
+    "    .orderBy(F.col(\"count\").desc()) \\\n",
+    "    .show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d1d6ea9-6faa-4adf-9f86-d5438c234996",
+   "metadata": {},
+   "source": [
+    "### Persist Labeled DataFrame \n",
+    "\n",
+    "We persist df_labeled to disk to break expensive lineage and have every subsequent action read from persisted Parquet file to avoid future re-shuffles and avoid disk spills."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b95d3e47-1f92-4be7-b184-cfc12cae4ffd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Write complete. Reloading from disk...\n",
+      "Rows in persisted df_labeled: 535,480,818\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── PERSIST df_labeled TO data/processed/ ─────────────────────────────────────────────\n",
+    "\n",
+    "PROCESSED_DIR = \"../data/processed/labeled/\"\n",
+    "\n",
+    "# Drop threshold columns before persisting — not needed downstream\n",
+    "df_labeled = df_labeled.drop(\"score_thresh\", \"comments_thresh\")\n",
+    "\n",
+    "# Write to Parquet\n",
+    "df_labeled.write \\\n",
+    "    .mode(\"overwrite\") \\\n",
+    "    .parquet(PROCESSED_DIR)\n",
+    "\n",
+    "print(\"Write complete. Reloading from disk...\")\n",
+    "\n",
+    "# Reload from disk — this breaks the lineage entirely\n",
+    "df_labeled = spark.read.parquet(PROCESSED_DIR)\n",
+    "\n",
+    "row_count_labeled = df_labeled.count()\n",
+    "print(f\"Rows in persisted df_labeled: {row_count_labeled:,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fb9c0def-41cd-4240-a14c-ba5e4f19f1a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reload df_labeled from data/processed/ \n",
+    "# Note: df_labeled is loaded in persist cell just for count validation\n",
+    "# This cell begins checkpoint for feature engineering\n",
+    "\n",
+    "PROCESSED_DIR = \"../data/processed/labeled/\"\n",
+    "df_labeled = spark.read.parquet(PROCESSED_DIR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "686fa055-ed12-4356-a384-c472866fa85b",
+   "metadata": {},
+   "source": [
+    "### Cold-Start Diagnostics\n",
+    "\n",
+    "We must diagnose the current leakage from per-author and per-subreddit features being currently computed on the aggregate dataset. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "abef71eb-0a13-445b-98b4-fd368ed0e92c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Columns in df_labeled:\n",
+      "  subreddit\n",
+      "  author\n",
+      "  id\n",
+      "  num_comments\n",
+      "  score\n",
+      "  selftext\n",
+      "  subreddit_id\n",
+      "  title\n",
+      "  created_utc\n",
+      "  is_known_bot\n",
+      "  is_anonymous_author\n",
+      "  has_title\n",
+      "  label_4class\n",
+      "  label_binary\n",
+      "\n",
+      "Total columns: 14\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── VERIFY df_labeled SCHEMA ─────────────────────────────────────────────────\n",
+    "# Confirm which features are already persisted vs. need to be re-added.\n",
+    "print(\"Columns in df_labeled:\")\n",
+    "for col in df_labeled.columns:\n",
+    "    print(f\"  {col}\")\n",
+    "print(f\"\\nTotal columns: {len(df_labeled.columns)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0fe761e9-2299-4fbe-a157-85d1110124ec",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "─── Cold-start prevalence ───\n",
+      "Val rows:  114,089,205\n",
+      "  unknown author:    32,867,850  (28.81%)\n",
+      "  unknown subreddit: 8,085,722  (7.09%)\n",
+      "Test rows: 144,949,019\n",
+      "  unknown author:    70,467,652  (48.62%)\n",
+      "  unknown subreddit: 27,492,501  (18.97%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── COLD-START PREVALENCE DIAGNOSTIC ─────────────────────────────────────────\n",
+    "# Goal: quantify how many val/test rows have authors or subreddits unseen in train.\n",
+    "# Split is temporal: train = 2012-2016, val = 2017, test = 2018.\n",
+    "\n",
+    "TRAIN_END = 1483228800  # 2017-01-01 00:00:00 UTC\n",
+    "VAL_END   = 1514764800  # 2018-01-01 00:00:00 UTC\n",
+    "\n",
+    "train_split = df_labeled.filter(F.col(\"created_utc\") < TRAIN_END)\n",
+    "val_split   = df_labeled.filter((F.col(\"created_utc\") >= TRAIN_END) & (F.col(\"created_utc\") < VAL_END))\n",
+    "test_split  = df_labeled.filter(F.col(\"created_utc\") >= VAL_END)\n",
+    "\n",
+    "# Distinct authors and subreddits seen in train\n",
+    "train_authors    = train_split.select(\"author\").distinct()\n",
+    "train_subreddits = train_split.select(\"subreddit\").distinct()\n",
+    "\n",
+    "# Cold-start counts via left-anti join (rows in val/test whose key is NOT in train)\n",
+    "val_total          = val_split.count()\n",
+    "val_cold_authors   = val_split.join(train_authors,    on=\"author\",    how=\"left_anti\").count()\n",
+    "val_cold_subreds   = val_split.join(train_subreddits, on=\"subreddit\", how=\"left_anti\").count()\n",
+    "\n",
+    "test_total         = test_split.count()\n",
+    "test_cold_authors  = test_split.join(train_authors,    on=\"author\",    how=\"left_anti\").count()\n",
+    "test_cold_subreds  = test_split.join(train_subreddits, on=\"subreddit\", how=\"left_anti\").count()\n",
+    "\n",
+    "print(\"─── Cold-start prevalence ───\")\n",
+    "print(f\"Val rows:  {val_total:,}\")\n",
+    "print(f\"  unknown author:    {val_cold_authors:,}  ({100*val_cold_authors/val_total:.2f}%)\")\n",
+    "print(f\"  unknown subreddit: {val_cold_subreds:,}  ({100*val_cold_subreds/val_total:.2f}%)\")\n",
+    "print(f\"Test rows: {test_total:,}\")\n",
+    "print(f\"  unknown author:    {test_cold_authors:,}  ({100*test_cold_authors/test_total:.2f}%)\")\n",
+    "print(f\"  unknown subreddit: {test_cold_subreds:,}  ({100*test_cold_subreds/test_total:.2f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d65e8e6-4aaf-4c08-9f03-15895acdfa87",
+   "metadata": {},
+   "source": [
+    "## Pipeline Restructure (v2): Train-Only Aggregations\n",
+    "\n",
+    "The original Milestone 3 pipeline computed author and subreddit aggregates over the full 2012–2018 dataset before the temporal split, allowing val and test rows to access information from their own period. The cold-start diagnostic confirmed the severity: 48.62% of test rows have authors absent from the training period and 18.97% are from subreddits not active in training. A substantial fraction of previously reported test performance was therefore driven by aggregate leakage.\n",
+    "\n",
+    "This section restructures the pipeline to enforce strict temporal isolation:\n",
+    "\n",
+    "1. Compute per-row features (title structural, post type, temporal) on the unsplit dataset — these are row-local and not leakage-prone. Author flags (`is_known_bot`, `is_anonymous_author`, `has_title`) and labels are already present from the persisted `df_labeled` checkpoint.\n",
+    "2. Split temporally before computing any aggregate.\n",
+    "3. Compute author and subreddit aggregates on the training split only.\n",
+    "4. Left-join those aggregates back to all three splits, leaving null values for cold-start rows.\n",
+    "5. Add explicit `is_new_author` and `is_new_subreddit` indicators so the model can learn cold-start handling directly.\n",
+    "\n",
+    "Null aggregate values are left as nulls rather than imputed, because XGBoost 2.x handles missing values natively by learning an optimal default branch direction per split. Pairing native null handling with explicit cold-start flags gives the model both the signal that information is missing and the freedom to route those rows through learned cold-start branches, avoiding the bias that a fixed imputation value would introduce given the high cold-start prevalence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "63c8fd35-530a-4111-aa08-cf57ebb9e277",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------------------------------------+---------+------------+---------------+----------------+----------------+------------+------------+-----------+-----------+\n",
+      "|                                   title|title_len|has_question|has_exclamation|title_has_number|title_is_allcaps|is_text_post|selftext_len|hour_of_day|day_of_week|\n",
+      "+----------------------------------------+---------+------------+---------------+----------------+----------------+------------+------------+-----------+-----------+\n",
+      "|                                        |        1|           0|              0|               0|               0|           0|           0|         18|          6|\n",
+      "|                          post video pls|       14|           0|              0|               0|               0|           0|           0|         19|          6|\n",
+      "| that would put you a basic because e...|       53|           0|              0|               0|               0|           0|           0|         20|          6|\n",
+      "|                  i love to call the epa|       22|           0|              0|               0|               0|           0|           0|         21|          4|\n",
+      "|                                        |        1|           0|              0|               0|               0|           0|           0|         22|          4|\n",
+      "+----------------------------------------+---------+------------+---------------+----------------+----------------+------------+------------+-----------+-----------+\n",
+      "only showing top 5 rows\n",
+      "\n",
+      "Total columns now: 23\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── PER-ROW FEATURE ENGINEERING ──────────────────────────────────────────────\n",
+    "# All features below are row-local: each value depends only on the row itself,\n",
+    "# never on aggregates over other rows, so they are safe to compute before the\n",
+    "# temporal split. Author flags (is_known_bot, is_anonymous_author, has_title)\n",
+    "# and labels are already present in df_labeled from the persisted checkpoint.\n",
+    "\n",
+    "df_features_base = df_labeled \\\n",
+    "    .withColumn(\"title_len\",\n",
+    "        F.length(F.col(\"title\"))) \\\n",
+    "    .withColumn(\"has_question\",\n",
+    "        F.when(F.col(\"title\").contains(\"?\"), 1).otherwise(0)) \\\n",
+    "    .withColumn(\"has_exclamation\",\n",
+    "        F.when(F.col(\"title\").contains(\"!\"), 1).otherwise(0)) \\\n",
+    "    .withColumn(\"title_has_number\",\n",
+    "        F.when(F.col(\"title\").rlike(r\"\\d+\"), 1).otherwise(0)) \\\n",
+    "    .withColumn(\"title_is_allcaps\",\n",
+    "        F.when(\n",
+    "            (F.length(F.col(\"title\")) > 0) &\n",
+    "            (F.col(\"title\").rlike(\"[A-Za-z]\")) &\n",
+    "            (F.col(\"title\") == F.upper(F.col(\"title\"))), 1\n",
+    "        ).otherwise(0)) \\\n",
+    "    .withColumn(\"is_text_post\",\n",
+    "        F.when(F.col(\"selftext\") != \"\", 1).otherwise(0)) \\\n",
+    "    .withColumn(\"selftext_len\",\n",
+    "        F.when(F.col(\"selftext\") != \"\", F.length(F.col(\"selftext\"))).otherwise(0)) \\\n",
+    "    .withColumn(\"hour_of_day\",\n",
+    "        F.hour(F.from_unixtime(F.col(\"created_utc\")))) \\\n",
+    "    .withColumn(\"day_of_week\",\n",
+    "        F.dayofweek(F.from_unixtime(F.col(\"created_utc\"))))\n",
+    "\n",
+    "# Quick visual check on the newly engineered columns\n",
+    "df_features_base.select(\n",
+    "    \"title\", \"title_len\",\n",
+    "    \"has_question\", \"has_exclamation\", \"title_has_number\", \"title_is_allcaps\",\n",
+    "    \"is_text_post\", \"selftext_len\",\n",
+    "    \"hour_of_day\", \"day_of_week\"\n",
+    ").show(5, truncate=40)\n",
+    "\n",
+    "print(f\"Total columns now: {len(df_features_base.columns)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a676a0e1-a749-4e6a-a18b-1f9161eb2961",
+   "metadata": {},
+   "source": [
+    "**Per-row feature engineering complete.** Nine row-local features were added to the 14 columns carried from `df_labeled`, for 23 total. Five title-structural features (`title_len`, `has_question`, `has_exclamation`, `title_has_number`, `title_is_allcaps`), two post-type features (`is_text_post`, `selftext_len`), and two temporal features (`hour_of_day`, `day_of_week`) are all derived from a single row's own fields and carry no cross-row leakage.\n",
+    "\n",
+    "The sample confirms expected behavior: the question, exclamation, and number flags fire only on relevant titles, `hour_of_day` and `day_of_week` decode correctly from `created_utc`, and `selftext_len` is 0 for the link posts shown. The `title_is_allcaps` flag now requires at least one alphabetic character, so the whitespace-only titles in rows 1 and 5 (which register `title_len = 1` from a single space character rather than a true empty string) are correctly assigned 0 rather than being miscounted as all-caps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "480559d5-32d0-4f15-adf7-47be26e7bf1d",
+   "metadata": {},
+   "source": [
+    "### Persist `df_features_base`\n",
+    "\n",
+    "We persist the per-row feature DataFrame before the split-and-aggregate work. This is a deliberate checkpoint: the per-row features are cheap but materialize over all 535M rows, and persisting here means any failure in the downstream aggregation steps can be recovered by reloading rather than recomputing. Reloading from disk also breaks the Spark lineage, preventing the query plan from growing unwieldy across the many transformations still ahead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6f043ca0-53cb-4b8c-ba47-7dd9f892a619",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Write complete. Reloading from disk to break lineage...\n",
+      "Rows:    535,480,818\n",
+      "Columns: 23\n",
+      "['subreddit', 'author', 'id', 'num_comments', 'score', 'selftext', 'subreddit_id', 'title', 'created_utc', 'is_known_bot', 'is_anonymous_author', 'has_title', 'label_4class', 'label_binary', 'title_len', 'has_question', 'has_exclamation', 'title_has_number', 'title_is_allcaps', 'is_text_post', 'selftext_len', 'hour_of_day', 'day_of_week']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── PERSIST df_features_base ─────────────────────────────────────────────────\n",
+    "# Checkpoint before split + aggregation. Reloading breaks lineage so the plan\n",
+    "# does not accumulate across downstream transformations.\n",
+    "\n",
+    "FEATURES_BASE_DIR = \"../data/processed/features_base_v2/\"\n",
+    "\n",
+    "df_features_base.write \\\n",
+    "    .mode(\"overwrite\") \\\n",
+    "    .parquet(FEATURES_BASE_DIR)\n",
+    "\n",
+    "print(\"Write complete. Reloading from disk to break lineage...\")\n",
+    "df_features_base = spark.read.parquet(FEATURES_BASE_DIR)\n",
+    "\n",
+    "print(f\"Rows:    {df_features_base.count():,}\")\n",
+    "print(f\"Columns: {len(df_features_base.columns)}\")\n",
+    "print(df_features_base.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "75ce607d-9463-46a3-bed5-0604fa3bb5ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rows: 535,480,818 | Columns: 23\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reload df_features_base from disk\n",
+    "FEATURES_BASE_DIR = \"../data/processed/features_base_v2/\"\n",
+    "df_features_base = spark.read.parquet(FEATURES_BASE_DIR)\n",
+    "print(f\"Rows: {df_features_base.count():,} | Columns: {len(df_features_base.columns)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f954c78-1ee7-4445-8859-6ebfc78c1f04",
+   "metadata": {},
+   "source": [
+    "### Temporal Split (Before Aggregation)\n",
+    "\n",
+    "This is the central methodological correction. The split into train (2012–2016), val (2017), and test (2018) happens *before* any aggregate is computed, so the author and subreddit statistics calculated downstream can only ever observe training-period data. The split boundaries are identical to those used in Milestone 3 (v1), so the corrected results remain directly comparable to the previously reported, leakage-affected numbers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "de50d5c1-4b69-4085-836e-f32eb17dcb1f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train rows: 276,442,594  (2012-2016)\n",
+      "Val rows:   114,089,205  (2017)\n",
+      "Test rows:  144,949,019  (2018)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── TEMPORAL SPLIT ───────────────────────────────────────────────────────────\n",
+    "# Split BEFORE aggregation so train-only statistics cannot see val/test rows.\n",
+    "# Boundaries match v1 for direct comparability.\n",
+    "\n",
+    "TRAIN_END = 1483228800  # 2017-01-01 00:00:00 UTC\n",
+    "VAL_END   = 1514764800  # 2018-01-01 00:00:00 UTC\n",
+    "\n",
+    "train_split = df_features_base.filter(F.col(\"created_utc\") < TRAIN_END)\n",
+    "val_split   = df_features_base.filter(\n",
+    "    (F.col(\"created_utc\") >= TRAIN_END) & (F.col(\"created_utc\") < VAL_END))\n",
+    "test_split  = df_features_base.filter(F.col(\"created_utc\") >= VAL_END)\n",
+    "\n",
+    "print(f\"Train rows: {train_split.count():,}  (2012-2016)\")\n",
+    "print(f\"Val rows:   {val_split.count():,}  (2017)\")\n",
+    "print(f\"Test rows:  {test_split.count():,}  (2018)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "313a7d83-1a2d-419d-9c19-fbaf897143ef",
+   "metadata": {},
+   "source": [
+    "### Author History Features (Train-Only Computation)\n",
+    "\n",
+    "`author_post_count` and `author_mean_score` are computed by grouping `train_split` by author, producing a table that maps each training-period author to their historical posting volume and mean score using only information available at training time. This table is then left-joined back to all three splits.\n",
+    "\n",
+    "Authors present in val or test but absent from train produce null values for both aggregate columns. We capture this explicitly with an `is_new_author` indicator. The nulls are intentionally left in place: XGBoost handles them natively at training time via its learned missing-value default direction, while the flag gives the model a direct, unambiguous signal that the row is cold-start. The sanity check below should reproduce the cold-start rates measured earlier (0% in train by construction, ~28.8% in val, ~48.6% in test), confirming the join behaved correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "0a1a33ed-3127-496e-8dab-9041e78ec2e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Authors observed in train: 21,177,082\n",
+      "\n",
+      "─── is_new_author prevalence ───\n",
+      "train: 0/276,442,594  (0.00%)\n",
+      "val: 32,867,850/114,089,205  (28.81%)\n",
+      "test: 70,467,652/144,949,019  (48.62%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── AUTHOR HISTORY AGGREGATES (TRAIN-ONLY) — lineage-broken via disk ──────────\n",
+    "# Re-derive a clean train_split (the earlier one was overwritten during debugging)\n",
+    "train_split = df_features_base.filter(F.col(\"created_utc\") < TRAIN_END)\n",
+    "val_split   = df_features_base.filter(\n",
+    "    (F.col(\"created_utc\") >= TRAIN_END) & (F.col(\"created_utc\") < VAL_END))\n",
+    "test_split  = df_features_base.filter(F.col(\"created_utc\") >= VAL_END)\n",
+    "\n",
+    "# Compute aggregate, then PERSIST + RELOAD to break shared lineage with the splits.\n",
+    "AUTHOR_STATS_DIR = \"../data/processed/author_stats_train_v2/\"\n",
+    "\n",
+    "train_split.groupBy(\"author\").agg(\n",
+    "    F.count(\"*\").alias(\"author_post_count\"),\n",
+    "    F.mean(\"score\").alias(\"author_mean_score\")\n",
+    ").write.mode(\"overwrite\").parquet(AUTHOR_STATS_DIR)\n",
+    "\n",
+    "author_stats_train = spark.read.parquet(AUTHOR_STATS_DIR)\n",
+    "n_known_authors = author_stats_train.count()\n",
+    "print(f\"Authors observed in train: {n_known_authors:,}\")\n",
+    "\n",
+    "def attach_author_stats(df):\n",
+    "    return df.join(author_stats_train, on=\"author\", how=\"left\") \\\n",
+    "             .withColumn(\"is_new_author\",\n",
+    "                 F.when(F.col(\"author_post_count\").isNull(), 1).otherwise(0))\n",
+    "\n",
+    "train_split = attach_author_stats(train_split)\n",
+    "val_split   = attach_author_stats(val_split)\n",
+    "test_split  = attach_author_stats(test_split)\n",
+    "\n",
+    "print(\"\\n─── is_new_author prevalence ───\")\n",
+    "for name, df in [(\"train\", train_split), (\"val\", val_split), (\"test\", test_split)]:\n",
+    "    n_new = df.filter(F.col(\"is_new_author\") == 1).count()\n",
+    "    n_tot = df.count()\n",
+    "    print(f\"{name}: {n_new:,}/{n_tot:,}  ({100*n_new/n_tot:.2f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5b855f2-1558-4b50-aa3a-d417f3a45f0d",
+   "metadata": {},
+   "source": [
+    "**Author history aggregates attached.** The training split contains 21,177,082 distinct authors. After left-joining the train-only aggregate to all three splits, the cold-start prevalence matches the earlier diagnostic exactly: 0.00% in train (every train author is in the train aggregate by construction), 28.81% in val, and 48.62% in test. The train rate of exactly zero confirms the join keys resolve correctly; the val and test rates reproducing the independent diagnostic measurement confirms the aggregate captures precisely the training-period author population and nothing more.\n",
+    "\n",
+    "Note that the aggregate table was persisted to disk and reloaded before joining. This breaks the shared Spark lineage between the aggregate and the split DataFrames — both derive from the same `df_features_base` plan, and joining them directly produced an ambiguous column-provenance resolution that silently returned nulls for matching keys. Materializing the aggregate to disk forces Spark to treat it as an independent source, resolving the join correctly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e65827bf-5e4b-4edb-bd62-2b7cfe96225e",
+   "metadata": {},
+   "source": [
+    "### Subreddit Context Features (Train-Only Computation)\n",
+    "\n",
+    "The same train-only pattern applies to subreddit aggregates. `subreddit_post_count`, `subreddit_median_score`, and `subreddit_median_comments` are computed on `train_split`, persisted to disk to break lineage, then left-joined to all three splits with an `is_new_subreddit` flag for cold-start subreddits.\n",
+    "\n",
+    "Unlike the author aggregates, the subreddit medians use `percentile_approx`, which is more compute-intensive than a mean. The cold-start rates here are expected to be lower than for authors (roughly 7% val, 19% test from the diagnostic), since communities are far less numerous than users and turn over more slowly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9be904ee-1b98-4f70-866e-ef70ce6cadd6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subreddits observed in train: 76,624\n",
+      "\n",
+      "─── is_new_subreddit prevalence ───\n",
+      "train: 0/276,442,594  (0.00%)\n",
+      "val: 8,085,722/114,089,205  (7.09%)\n",
+      "test: 27,492,501/144,949,019  (18.97%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── SUBREDDIT CONTEXT AGGREGATES (TRAIN-ONLY) — lineage-broken via disk ───────\n",
+    "# Same pattern as author aggregates: compute on train, persist + reload to break\n",
+    "# lineage, then left-join to all three splits with an is_new_subreddit flag.\n",
+    "\n",
+    "SUBREDDIT_STATS_DIR = \"../data/processed/subreddit_stats_train_v2/\"\n",
+    "\n",
+    "train_split.groupBy(\"subreddit\").agg(\n",
+    "    F.count(\"*\").alias(\"subreddit_post_count\"),\n",
+    "    F.expr(\"percentile_approx(score, 0.5)\").alias(\"subreddit_median_score\"),\n",
+    "    F.expr(\"percentile_approx(num_comments, 0.5)\").alias(\"subreddit_median_comments\")\n",
+    ").write.mode(\"overwrite\").parquet(SUBREDDIT_STATS_DIR)\n",
+    "\n",
+    "subreddit_stats_train = spark.read.parquet(SUBREDDIT_STATS_DIR)\n",
+    "n_known_subreddits = subreddit_stats_train.count()\n",
+    "print(f\"Subreddits observed in train: {n_known_subreddits:,}\")\n",
+    "\n",
+    "def attach_subreddit_stats(df):\n",
+    "    return df.join(subreddit_stats_train, on=\"subreddit\", how=\"left\") \\\n",
+    "             .withColumn(\"is_new_subreddit\",\n",
+    "                 F.when(F.col(\"subreddit_post_count\").isNull(), 1).otherwise(0))\n",
+    "\n",
+    "train_split = attach_subreddit_stats(train_split)\n",
+    "val_split   = attach_subreddit_stats(val_split)\n",
+    "test_split  = attach_subreddit_stats(test_split)\n",
+    "\n",
+    "print(\"\\n─── is_new_subreddit prevalence ───\")\n",
+    "for name, df in [(\"train\", train_split), (\"val\", val_split), (\"test\", test_split)]:\n",
+    "    n_new = df.filter(F.col(\"is_new_subreddit\") == 1).count()\n",
+    "    n_tot = df.count()\n",
+    "    print(f\"{name}: {n_new:,}/{n_tot:,}  ({100*n_new/n_tot:.2f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7119dec-2243-44a7-a860-02e9967bf213",
+   "metadata": {},
+   "source": [
+    "**Subreddit context aggregates attached.** Following the same train-only, lineage-broken pattern, subreddit post counts and median score/comments are now joined to all three splits. Cold-start prevalence again matches the diagnostic: 0.00% in train by construction, ~7.09% in val, and ~18.97% in test. As anticipated, subreddit cold-start rates are substantially lower than author rates (28.81% / 48.62%), reflecting that communities are far fewer in number and turn over more slowly than individual users.\n",
+    "\n",
+    "Each split now carries the full structured feature set: the per-row features from `df_features_base`, both train-only author aggregates, both train-only subreddit aggregates, and the two cold-start indicators (`is_new_author`, `is_new_subreddit`). All aggregate-derived features are computed strictly from training-period data, eliminating the temporal leakage present in the original Milestone 3 pipeline."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b200db3f-5825-4f4f-9ba4-b9598e5d7431",
+   "metadata": {},
+   "source": [
+    "### Persist Per-Split Feature DataFrames\n",
+    "\n",
+    "We persist the three splits independently rather than recombining them into a single DataFrame. Each split now holds aggregate features that were computed against train-only data and joined per-split, so they are no longer interchangeable rows of one table — recombining and re-splitting would serve no purpose and would risk reintroducing lineage entanglement. Persisting per-split also matches the structure the downstream NLP enrichment and model-training stages expect: each stage loads the split it needs, adds to it, and writes it back.\n",
+    "\n",
+    "This checkpoint captures the fully leakage-corrected structured feature set. The next stage (NLP feature enrichment) builds directly on top of these persisted splits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "07f02d75-d7ae-4229-8eb6-990930fe147a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing train split...\n",
+      "Writing val split...\n",
+      "Writing test split...\n",
+      "\n",
+      "Reloading from disk to break lineage...\n",
+      "Train rows: 276,442,594\n",
+      "Val rows:   114,089,205\n",
+      "Test rows:  144,949,019\n",
+      "\n",
+      "Columns (30):\n",
+      "['subreddit', 'author', 'id', 'num_comments', 'score', 'selftext', 'subreddit_id', 'title', 'created_utc', 'is_known_bot', 'is_anonymous_author', 'has_title', 'label_4class', 'label_binary', 'title_len', 'has_question', 'has_exclamation', 'title_has_number', 'title_is_allcaps', 'is_text_post', 'selftext_len', 'hour_of_day', 'day_of_week', 'author_post_count', 'author_mean_score', 'is_new_author', 'subreddit_post_count', 'subreddit_median_score', 'subreddit_median_comments', 'is_new_subreddit']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── PERSIST TRAIN/VAL/TEST WITH STRUCTURED FEATURES ──────────────────────────\n",
+    "# Leakage-corrected checkpoint. Each split carries per-row features + train-only\n",
+    "# author/subreddit aggregates + cold-start flags. NLP enrichment builds on these.\n",
+    "\n",
+    "TRAIN_FEATURES_DIR = \"../data/processed/train_features_v2/\"\n",
+    "VAL_FEATURES_DIR   = \"../data/processed/val_features_v2/\"\n",
+    "TEST_FEATURES_DIR  = \"../data/processed/test_features_v2/\"\n",
+    "\n",
+    "print(\"Writing train split...\")\n",
+    "train_split.write.mode(\"overwrite\").parquet(TRAIN_FEATURES_DIR)\n",
+    "print(\"Writing val split...\")\n",
+    "val_split.write.mode(\"overwrite\").parquet(VAL_FEATURES_DIR)\n",
+    "print(\"Writing test split...\")\n",
+    "test_split.write.mode(\"overwrite\").parquet(TEST_FEATURES_DIR)\n",
+    "\n",
+    "print(\"\\nReloading from disk to break lineage...\")\n",
+    "train_split = spark.read.parquet(TRAIN_FEATURES_DIR)\n",
+    "val_split   = spark.read.parquet(VAL_FEATURES_DIR)\n",
+    "test_split  = spark.read.parquet(TEST_FEATURES_DIR)\n",
+    "\n",
+    "print(f\"Train rows: {train_split.count():,}\")\n",
+    "print(f\"Val rows:   {val_split.count():,}\")\n",
+    "print(f\"Test rows:  {test_split.count():,}\")\n",
+    "print(f\"\\nColumns ({len(train_split.columns)}):\")\n",
+    "print(train_split.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d068c8cb-648a-4ace-b93c-fcc8c28b09a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train: 276,442,594 rows\n",
+      "Val:   114,089,205 rows\n",
+      "Test:  144,949,019 rows\n",
+      "Columns (30): ['subreddit', 'author', 'id', 'num_comments', 'score', 'selftext', 'subreddit_id', 'title', 'created_utc', 'is_known_bot', 'is_anonymous_author', 'has_title', 'label_4class', 'label_binary', 'title_len', 'has_question', 'has_exclamation', 'title_has_number', 'title_is_allcaps', 'is_text_post', 'selftext_len', 'hour_of_day', 'day_of_week', 'author_post_count', 'author_mean_score', 'is_new_author', 'subreddit_post_count', 'subreddit_median_score', 'subreddit_median_comments', 'is_new_subreddit']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reload leakage-corrected splits from disk (post-restart entry point)\n",
+    "TRAIN_FEATURES_DIR = \"../data/processed/train_features_v2/\"\n",
+    "VAL_FEATURES_DIR   = \"../data/processed/val_features_v2/\"\n",
+    "TEST_FEATURES_DIR  = \"../data/processed/test_features_v2/\"\n",
+    "\n",
+    "train_split = spark.read.parquet(TRAIN_FEATURES_DIR)\n",
+    "val_split   = spark.read.parquet(VAL_FEATURES_DIR)\n",
+    "test_split  = spark.read.parquet(TEST_FEATURES_DIR)\n",
+    "\n",
+    "print(f\"Train: {train_split.count():,} rows\")\n",
+    "print(f\"Val:   {val_split.count():,} rows\")\n",
+    "print(f\"Test:  {test_split.count():,} rows\")\n",
+    "print(f\"Columns ({len(train_split.columns)}): {train_split.columns}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8613985-dcbf-4881-949c-68b16292f523",
+   "metadata": {},
+   "source": [
+    "## NLP Feature Enrichment: VADER Sentiment\n",
+    "\n",
+    "Two VADER compound-sentiment features are attached: `title_sentiment` (computed on every title) and `selftext_sentiment` (computed on the first 500 characters of selftext for text posts; null for link posts). Both are row-local and deterministic — a post's sentiment depends only on its own text, not on any other row — so they are unaffected by the temporal leakage correction applied to the aggregate features.\n",
+    "\n",
+    "Because sentiment is identical regardless of when it is computed, the canonical from-scratch VADER UDF cells (preserved below, matching the Milestone 3 v1 implementation) are not re-executed in this pass. Instead, the previously computed sentiment values are joined from the prior run's persisted output, keyed on the post `id`. This is an iteration-speed decision: re-running VADER over 535M rows costs roughly 38 minutes and would reproduce values identical to those already on disk. The from-scratch cells remain the reproducible path of record; the join is an equivalent shortcut for development velocity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0648cba2-d2fd-460b-976c-9e9806b926e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── CANONICAL PATH (NOT RUN THIS PASS) ───────────────────────────────────────\n",
+    "# The from-scratch VADER title + selftext UDF cells from Milestone 3 v1 are the\n",
+    "# reproducible path of record. They are preserved in Milestone3_Pushshift.ipynb\n",
+    "# (cells 38-48) and produce values identical to those joined below, since VADER\n",
+    "# sentiment is row-local and deterministic.\n",
+    "#\n",
+    "# Source UDFs:\n",
+    "#   - vader_sentiment_udf(title)      -> title_sentiment   (0.0 for empty title)\n",
+    "#   - selftext_sentiment_udf(selftext)-> selftext_sentiment (null for link posts)\n",
+    "#\n",
+    "# For the final reproducible submission, re-enable these cells in place of the\n",
+    "# join below if a fully self-contained top-to-bottom run is required.\n",
+    "# ─────────────────────────────────────────────────────────────────────────────"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4845534c-1ece-42dd-8eb7-685e69859e1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── INSTALL VADER ─────────────────────────────────────────────────────────────\n",
+    "import subprocess\n",
+    "result = subprocess.run(\n",
+    "    [\"pip\", \"install\", \"vaderSentiment\"],\n",
+    "    capture_output=True, text=True\n",
+    ")\n",
+    "print(result.stdout)\n",
+    "print(result.stderr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "584018cb-f766-4784-af75-78384c51ddfa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This is the most amazing thing I've ever seen!!!   → compound: +0.716\n",
+      "Why does nobody care about this?                   → compound: +0.494\n",
+      "I hate everything about this                       → compound: -0.572\n",
+      "lol this is hilarious                              → compound: +0.670\n",
+      "Breaking news: major disaster strikes              → compound: -0.800\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── VERIFY VADER INSTALLATION ─────────────────────────────────────────────────\n",
+    "from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer\n",
+    "\n",
+    "analyzer = SentimentIntensityAnalyzer()\n",
+    "\n",
+    "# Test on a few Reddit-style titles\n",
+    "test_titles = [\n",
+    "    \"This is the most amazing thing I've ever seen!!!\",\n",
+    "    \"Why does nobody care about this?\",\n",
+    "    \"I hate everything about this\",\n",
+    "    \"lol this is hilarious\",\n",
+    "    \"Breaking news: major disaster strikes\"\n",
+    "]\n",
+    "\n",
+    "for title in test_titles:\n",
+    "    score = analyzer.polarity_scores(title)\n",
+    "    print(f\"{title[:50]:<50} → compound: {score['compound']:+.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0adecc53-3f0c-42e6-b515-04d7250bebcc",
+   "metadata": {},
+   "source": [
+    "### VADER Performance Benchmark\n",
+    "\n",
+    "Before deciding whether to run VADER sentiment on the full 535M row dataset, we benchmark throughput on a small sample and extrapolate to estimate total runtime. Python UDFs in local mode process rows sequentially in Python, bypassing Spark's JVM optimizations. The benchmark will determine whether full-dataset NLP feature engineering is feasible within reasonable time constraints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "a9ec8462-5c56-4785-89f2-f1944f34dda2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sample size:         10,000 rows\n",
+      "Elapsed:             0.26 seconds\n",
+      "Throughput:          38,114 rows/sec\n",
+      "Estimated full run:  3.9 hours for 535M rows\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── VADER THROUGHPUT BENCHMARK ────────────────────────────────────────────────\n",
+    "import time\n",
+    "from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer\n",
+    "\n",
+    "# Collect a small sample of titles to the driver\n",
+    "sample_size = 10000\n",
+    "sample_titles = df_features \\\n",
+    "    .select(\"title\") \\\n",
+    "    .limit(sample_size) \\\n",
+    "    .toPandas()[\"title\"].tolist()\n",
+    "\n",
+    "analyzer = SentimentIntensityAnalyzer()\n",
+    "\n",
+    "start = time.time()\n",
+    "scores = [analyzer.polarity_scores(t)[\"compound\"] for t in sample_titles]\n",
+    "elapsed = time.time() - start\n",
+    "\n",
+    "rows_per_sec = sample_size / elapsed\n",
+    "estimated_total_hours = (535_480_818 / rows_per_sec) / 3600\n",
+    "\n",
+    "print(f\"Sample size:         {sample_size:,} rows\")\n",
+    "print(f\"Elapsed:             {elapsed:.2f} seconds\")\n",
+    "print(f\"Throughput:          {rows_per_sec:,.0f} rows/sec\")\n",
+    "print(f\"Estimated full run:  {estimated_total_hours:.1f} hours for 535M rows\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5012ff96-8365-418b-9a6b-0252c9fde144",
+   "metadata": {},
+   "source": [
+    "### VADER Sentiment Feature\n",
+    "\n",
+    "We implement VADER sentiment as a Spark UDF applied to the `title` column across the full 535M row dataset. To avoid the overhead of instantiating `SentimentIntensityAnalyzer` on every row, we use a module-level singleton pattern and the analyzer is instantiated once per worker thread and reused across all rows processed by that thread.\n",
+    "\n",
+    "The UDF returns a compound sentiment score in [-1.0, 1.0] where:\n",
+    "- Scores > 0.05 indicate positive sentiment\n",
+    "- Scores < -0.05 indicate negative sentiment  \n",
+    "- Scores between -0.05 and 0.05 indicate neutral sentiment\n",
+    "\n",
+    "Empty or null titles (zero-length title posts) return 0.0 (neutral).\n",
+    "\n",
+    "Estimated runtime based on benchmarking: ~4.4 hours worst case on a single thread, significantly less with 16-core parallelization in local[*] mode."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "9591d994-f826-467b-9a9f-ca8ca3c4bce4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Title sentiment run started at: 2026-05-07 22:09:57\n",
+      "Completed at:  2026-05-07 22:35:00\n",
+      "Total runtime: 0h 25m 2s\n",
+      "Throughput:    356,458 rows/sec\n",
+      "Rows: 535,480,818 | Columns: 29\n",
+      "+-------------------+-------------+-------------+---------+---------+---------+\n",
+      "|     mean_sentiment|min_sentiment|max_sentiment| positive| negative|  neutral|\n",
+      "+-------------------+-------------+-------------+---------+---------+---------+\n",
+      "|0.04680778548004337|      -0.9998|       0.9999|150730614|100471690|284278514|\n",
+      "+-------------------+-------------+-------------+---------+---------+---------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── VADER TITLE SENTIMENT UDF ─────────────────────────────────────────────────\n",
+    "import time\n",
+    "import datetime\n",
+    "from pyspark.sql.types import FloatType\n",
+    "import pyspark.sql.functions as F\n",
+    "\n",
+    "# Module-level singleton — instantiated once per worker thread, not per row\n",
+    "_analyzer = None\n",
+    "\n",
+    "def get_analyzer():\n",
+    "    global _analyzer\n",
+    "    if _analyzer is None:\n",
+    "        from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer\n",
+    "        _analyzer = SentimentIntensityAnalyzer()\n",
+    "    return _analyzer\n",
+    "\n",
+    "# Register Python function as Spark UDF returning a float\n",
+    "@F.udf(returnType=FloatType())\n",
+    "def vader_sentiment_udf(text):\n",
+    "    # Return neutral for empty/null titles\n",
+    "    if text is None or text == \"\":\n",
+    "        return 0.0\n",
+    "    try:\n",
+    "        analyzer = get_analyzer()\n",
+    "        # Extract compound score from VADER polarity dict\n",
+    "        return float(analyzer.polarity_scores(text)[\"compound\"])\n",
+    "    except Exception:\n",
+    "        return 0.0\n",
+    "\n",
+    "# Add title_sentiment to logical plan — no execution yet\n",
+    "df_features = df_features \\\n",
+    "    .withColumn(\"title_sentiment\", vader_sentiment_udf(F.col(\"title\")))\n",
+    "\n",
+    "# Write to temp directory to avoid reading from and writing to the same location\n",
+    "FEATURES_NLP_TEMP_DIR = \"../data/processed/features_nlp_temp/\"\n",
+    "FEATURES_NLP_DIR = \"../data/processed/features_nlp/\"\n",
+    "\n",
+    "start_time = time.time()\n",
+    "start_dt = datetime.datetime.now()\n",
+    "print(f\"Title sentiment run started at: {start_dt.strftime('%Y-%m-%d %H:%M:%S')}\")\n",
+    "\n",
+    "# Triggers UDF execution across all 535M rows\n",
+    "df_features.write \\\n",
+    "    .mode(\"overwrite\") \\\n",
+    "    .parquet(FEATURES_NLP_TEMP_DIR)\n",
+    "\n",
+    "elapsed = time.time() - start_time\n",
+    "print(f\"Completed at:  {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\")\n",
+    "print(f\"Total runtime: {int(elapsed//3600)}h {int((elapsed%3600)//60)}m {int(elapsed%60)}s\")\n",
+    "print(f\"Throughput:    {535_480_818 / elapsed:,.0f} rows/sec\")\n",
+    "\n",
+    "# Reload from temp to break lineage\n",
+    "df_features = spark.read.parquet(FEATURES_NLP_TEMP_DIR)\n",
+    "print(f\"Rows: {df_features.count():,} | Columns: {len(df_features.columns)}\")\n",
+    "\n",
+    "# Sanity check on title sentiment distribution\n",
+    "df_features.select(\n",
+    "    F.mean(\"title_sentiment\").alias(\"mean_sentiment\"),\n",
+    "    F.min(\"title_sentiment\").alias(\"min_sentiment\"),\n",
+    "    F.max(\"title_sentiment\").alias(\"max_sentiment\"),\n",
+    "    F.count(F.when(F.col(\"title_sentiment\") > 0.05, 1)).alias(\"positive\"),\n",
+    "    F.count(F.when(F.col(\"title_sentiment\") < -0.05, 1)).alias(\"negative\"),\n",
+    "    F.count(F.when(\n",
+    "        (F.col(\"title_sentiment\") >= -0.05) &\n",
+    "        (F.col(\"title_sentiment\") <= 0.05), 1)\n",
+    "    ).alias(\"neutral\")\n",
+    ").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5759eb2-d7b7-456e-aef0-2b4a060a6f00",
+   "metadata": {},
+   "source": [
+    "### VADER Sentiment Results\n",
+    "\n",
+    "VADER sentiment was computed across all 535,480,818 posts in 27 minutes 51 seconds, significantly faster than the 4.4 hour worst-case estimate due to 16-core parallelization achieving 320,432 rows/sec (vs. 40,989 rows/sec single-threaded), an ~8x speedup over the single-thread benchmark.\n",
+    "\n",
+    "Sentiment distribution across the full dataset:\n",
+    "\n",
+    "| Sentiment | Count | % of Total |\n",
+    "|---|---|---|\n",
+    "| Neutral (-0.05 to 0.05) | 284,278,514 | 53.1% |\n",
+    "| Positive (> 0.05) | 150,730,614 | 28.1% |\n",
+    "| Negative (< -0.05) | 100,471,690 | 18.8% |\n",
+    "\n",
+    "Mean compound score: +0.047 slightly positive overall, consistent with Reddit's upvote-driven culture where positive content tends to surface more readily. The full [-0.9998, +0.9999] range confirms VADER is utilizing its full scoring scale on Reddit title text. The majority-neutral distribution (53.1%) reflects that most Reddit titles are factual or descriptive rather than emotionally charged."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3295efd5-f1c4-4c97-9d1f-a64f28c74f4b",
+   "metadata": {},
+   "source": [
+    "### Selftext Sentiment Feature\n",
+    "\n",
+    "Given the VADER title sentiment run completed in under 28 minutes at 320K rows/sec, we extend sentiment analysis to post body text (`selftext`). \n",
+    "\n",
+    "**Relationship to title sentiment:** 912,556 posts have zero-length titles where post content is entirely in `selftext` (e.g. r/SuggestALaptop, r/friendsafari). For these posts `title_sentiment` returns 0.0 (neutral) since there is no title text, but the real sentiment signal lives in `selftext`. We keep `title_sentiment` and `selftext_sentiment` as separate features rather than combining them as a tree-based model can learn the interaction between `has_title`, `title_sentiment`, and `selftext_sentiment` naturally. The existing `has_title` flag gives the model the context to correctly interpret a `title_sentiment` of 0.0 on a no-title post.\n",
+    "\n",
+    "**Truncation:** VADER was designed for short social media text. Selftext can range from a few words to thousands of characters. We truncate to the first 500 characters before scoring. This captures the opening sentiment of the post which is most relevant to engagement, avoids unreliable scoring on very long text, and reduces per-row processing time.\n",
+    "\n",
+    "**Null handling:** Empty selftext (link posts, 72.8% of dataset) returns null rather than 0.0. Returning 0.0 would conflate \"no body text\" with \"neutral body text\", which are meaningfully different. The existing `is_text_post` binary flag already distinguishes these cases, and null values will be handled by the Imputer during model preparation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6cee1c7-1cbb-4967-ac58-540655e9e6a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reload Persisted df_features w/ newly added title sentiment features\n",
+    "\n",
+    "FEATURES_NLP_DIR = \"../data/processed/features_nlp_temp/\"\n",
+    "df_features = spark.read.parquet(FEATURES_NLP_DIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "1ceabc2a-5d21-4d20-bd5f-0edaacbaaf4d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sample size:                    10,000 rows\n",
+      "Elapsed:                        1.73 seconds\n",
+      "Throughput:                     5,788 rows/sec (single thread)\n",
+      "Est. full run (single thread):  431.9 minutes\n",
+      "Est. full run (16-core par.):   54.0 minutes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── SELFTEXT SENTIMENT BENCHMARK ─────────────────────────────────────────────\n",
+    "import time\n",
+    "\n",
+    "# Sample non-empty selftexts only — these are the rows the UDF will actually work on\n",
+    "sample_size = 10000\n",
+    "sample_selftexts = df_features \\\n",
+    "    .filter(F.col(\"selftext\") != \"\") \\\n",
+    "    .select(\"selftext\") \\\n",
+    "    .limit(sample_size) \\\n",
+    "    .toPandas()[\"selftext\"].tolist()\n",
+    "\n",
+    "# Apply same 500-char truncation we will use in the UDF\n",
+    "sample_selftexts = [s[:500] for s in sample_selftexts]\n",
+    "\n",
+    "analyzer = get_analyzer()\n",
+    "\n",
+    "start = time.time()\n",
+    "scores = [analyzer.polarity_scores(t)[\"compound\"] for t in sample_selftexts]\n",
+    "elapsed = time.time() - start\n",
+    "\n",
+    "rows_per_sec = sample_size / elapsed\n",
+    "non_empty_rows = 150_000_000  # approximate non-empty selftext count\n",
+    "estimated_minutes_single = (non_empty_rows / rows_per_sec) / 60\n",
+    "estimated_minutes_parallel = estimated_minutes_single / 8  # ~8x speedup observed on title run\n",
+    "\n",
+    "print(f\"Sample size:                    {sample_size:,} rows\")\n",
+    "print(f\"Elapsed:                        {elapsed:.2f} seconds\")\n",
+    "print(f\"Throughput:                     {rows_per_sec:,.0f} rows/sec (single thread)\")\n",
+    "print(f\"Est. full run (single thread):  {estimated_minutes_single:.1f} minutes\")\n",
+    "print(f\"Est. full run (16-core par.):   {estimated_minutes_parallel:.1f} minutes\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "8d688509-d877-415c-92cb-8aeea86e3057",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selftext sentiment run started at: 2026-05-07 22:37:25\n",
+      "Completed at:  2026-05-07 23:15:53\n",
+      "Total runtime: 0h 38m 28s\n",
+      "Throughput:    232,009 rows/sec\n",
+      "Rows: 535,480,818 | Columns: 30\n",
+      "\n",
+      "Writing final DataFrame to features_nlp...\n",
+      "Final rows: 535,480,818 | Columns: 30\n",
+      "+--------------+-------------------+-------------+-------------+--------+--------+--------+\n",
+      "|non_null_count|     mean_sentiment|min_sentiment|max_sentiment|positive|negative| neutral|\n",
+      "+--------------+-------------------+-------------+-------------+--------+--------+--------+\n",
+      "|     146581291|0.23307564779035508|      -0.9999|          1.0|85438940|36451127|24691224|\n",
+      "+--------------+-------------------+-------------+-------------+--------+--------+--------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── VADER SELFTEXT SENTIMENT UDF ──────────────────────────────────────────────\n",
+    "\n",
+    "# Register selftext UDF — returns null for empty selftext (distinct from neutral)\n",
+    "@F.udf(returnType=FloatType())\n",
+    "def selftext_sentiment_udf(text):\n",
+    "    if text is None or text == \"\":\n",
+    "        return None\n",
+    "    try:\n",
+    "        # Truncate to 500 chars — VADER designed for short text\n",
+    "        truncated = text[:500]\n",
+    "        analyzer = get_analyzer()\n",
+    "        return float(analyzer.polarity_scores(truncated)[\"compound\"])\n",
+    "    except Exception:\n",
+    "        return None\n",
+    "\n",
+    "# Add selftext_sentiment to logical plan\n",
+    "df_features = df_features \\\n",
+    "    .withColumn(\"selftext_sentiment\", selftext_sentiment_udf(F.col(\"selftext\")))\n",
+    "\n",
+    "# Write to a new temp directory — source is features_nlp_temp, target is features_nlp_temp2\n",
+    "FEATURES_NLP_TEMP2_DIR = \"../data/processed/features_nlp_temp2/\"\n",
+    "\n",
+    "start_time = time.time()\n",
+    "start_dt = datetime.datetime.now()\n",
+    "print(f\"Selftext sentiment run started at: {start_dt.strftime('%Y-%m-%d %H:%M:%S')}\")\n",
+    "\n",
+    "df_features.write \\\n",
+    "    .mode(\"overwrite\") \\\n",
+    "    .parquet(FEATURES_NLP_TEMP2_DIR)\n",
+    "\n",
+    "elapsed = time.time() - start_time\n",
+    "print(f\"Completed at:  {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\")\n",
+    "print(f\"Total runtime: {int(elapsed//3600)}h {int((elapsed%3600)//60)}m {int(elapsed%60)}s\")\n",
+    "print(f\"Throughput:    {535_480_818 / elapsed:,.0f} rows/sec\")\n",
+    "\n",
+    "# Reload from temp2 to break lineage\n",
+    "df_features = spark.read.parquet(FEATURES_NLP_TEMP2_DIR)\n",
+    "print(f\"Rows: {df_features.count():,} | Columns: {len(df_features.columns)}\")\n",
+    "\n",
+    "# Final clean write to features_nlp — both sentiment columns now included\n",
+    "print(\"\\nWriting final DataFrame to features_nlp...\")\n",
+    "df_features.write \\\n",
+    "    .mode(\"overwrite\") \\\n",
+    "    .parquet(FEATURES_NLP_DIR)\n",
+    "\n",
+    "df_features = spark.read.parquet(FEATURES_NLP_DIR)\n",
+    "print(f\"Final rows: {df_features.count():,} | Columns: {len(df_features.columns)}\")\n",
+    "\n",
+    "# Sanity check on text posts only — nulls expected for link posts\n",
+    "df_features.filter(F.col(\"is_text_post\") == 1) \\\n",
+    "    .select(\n",
+    "        F.count(\"selftext_sentiment\").alias(\"non_null_count\"),\n",
+    "        F.mean(\"selftext_sentiment\").alias(\"mean_sentiment\"),\n",
+    "        F.min(\"selftext_sentiment\").alias(\"min_sentiment\"),\n",
+    "        F.max(\"selftext_sentiment\").alias(\"max_sentiment\"),\n",
+    "        F.count(F.when(F.col(\"selftext_sentiment\") > 0.05, 1)).alias(\"positive\"),\n",
+    "        F.count(F.when(F.col(\"selftext_sentiment\") < -0.05, 1)).alias(\"negative\"),\n",
+    "        F.count(F.when(\n",
+    "            (F.col(\"selftext_sentiment\") >= -0.05) &\n",
+    "            (F.col(\"selftext_sentiment\") <= 0.05), 1)\n",
+    "        ).alias(\"neutral\")\n",
+    "    ).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7f96b0d3-6b60-4dbf-afe7-dfd2a95c4302",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rows: 535,480,818 | Columns: 29\n",
+      "['author', 'subreddit', 'id', 'num_comments', 'score', 'selftext', 'subreddit_id', 'title', 'created_utc', 'is_known_bot', 'is_anonymous_author', 'has_title', 'label_4class', 'label_binary', 'title_len', 'title_word_count', 'has_question', 'has_exclamation', 'is_text_post', 'selftext_len', 'hour_of_day', 'day_of_week', 'subreddit_post_count', 'subreddit_median_score', 'subreddit_median_comments', 'author_post_count', 'author_mean_score', 'title_sentiment', 'selftext_sentiment']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reload final persisted DataFrame with all features including both sentiment columns\n",
+    "\n",
+    "FEATURES_NLP_DIR = \"../data/processed/features_nlp/\"\n",
+    "df_features = spark.read.parquet(FEATURES_NLP_DIR)\n",
+    "print(f\"Rows: {df_features.count():,} | Columns: {len(df_features.columns)}\")\n",
+    "print(df_features.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "61a31a8a-e859-4563-af28-9674af1978e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lookup rows: 535,480,817 | distinct ids: 535,480,817 | unique: True\n",
+      "\n",
+      "─── Sentiment join verification ───\n",
+      "train: rows=276,442,594 [OK] | title null=0 | selftext null=190,997,932 (link=190,997,932)\n",
+      "val: rows=114,089,205 [OK] | title null=0 | selftext null=86,001,321 (link=86,001,321)\n",
+      "test: rows=144,949,019 [OK] | title null=0 | selftext null=111,900,274 (link=111,900,274)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── ATTACH VADER SENTIMENT VIA JOIN (fresh lookup path, eager materialize) ───\n",
+    "import shutil, os\n",
+    "\n",
+    "FEATURES_NLP_V1_DIR  = \"../data/processed/features_nlp/\"\n",
+    "# NEW path — avoids colliding with the stale sentiment_lookup_v2 listing\n",
+    "SENTIMENT_LOOKUP_DIR = \"../data/processed/sentiment_lookup_v2b/\"\n",
+    "\n",
+    "# Defensive: remove the target dir if it exists, so overwrite starts clean\n",
+    "if os.path.exists(SENTIMENT_LOOKUP_DIR):\n",
+    "    shutil.rmtree(SENTIMENT_LOOKUP_DIR)\n",
+    "\n",
+    "spark.read.parquet(FEATURES_NLP_V1_DIR) \\\n",
+    "    .select(\"id\", \"title_sentiment\", \"selftext_sentiment\") \\\n",
+    "    .dropDuplicates([\"id\"]) \\\n",
+    "    .write.mode(\"overwrite\").parquet(SENTIMENT_LOOKUP_DIR)\n",
+    "\n",
+    "# Read back and EAGERLY materialize so the file listing is committed before\n",
+    "# any downstream lazy plan binds to it.\n",
+    "sentiment_lookup = spark.read.parquet(SENTIMENT_LOOKUP_DIR)\n",
+    "n_lookup = sentiment_lookup.count()\n",
+    "n_distinct = sentiment_lookup.select(\"id\").distinct().count()\n",
+    "print(f\"Lookup rows: {n_lookup:,} | distinct ids: {n_distinct:,} | unique: {n_lookup == n_distinct}\")\n",
+    "\n",
+    "def attach_sentiment(df):\n",
+    "    return df.join(sentiment_lookup, on=\"id\", how=\"left\")\n",
+    "\n",
+    "train_split = attach_sentiment(train_split)\n",
+    "val_split   = attach_sentiment(val_split)\n",
+    "test_split  = attach_sentiment(test_split)\n",
+    "\n",
+    "print(\"\\n─── Sentiment join verification ───\")\n",
+    "for name, df, expected in [(\"train\", train_split, 276_442_594),\n",
+    "                            (\"val\",   val_split,   114_089_205),\n",
+    "                            (\"test\",  test_split,  144_949_019)]:\n",
+    "    n_tot = df.count()\n",
+    "    n_title_null = df.filter(F.col(\"title_sentiment\").isNull()).count()\n",
+    "    n_self_null  = df.filter(F.col(\"selftext_sentiment\").isNull()).count()\n",
+    "    n_link       = df.filter(F.col(\"is_text_post\") == 0).count()\n",
+    "    flag = \"OK\" if n_tot == expected else f\"MISMATCH (expected {expected:,})\"\n",
+    "    print(f\"{name}: rows={n_tot:,} [{flag}] | title null={n_title_null:,} \"\n",
+    "          f\"| selftext null={n_self_null:,} (link={n_link:,})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ca311f3-1058-4fce-abab-9e752da6f874",
+   "metadata": {},
+   "source": [
+    "> **⚠️ Environment note — `shutil.rmtree` is local-mode only**\n",
+    ">\n",
+    "> This cell uses `shutil.rmtree` to clear the lookup directory before writing, and relies on the lookup being read back from a local `file:/` path. This works **only because this pipeline runs in Spark `local[*]` mode on a single Expanse node**, where the driver's filesystem *is* the data filesystem.\n",
+    ">\n",
+    "> On a distributed cluster (e.g. YARN/Kubernetes with HDFS or S3 storage), this would fail: `shutil.rmtree` runs only on the driver and cannot see or delete files on executor nodes or in distributed object stores. The portable equivalent is `df.write.mode(\"overwrite\")` (which handles cleanup atomically through Spark's commit protocol) or Hadoop FileSystem APIs (`fs.delete(path, recursive=True)`) for explicit deletion. The `rmtree` here is a pragmatic single-node convenience, not a distributed-safe pattern."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dba2fc33-f754-437d-a964-cbeca62b872b",
+   "metadata": {},
+   "source": [
+    "### Persist NLP-Enriched Splits\n",
+    "\n",
+    "With VADER sentiment attached, each split now carries the complete feature set: per-row structural/temporal features, train-only author and subreddit aggregates, cold-start flags, and both sentiment columns (32 columns total). We persist these to a new set of directories so the sentiment join — like every prior stage — becomes a reloadable checkpoint. This is the final preprocessing artifact: the model-preparation stage (imputation, indexing, assembly, scaling) and the corrected XGBoost re-baseline both load directly from here.\n",
+    "\n",
+    "The deduplicated sentiment lookup contained 535,480,817 rows versus the original 535,480,818, the difference being the single known duplicate post id removed during the join to guarantee a 1:1 key mapping."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ef50d9ba-fb54-44ed-9149-ce000e1333ae",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing train split...\n",
+      "Writing val split...\n",
+      "Writing test split...\n",
+      "\n",
+      "Reloading from disk to break lineage...\n",
+      "Train rows: 276,442,594\n",
+      "Val rows:   114,089,205\n",
+      "Test rows:  144,949,019\n",
+      "\n",
+      "Columns (32):\n",
+      "['id', 'subreddit', 'author', 'num_comments', 'score', 'selftext', 'subreddit_id', 'title', 'created_utc', 'is_known_bot', 'is_anonymous_author', 'has_title', 'label_4class', 'label_binary', 'title_len', 'has_question', 'has_exclamation', 'title_has_number', 'title_is_allcaps', 'is_text_post', 'selftext_len', 'hour_of_day', 'day_of_week', 'author_post_count', 'author_mean_score', 'is_new_author', 'subreddit_post_count', 'subreddit_median_score', 'subreddit_median_comments', 'is_new_subreddit', 'title_sentiment', 'selftext_sentiment']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── PERSIST NLP-ENRICHED TRAIN/VAL/TEST SPLITS ───────────────────────────────\n",
+    "# Final preprocessing checkpoint: structured features + cold-start flags +\n",
+    "# VADER sentiment. Model prep and the corrected XGBoost baseline load from here.\n",
+    "\n",
+    "TRAIN_NLP_DIR = \"../data/processed/train_features_nlp_v2/\"\n",
+    "VAL_NLP_DIR   = \"../data/processed/val_features_nlp_v2/\"\n",
+    "TEST_NLP_DIR  = \"../data/processed/test_features_nlp_v2/\"\n",
+    "\n",
+    "print(\"Writing train split...\")\n",
+    "train_split.write.mode(\"overwrite\").parquet(TRAIN_NLP_DIR)\n",
+    "print(\"Writing val split...\")\n",
+    "val_split.write.mode(\"overwrite\").parquet(VAL_NLP_DIR)\n",
+    "print(\"Writing test split...\")\n",
+    "test_split.write.mode(\"overwrite\").parquet(TEST_NLP_DIR)\n",
+    "\n",
+    "print(\"\\nReloading from disk to break lineage...\")\n",
+    "train_split = spark.read.parquet(TRAIN_NLP_DIR)\n",
+    "val_split   = spark.read.parquet(VAL_NLP_DIR)\n",
+    "test_split  = spark.read.parquet(TEST_NLP_DIR)\n",
+    "\n",
+    "print(f\"Train rows: {train_split.count():,}\")\n",
+    "print(f\"Val rows:   {val_split.count():,}\")\n",
+    "print(f\"Test rows:  {test_split.count():,}\")\n",
+    "print(f\"\\nColumns ({len(train_split.columns)}):\")\n",
+    "print(train_split.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8be9574-7805-466a-919c-412db69e0d11",
+   "metadata": {},
+   "source": [
+    "## Model Preparation\n",
+    "\n",
+    "The assembled feature pipeline diverges deliberately from the Milestone 3 (v1) approach in two ways, both driven by the leakage correction:\n",
+    "\n",
+    "**1. Aggregate nulls are preserved, not imputed.** The cold-start rows (up to 48.6% of test) carry null author/subreddit aggregates by design. These nulls are passed through to XGBoost, which handles missing values natively by learning an optimal default branch direction at each split. Only `selftext_sentiment` is imputed — its nulls correspond to link posts (no body text), a structurally different kind of missingness that is already signaled by `is_text_post`.\n",
+    "\n",
+    "**2. StandardScaler is removed from the XGBoost pipeline.** XGBoost is a tree ensemble: it splits on feature thresholds and is completely scale-invariant, so standardization has no effect on its performance. v1 included a scaling step, but it was a no-op for the tree models. More importantly, scaling is actively counterproductive here — `StandardScaler` would compute mean and standard deviation over the cold-start NaNs, contaminating the feature statistics. Dropping it lets the cold-start nulls pass cleanly to XGBoost's native missing-value handling. If a scale-sensitive model (e.g. a neural network) is added later, it would receive its own separately-scaled pipeline.\n",
+    "\n",
+    "The remaining preparation steps are: a null audit, imputation of `selftext_sentiment` only, label indexing, and feature-vector assembly with `handleInvalid=\"keep\"` so that rows with null aggregates are retained (with missing entries represented as NaN) rather than dropped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "736a0a17-c0da-4fad-bccd-1ae5443bcec4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Null counts per feature column (train):\n",
+      "-RECORD 0------------------------------\n",
+      " title_len                 | 0         \n",
+      " has_question              | 0         \n",
+      " has_exclamation           | 0         \n",
+      " title_has_number          | 0         \n",
+      " title_is_allcaps          | 0         \n",
+      " is_text_post              | 0         \n",
+      " selftext_len              | 0         \n",
+      " hour_of_day               | 0         \n",
+      " day_of_week               | 0         \n",
+      " has_title                 | 0         \n",
+      " is_known_bot              | 0         \n",
+      " is_anonymous_author       | 0         \n",
+      " is_new_author             | 0         \n",
+      " is_new_subreddit          | 0         \n",
+      " author_post_count         | 0         \n",
+      " author_mean_score         | 0         \n",
+      " subreddit_post_count      | 0         \n",
+      " subreddit_median_score    | 0         \n",
+      " subreddit_median_comments | 0         \n",
+      " title_sentiment           | 0         \n",
+      " selftext_sentiment        | 190997932 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── NULL AUDIT ON FEATURE COLUMNS ────────────────────────────────────────────\n",
+    "# Confirm which columns carry nulls and that they match expectations:\n",
+    "#   - author/subreddit aggregates: null ONLY on cold-start rows (val/test)\n",
+    "#   - selftext_sentiment: null on link posts (to be imputed)\n",
+    "#   - everything else: zero nulls\n",
+    "\n",
+    "feature_cols = [\n",
+    "    \"title_len\", \"has_question\", \"has_exclamation\",\n",
+    "    \"title_has_number\", \"title_is_allcaps\",\n",
+    "    \"is_text_post\", \"selftext_len\", \"hour_of_day\", \"day_of_week\",\n",
+    "    \"has_title\", \"is_known_bot\", \"is_anonymous_author\",\n",
+    "    \"is_new_author\", \"is_new_subreddit\",\n",
+    "    \"author_post_count\", \"author_mean_score\",\n",
+    "    \"subreddit_post_count\", \"subreddit_median_score\", \"subreddit_median_comments\",\n",
+    "    \"title_sentiment\", \"selftext_sentiment\",\n",
+    "]\n",
+    "\n",
+    "print(\"Null counts per feature column (train):\")\n",
+    "train_split.select([\n",
+    "    F.count(F.when(F.col(c).isNull(), c)).alias(c) for c in feature_cols\n",
+    "]).show(vertical=True, truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b376c47b-acd0-491d-8798-64775ec8ed43",
+   "metadata": {},
+   "source": [
+    "### Impute `selftext_sentiment` Only\n",
+    "\n",
+    "`selftext_sentiment` is null for link posts, which have no body text. We impute these with the mean over text posts. This is the one imputation that is appropriate: the missingness is structural (not cold-start) and is already separately encoded by the `is_text_post` flag, so the model can distinguish a genuine neutral-sentiment body from an imputed link-post placeholder. The aggregate columns are deliberately excluded from imputation — their nulls flow through to XGBoost untouched."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "41223b21-5b0f-4ff9-a0e3-03689392cde8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Post-imputation null check:\n",
+      "train: selftext_sentiment null=0 | author_post_count null=0 (cold-start, expected)\n",
+      "val: selftext_sentiment null=0 | author_post_count null=32,867,850 (cold-start, expected)\n",
+      "test: selftext_sentiment null=0 | author_post_count null=70,467,652 (cold-start, expected)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── IMPUTE selftext_sentiment ONLY ───────────────────────────────────────────\n",
+    "from pyspark.ml.feature import Imputer\n",
+    "\n",
+    "imputer = Imputer(\n",
+    "    inputCols=[\"selftext_sentiment\"],\n",
+    "    outputCols=[\"selftext_sentiment\"],\n",
+    "    strategy=\"mean\",\n",
+    ")\n",
+    "imputer_model = imputer.fit(train_split)   # fit on train only — no leakage\n",
+    "\n",
+    "train_split = imputer_model.transform(train_split)\n",
+    "val_split   = imputer_model.transform(val_split)\n",
+    "test_split  = imputer_model.transform(test_split)\n",
+    "\n",
+    "# Verify: selftext_sentiment now null-free; aggregates UNCHANGED (still null on cold-start)\n",
+    "print(\"Post-imputation null check:\")\n",
+    "for name, df in [(\"train\", train_split), (\"val\", val_split), (\"test\", test_split)]:\n",
+    "    n_self = df.filter(F.col(\"selftext_sentiment\").isNull()).count()\n",
+    "    n_auth = df.filter(F.col(\"author_post_count\").isNull()).count()\n",
+    "    print(f\"{name}: selftext_sentiment null={n_self:,} | author_post_count null={n_auth:,} (cold-start, expected)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b773027-4b11-4570-a9d5-31a6d5da0b9a",
+   "metadata": {},
+   "source": [
+    "### Label Indexing\n",
+    "\n",
+    "Both target columns are indexed to numeric form for XGBoost: `label_4class` → `label_4class_idx` and `label_binary` → `label_binary_idx`. The indexers are fit on train only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "dfb592b2-432c-4eae-85f9-63bf12addb36",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4-class index mapping:\n",
+      "+--------------+----------------+---------+\n",
+      "|  label_4class|label_4class_idx|    count|\n",
+      "+--------------+----------------+---------+\n",
+      "|low-engagement|             0.0|130366256|\n",
+      "|         viral|             1.0| 71020637|\n",
+      "| crowd-pleaser|             2.0| 40882874|\n",
+      "|debate-starter|             3.0| 34172827|\n",
+      "+--------------+----------------+---------+\n",
+      "\n",
+      "Binary index mapping:\n",
+      "+---------------+----------------+---------+\n",
+      "|   label_binary|label_binary_idx|    count|\n",
+      "+---------------+----------------+---------+\n",
+      "|high-engagement|             0.0|146076338|\n",
+      "| low-engagement|             1.0|130366256|\n",
+      "+---------------+----------------+---------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── LABEL INDEXING ───────────────────────────────────────────────────────────\n",
+    "from pyspark.ml.feature import StringIndexer\n",
+    "\n",
+    "idx_4 = StringIndexer(inputCol=\"label_4class\", outputCol=\"label_4class_idx\",\n",
+    "                      handleInvalid=\"keep\").fit(train_split)\n",
+    "idx_b = StringIndexer(inputCol=\"label_binary\", outputCol=\"label_binary_idx\",\n",
+    "                      handleInvalid=\"keep\").fit(train_split)\n",
+    "\n",
+    "for name in [\"train\", \"val\", \"test\"]:\n",
+    "    pass  # apply below\n",
+    "\n",
+    "train_split = idx_b.transform(idx_4.transform(train_split))\n",
+    "val_split   = idx_b.transform(idx_4.transform(val_split))\n",
+    "test_split  = idx_b.transform(idx_4.transform(test_split))\n",
+    "\n",
+    "print(\"4-class index mapping:\")\n",
+    "train_split.groupBy(\"label_4class\", \"label_4class_idx\").count().orderBy(\"label_4class_idx\").show()\n",
+    "print(\"Binary index mapping:\")\n",
+    "train_split.groupBy(\"label_binary\", \"label_binary_idx\").count().orderBy(\"label_binary_idx\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "161de944-c48e-4555-a5dd-f0aa2e547bc7",
+   "metadata": {},
+   "source": [
+    "### Feature Vector Assembly\n",
+    "\n",
+    "The 21 feature columns are assembled into a single vector with `handleInvalid=\"keep\"`. This is the critical setting for the leakage fix: `\"keep\"` retains rows that contain null aggregates, representing the missing entries as NaN within the vector, whereas v1's `\"skip\"` would have silently dropped every cold-start row — up to 48.6% of the test set. The NaN entries are exactly what XGBoost's native missing-value handling consumes. No scaling is applied, for the reasons described above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "1dd61976-5a82-46fe-ae95-89338123f274",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Assembled 21 features into 'features' vector.\n",
+      "Row counts after assembly (must be unchanged — no rows dropped):\n",
+      "  train: 276,442,594 OK\n",
+      "  val: 114,089,205 OK\n",
+      "  test: 144,949,019 OK\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── FEATURE VECTOR ASSEMBLY (handleInvalid=\"keep\" preserves cold-start rows) ──\n",
+    "from pyspark.ml.feature import VectorAssembler\n",
+    "\n",
+    "assembler_cols = [\n",
+    "    # Title structural\n",
+    "    \"title_len\", \"has_question\", \"has_exclamation\", \"title_has_number\", \"title_is_allcaps\",\n",
+    "    # Post type\n",
+    "    \"has_title\", \"is_text_post\", \"selftext_len\",\n",
+    "    # Temporal\n",
+    "    \"hour_of_day\", \"day_of_week\",\n",
+    "    # Author flags\n",
+    "    \"is_known_bot\", \"is_anonymous_author\",\n",
+    "    # Cold-start flags (NEW in v2)\n",
+    "    \"is_new_author\", \"is_new_subreddit\",\n",
+    "    # Author history aggregates (train-only; null on cold-start)\n",
+    "    \"author_post_count\", \"author_mean_score\",\n",
+    "    # Subreddit context aggregates (train-only; null on cold-start)\n",
+    "    \"subreddit_post_count\", \"subreddit_median_score\", \"subreddit_median_comments\",\n",
+    "    # NLP sentiment\n",
+    "    \"title_sentiment\", \"selftext_sentiment\",\n",
+    "]\n",
+    "\n",
+    "assembler = VectorAssembler(\n",
+    "    inputCols=assembler_cols,\n",
+    "    outputCol=\"features\",          # note: \"features\" directly, no separate scaled col\n",
+    "    handleInvalid=\"keep\",          # CRITICAL: keep cold-start rows, missing -> NaN\n",
+    ")\n",
+    "\n",
+    "train_split = assembler.transform(train_split)\n",
+    "val_split   = assembler.transform(val_split)\n",
+    "test_split  = assembler.transform(test_split)\n",
+    "\n",
+    "print(f\"Assembled {len(assembler_cols)} features into 'features' vector.\")\n",
+    "print(\"Row counts after assembly (must be unchanged — no rows dropped):\")\n",
+    "for name, df, expected in [(\"train\", train_split, 276_442_594),\n",
+    "                            (\"val\", val_split, 114_089_205),\n",
+    "                            (\"test\", test_split, 144_949_019)]:\n",
+    "    n = df.count()\n",
+    "    print(f\"  {name}: {n:,} {'OK' if n == expected else 'ROW LOSS!'}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "bc3f4d7a-769b-4e1c-a6f4-30413bb23cd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing train split...\n",
+      "Writing val split...\n",
+      "Writing test split...\n",
+      "\n",
+      "Reloading from disk to break lineage...\n",
+      "Train rows: 276,442,594\n",
+      "Val rows:   114,089,205\n",
+      "Test rows:  144,949,019\n",
+      "Columns (35): ['id', 'subreddit', 'author', 'num_comments', 'score', 'selftext', 'subreddit_id', 'title', 'created_utc', 'is_known_bot', 'is_anonymous_author', 'has_title', 'label_4class', 'label_binary', 'title_len', 'has_question', 'has_exclamation', 'title_has_number', 'title_is_allcaps', 'is_text_post', 'selftext_len', 'hour_of_day', 'day_of_week', 'author_post_count', 'author_mean_score', 'is_new_author', 'subreddit_post_count', 'subreddit_median_score', 'subreddit_median_comments', 'is_new_subreddit', 'title_sentiment', 'selftext_sentiment', 'label_4class_idx', 'label_binary_idx', 'features']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── PERSIST ASSEMBLED SPLITS (features vector + indexed labels + imputed sentiment) ──\n",
+    "TRAIN_MODEL_DIR = \"../data/processed/train_model_v2/\"\n",
+    "VAL_MODEL_DIR   = \"../data/processed/val_model_v2/\"\n",
+    "TEST_MODEL_DIR  = \"../data/processed/test_model_v2/\"\n",
+    "\n",
+    "# The 'features' column is a VectorUDT; parquet handles it natively.\n",
+    "print(\"Writing train split...\")\n",
+    "train_split.write.mode(\"overwrite\").parquet(TRAIN_MODEL_DIR)\n",
+    "print(\"Writing val split...\")\n",
+    "val_split.write.mode(\"overwrite\").parquet(VAL_MODEL_DIR)\n",
+    "print(\"Writing test split...\")\n",
+    "test_split.write.mode(\"overwrite\").parquet(TEST_MODEL_DIR)\n",
+    "\n",
+    "print(\"\\nReloading from disk to break lineage...\")\n",
+    "train_split = spark.read.parquet(TRAIN_MODEL_DIR)\n",
+    "val_split   = spark.read.parquet(VAL_MODEL_DIR)\n",
+    "test_split  = spark.read.parquet(TEST_MODEL_DIR)\n",
+    "\n",
+    "print(f\"Train rows: {train_split.count():,}\")\n",
+    "print(f\"Val rows:   {val_split.count():,}\")\n",
+    "print(f\"Test rows:  {test_split.count():,}\")\n",
+    "print(f\"Columns ({len(train_split.columns)}): {train_split.columns}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dde909f4-4602-4db4-bfaa-210c0ad1c934",
+   "metadata": {},
+   "source": [
+    "## Model Training: Leakage-Corrected XGBoost Baseline\n",
+    "\n",
+    "This trains the corrected baseline — the same XGBoost configurations and label tasks as Milestone 3 (v1), but on the leakage-free feature set. Comparing these results against v1's reported numbers quantifies how much of the original performance was attributable to temporal aggregate leakage versus genuine predictive signal.\n",
+    "\n",
+    "Three changes from the v1 training setup, all consequences of the leakage correction:\n",
+    "\n",
+    "1. **`missing=float(\"nan\")`** is set so XGBoost applies its native missing-value handling to the cold-start nulls (now NaN in the assembled vector), learning a default branch direction per split rather than relying on imputed values.\n",
+    "2. **No scaled feature column** — the `features` vector feeds XGBoost directly, since tree models are scale-invariant.\n",
+    "3. **Class weights are read from the indexed labels**, not hardcoded, so the binary label index swap (high-engagement is now index 0) is handled automatically.\n",
+    "\n",
+    "We train Config A (conservative) and Config B (aggressive), matching v1's hyperparameters exactly so the comparison isolates the effect of the leakage fix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9f66e51b-1792-4736-91e6-4e5f1c1ceca6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train: 276,442,594 | Val: 114,089,205 | Test: 144,949,019\n",
+      "Columns: 35\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── RELOAD ASSEMBLED SPLITS (post-restart) ───────────────────────────────────\n",
+    "TRAIN_MODEL_DIR = \"../data/processed/train_model_v2/\"\n",
+    "VAL_MODEL_DIR   = \"../data/processed/val_model_v2/\"\n",
+    "TEST_MODEL_DIR  = \"../data/processed/test_model_v2/\"\n",
+    "\n",
+    "train_split = spark.read.parquet(TRAIN_MODEL_DIR)\n",
+    "val_split   = spark.read.parquet(VAL_MODEL_DIR)\n",
+    "test_split  = spark.read.parquet(TEST_MODEL_DIR)\n",
+    "print(f\"Train: {train_split.count():,} | Val: {val_split.count():,} | Test: {test_split.count():,}\")\n",
+    "print(f\"Columns: {len(train_split.columns)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53f1dfa2-6641-4727-bef9-87bc349aabb0",
+   "metadata": {},
+   "source": [
+    "### Training on a Stratified Sample\n",
+    "\n",
+    "Distributed XGBoost training in `local[*]` mode materializes the training data as in-memory DMatrix structures within a single JVM. The full 276M-row training split exceeds the node's memory capacity during this materialization. We therefore train on a 30% stratified sample of the training data (~83M rows), drawn with `sampleBy` on the 4-class label to preserve exact class proportions — critical given that the minority crowd-pleaser and debate-starter classes are the focus of this analysis.\n",
+    "\n",
+    "The sample is applied to training data only; validation and test sets remain at full size, so reported metrics reflect performance over the complete held-out periods. Tree-ensemble model quality is effectively saturated at this sample size for tabular data of this dimensionality, so the sample is not expected to materially affect results versus full-data training. The full-data training cell is preserved as the canonical path for execution on a large-memory node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "efda22cc-b702-412d-af1b-267bf0bf3655",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sampled train rows: 82,930,798\n",
+      "Class distribution in sample:\n",
+      "+----------------+--------+\n",
+      "|label_4class_idx|   count|\n",
+      "+----------------+--------+\n",
+      "|             0.0|39105582|\n",
+      "|             1.0|21306558|\n",
+      "|             2.0|12266449|\n",
+      "|             3.0|10252209|\n",
+      "+----------------+--------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── STRATIFIED SAMPLE OF TRAINING DATA (30%, preserves class proportions) ────\n",
+    "SAMPLE_FRAC = 0.30\n",
+    "fractions = {0.0: SAMPLE_FRAC, 1.0: SAMPLE_FRAC, 2.0: SAMPLE_FRAC, 3.0: SAMPLE_FRAC}\n",
+    "\n",
+    "train_sample = train_split.sampleBy(\"label_4class_idx\", fractions=fractions, seed=42)\n",
+    "\n",
+    "# Persist the sample so repeated fits (Config A, B, binary) reuse identical rows\n",
+    "TRAIN_SAMPLE_DIR = \"../data/processed/train_sample30_v2/\"\n",
+    "train_sample.write.mode(\"overwrite\").parquet(TRAIN_SAMPLE_DIR)\n",
+    "train_sample = spark.read.parquet(TRAIN_SAMPLE_DIR)\n",
+    "\n",
+    "print(f\"Sampled train rows: {train_sample.count():,}\")\n",
+    "print(\"Class distribution in sample:\")\n",
+    "train_sample.groupBy(\"label_4class_idx\").count().orderBy(\"label_4class_idx\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e82c95ad-b247-40c9-b07c-50ff8995068e",
+   "metadata": {},
+   "source": [
+    "### Class Weights (Computed on the Sampled Training Data)\n",
+    "\n",
+    "Inverse-frequency class weights are computed directly on the stratified sample so that the weights reflect the exact data the model trains on. Because the sample preserves class proportions, these weights match those that would be computed on the full training split. Each weight is `total / (n_classes × class_count)`, giving minority classes proportionally higher influence on the loss — the rare debate-starter class receives roughly 3.8× the weight of the dominant low-engagement class. Weights are computed for both the 4-class and binary tasks (the binary index assignment has high-engagement as class 0) and attached as per-row columns for XGBoost's `weight_col`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e8d86723-d901-4e94-9f55-1965a24c74e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4-class weights: {0: 0.5302, 1: 0.9731, 2: 1.6902, 3: 2.0223}\n",
+      "Binary weights:  {0: 0.9462, 1: 1.0603}\n",
+      "Weight columns attached to train_sample.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── CLASS WEIGHTS ON THE SAMPLED TRAINING DATA ───────────────────────────────\n",
+    "def compute_class_weights(df, label_col):\n",
+    "    counts = df.groupBy(label_col).count().collect()\n",
+    "    total = sum(r[\"count\"] for r in counts)\n",
+    "    n_classes = len(counts)\n",
+    "    return {int(r[label_col]): total / (n_classes * r[\"count\"]) for r in counts}\n",
+    "\n",
+    "w4 = compute_class_weights(train_sample, \"label_4class_idx\")\n",
+    "wb = compute_class_weights(train_sample, \"label_binary_idx\")\n",
+    "print(\"4-class weights:\", {k: round(v, 4) for k, v in sorted(w4.items())})\n",
+    "print(\"Binary weights: \", {k: round(v, 4) for k, v in sorted(wb.items())})\n",
+    "\n",
+    "from itertools import chain\n",
+    "map4 = F.create_map([F.lit(x) for x in chain(*w4.items())])\n",
+    "mapb = F.create_map([F.lit(x) for x in chain(*wb.items())])\n",
+    "\n",
+    "train_sample = train_sample \\\n",
+    "    .withColumn(\"weight_4class\", map4[F.col(\"label_4class_idx\")]) \\\n",
+    "    .withColumn(\"weight_binary\", mapb[F.col(\"label_binary_idx\")])\n",
+    "print(\"Weight columns attached to train_sample.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e67c8bf-dcf4-469f-9aa3-d33405495332",
+   "metadata": {},
+   "source": [
+    "### Train All Four Models (4-Class and Binary, Configs A & B)\n",
+    "\n",
+    "Four XGBoost models are trained on the 82.9M-row stratified sample with 16 workers: Config A (conservative — shallow trees, strong regularization) and Config B (aggressive — deep trees, faster learning, light regularization), each on both the 4-class and binary label tasks. Hyperparameters match Milestone 3 (v1) exactly so that the leakage-corrected results are directly comparable to the previously reported numbers; the only deliberate differences are the leakage-free feature set, native NaN handling for cold-start rows (`missing=nan`), the removal of the unnecessary scaling step, and training on a stratified sample due to single-node memory constraints. Each model is persisted to disk immediately upon completion, allowing evaluation to reload models without retraining. Recorded training times feed the methods section.\n",
+    "\n",
+    "For the binary task, note that the StringIndexer assigned high-engagement to class 0 (it is the larger class in the training data), a swap relative to v1; overall weighted metrics are invariant to this, but per-class binary precision/recall should be read against this mapping."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e3c39b60-6a36-4a21-8e3e-d887faf8f437",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[00:43:43] Training 4-class Config A...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-28 00:44:07,091 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'multi:softprob', 'colsample_bytree': 0.8, 'device': 'cpu', 'learning_rate': 0.05, 'max_depth': 4, 'min_child_weight': 50, 'reg_alpha': 1.0, 'reg_lambda': 5.0, 'subsample': 0.8, 'num_class': 4, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 200}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n",
+      "2026-05-28 01:15:47,475 INFO XGBoost-PySpark: _fit Finished xgboost training!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[01:15:47] Done in 0h 32m 3s\n",
+      "Saved -> ../models/xgb_4class_configA_v2/\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── TRAIN 4-CLASS CONFIG A (30% stratified sample, 16 workers) ───────────────\n",
+    "from xgboost.spark import SparkXGBClassifier\n",
+    "import time, datetime\n",
+    "\n",
+    "# Repartition sample to align with worker count\n",
+    "train_sample = train_sample.repartition(16)\n",
+    "\n",
+    "COMMON_PARAMS = dict(\n",
+    "    features_col=\"features\",\n",
+    "    label_col=\"label_4class_idx\",\n",
+    "    weight_col=\"weight_4class\",\n",
+    "    num_class=4,\n",
+    "    num_workers=16,\n",
+    "    device=\"cpu\",\n",
+    "    missing=float(\"nan\"),\n",
+    "    seed=42,\n",
+    ")\n",
+    "\n",
+    "config_A = SparkXGBClassifier(**COMMON_PARAMS,\n",
+    "    max_depth=4, n_estimators=200, learning_rate=0.05,\n",
+    "    subsample=0.8, colsample_bytree=0.8,\n",
+    "    reg_lambda=5.0, reg_alpha=1.0, min_child_weight=50)\n",
+    "\n",
+    "MODEL_A_DIR = \"../models/xgb_4class_configA_v2/\"\n",
+    "\n",
+    "print(f\"[{datetime.datetime.now():%H:%M:%S}] Training 4-class Config A...\")\n",
+    "t0 = time.time()\n",
+    "model_A = config_A.fit(train_sample)\n",
+    "time_A = time.time() - t0\n",
+    "print(f\"[{datetime.datetime.now():%H:%M:%S}] Done in \"\n",
+    "      f\"{int(time_A//3600)}h {int((time_A%3600)//60)}m {int(time_A%60)}s\")\n",
+    "model_A.write().overwrite().save(MODEL_A_DIR)\n",
+    "print(f\"Saved -> {MODEL_A_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "de80a748-9cea-42e1-9e6f-062931f1e1c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[01:24:48] Training 4-class Config B...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-28 01:26:06,990 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'multi:softprob', 'colsample_bytree': 0.7, 'device': 'cpu', 'learning_rate': 0.1, 'max_depth': 8, 'min_child_weight': 10, 'reg_alpha': 0.0, 'reg_lambda': 1.0, 'subsample': 0.7, 'num_class': 4, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 300}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n",
+      "2026-05-28 02:14:09,914 INFO XGBoost-PySpark: _fit Finished xgboost training!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:14:10] Done in 0h 49m 22s\n",
+      "Saved -> ../models/xgb_4class_configB_v2/\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── TRAIN 4-CLASS CONFIG B (30% stratified sample, 16 workers) ───────────────\n",
+    "config_B = SparkXGBClassifier(**COMMON_PARAMS,\n",
+    "    max_depth=8, n_estimators=300, learning_rate=0.1,\n",
+    "    subsample=0.7, colsample_bytree=0.7,\n",
+    "    reg_lambda=1.0, reg_alpha=0.0, min_child_weight=10)\n",
+    "\n",
+    "MODEL_B_DIR = \"../models/xgb_4class_configB_v2/\"\n",
+    "\n",
+    "print(f\"[{datetime.datetime.now():%H:%M:%S}] Training 4-class Config B...\")\n",
+    "t0 = time.time()\n",
+    "model_B = config_B.fit(train_sample)\n",
+    "time_B = time.time() - t0\n",
+    "print(f\"[{datetime.datetime.now():%H:%M:%S}] Done in \"\n",
+    "      f\"{int(time_B//3600)}h {int((time_B%3600)//60)}m {int(time_B%60)}s\")\n",
+    "model_B.write().overwrite().save(MODEL_B_DIR)\n",
+    "print(f\"Saved -> {MODEL_B_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "da6be220-0fb1-4d80-8b0d-0392c299547a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:19:42] Training binary Config A...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-28 02:21:53,669 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'binary:logistic', 'colsample_bytree': 0.8, 'device': 'cpu', 'learning_rate': 0.05, 'max_depth': 4, 'min_child_weight': 50, 'reg_alpha': 1.0, 'reg_lambda': 5.0, 'subsample': 0.8, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 200}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n",
+      "2026-05-28 02:28:10,549 INFO XGBoost-PySpark: _fit Finished xgboost training!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:28:10] Done in 0h 8m 27s\n",
+      "Saved -> ../models/xgb_binary_configA_v2/\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── TRAIN BINARY CONFIG A (30% stratified sample, 16 workers) ────────────────\n",
+    "# ── BINARY COMMON PARAMS (no num_class — binary:logistic uses 1 output) ──────\n",
+    "BIN_COMMON = dict(\n",
+    "    features_col=\"features\",\n",
+    "    label_col=\"label_binary_idx\",\n",
+    "    weight_col=\"weight_binary\",\n",
+    "    # num_class REMOVED — binary:logistic produces a single probability per row;\n",
+    "    # specifying num_class=2 caused a labels/preds shape mismatch (2x rows).\n",
+    "    num_workers=16,\n",
+    "    device=\"cpu\",\n",
+    "    missing=float(\"nan\"),\n",
+    "    seed=42,\n",
+    ")\n",
+    "\n",
+    "config_A_bin = SparkXGBClassifier(**BIN_COMMON,\n",
+    "    max_depth=4, n_estimators=200, learning_rate=0.05,\n",
+    "    subsample=0.8, colsample_bytree=0.8,\n",
+    "    reg_lambda=5.0, reg_alpha=1.0, min_child_weight=50)\n",
+    "\n",
+    "MODEL_A_BIN_DIR = \"../models/xgb_binary_configA_v2/\"\n",
+    "\n",
+    "print(f\"[{datetime.datetime.now():%H:%M:%S}] Training binary Config A...\")\n",
+    "t0 = time.time()\n",
+    "model_A_bin = config_A_bin.fit(train_sample)\n",
+    "time_A_bin = time.time() - t0\n",
+    "print(f\"[{datetime.datetime.now():%H:%M:%S}] Done in \"\n",
+    "      f\"{int(time_A_bin//3600)}h {int((time_A_bin%3600)//60)}m {int(time_A_bin%60)}s\")\n",
+    "model_A_bin.write().overwrite().save(MODEL_A_BIN_DIR)\n",
+    "print(f\"Saved -> {MODEL_A_BIN_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f1a73c75-9dc2-46e4-ba23-3db69b139031",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:28:12] Training binary Config B...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-28 02:29:27,531 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'binary:logistic', 'colsample_bytree': 0.7, 'device': 'cpu', 'learning_rate': 0.1, 'max_depth': 8, 'min_child_weight': 10, 'reg_alpha': 0.0, 'reg_lambda': 1.0, 'subsample': 0.7, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 300}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n",
+      "2026-05-28 02:41:56,249 INFO XGBoost-PySpark: _fit Finished xgboost training!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:41:56] Done in 0h 13m 44s\n",
+      "Saved -> ../models/xgb_binary_configB_v2/\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── TRAIN BINARY CONFIG B (30% stratified sample, 16 workers) ────────────────\n",
+    "config_B_bin = SparkXGBClassifier(**BIN_COMMON,\n",
+    "    max_depth=8, n_estimators=300, learning_rate=0.1,\n",
+    "    subsample=0.7, colsample_bytree=0.7,\n",
+    "    reg_lambda=1.0, reg_alpha=0.0, min_child_weight=10)\n",
+    "\n",
+    "MODEL_B_BIN_DIR = \"../models/xgb_binary_configB_v2/\"\n",
+    "\n",
+    "print(f\"[{datetime.datetime.now():%H:%M:%S}] Training binary Config B...\")\n",
+    "t0 = time.time()\n",
+    "model_B_bin = config_B_bin.fit(train_sample)\n",
+    "time_B_bin = time.time() - t0\n",
+    "print(f\"[{datetime.datetime.now():%H:%M:%S}] Done in \"\n",
+    "      f\"{int(time_B_bin//3600)}h {int((time_B_bin%3600)//60)}m {int(time_B_bin%60)}s\")\n",
+    "model_B_bin.write().overwrite().save(MODEL_B_BIN_DIR)\n",
+    "print(f\"Saved -> {MODEL_B_BIN_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "175a34f3-73cc-4fcb-a2b8-8c94f764b821",
+   "metadata": {},
+   "source": [
+    "## Model Evaluation (Leakage-Corrected)\n",
+    "\n",
+    "All four models are evaluated on the full-size validation (2017) and test (2018) splits — only training data was sampled, so these metrics reflect performance over the complete held-out periods. For each model we report weighted F1, accuracy, weighted precision, and weighted recall, plus per-class precision/recall/F1 via a confusion matrix. Results are persisted to JSON as each model completes so the evaluation is recoverable if interrupted.\n",
+    "\n",
+    "These numbers are directly comparable to the Milestone 3 (v1) results, isolating the effect of the temporal leakage correction: v1 reported test weighted F1 of 0.5689/0.5866 (4-class, Configs A/B) and 0.7280/0.7440 (binary). Any drop here quantifies how much of the original performance was attributable to aggregate leakage versus genuine pre-publication signal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "4eac364c-f52a-45c1-b6aa-6046afc6759b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "====== 4class_A ======\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/spark/python/pyspark/sql/context.py:158: FutureWarning: Deprecated in 3.0.0. Use SparkSession.builder.getOrCreate() instead.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [train(sample)] WF1=0.5350  Acc=0.5115\n",
+      "     low-engagement   P=0.7289  R=0.5212  F1=0.6078\n",
+      "     viral            P=0.6468  R=0.5119  F1=0.5715\n",
+      "     crowd-pleaser    P=0.3651  R=0.4969  F1=0.4209\n",
+      "     debate-starter   P=0.2352  R=0.4913  F1=0.3181\n",
+      "  [val] WF1=0.5008  Acc=0.4962\n",
+      "     low-engagement   P=0.6489  R=0.424  F1=0.5129\n",
+      "     viral            P=0.5428  R=0.6621  F1=0.5966\n",
+      "     crowd-pleaser    P=0.4079  R=0.383  F1=0.3951\n",
+      "     debate-starter   P=0.2322  R=0.3912  F1=0.2914\n",
+      "  [test] WF1=0.4514  Acc=0.4607\n",
+      "     low-engagement   P=0.61  R=0.377  F1=0.466\n",
+      "     viral            P=0.4682  R=0.7026  F1=0.5619\n",
+      "     crowd-pleaser    P=0.3905  R=0.2161  F1=0.2783\n",
+      "     debate-starter   P=0.2233  R=0.3018  F1=0.2567\n",
+      "  -> saved 4class_A to ../outputs/xgboost_v2_evaluation_results.json\n",
+      "\n",
+      "====== 4class_B ======\n",
+      "  [train(sample)] WF1=0.5778  Acc=0.5573\n",
+      "     low-engagement   P=0.758  R=0.574  F1=0.6533\n",
+      "     viral            P=0.6989  R=0.5207  F1=0.5968\n",
+      "     crowd-pleaser    P=0.4129  R=0.593  F1=0.4868\n",
+      "     debate-starter   P=0.2723  R=0.5267  F1=0.359\n",
+      "  [val] WF1=0.5122  Acc=0.5038\n",
+      "     low-engagement   P=0.6376  R=0.458  F1=0.533\n",
+      "     viral            P=0.5761  R=0.5946  F1=0.5852\n",
+      "     crowd-pleaser    P=0.3727  R=0.5048  F1=0.4288\n",
+      "     debate-starter   P=0.2601  R=0.3904  F1=0.3122\n",
+      "  [test] WF1=0.4451  Acc=0.4413\n",
+      "     low-engagement   P=0.5481  R=0.4255  F1=0.4791\n",
+      "     viral            P=0.4793  R=0.5427  F1=0.509\n",
+      "     crowd-pleaser    P=0.3119  R=0.3615  F1=0.3349\n",
+      "     debate-starter   P=0.2279  R=0.2806  F1=0.2515\n",
+      "  -> saved 4class_B to ../outputs/xgboost_v2_evaluation_results.json\n",
+      "\n",
+      "====== binary_A ======\n",
+      "  [train(sample)] WF1=0.7116  Acc=0.7125\n",
+      "     high-engagement  P=0.7768  R=0.64  F1=0.7018\n",
+      "     low-engagement   P=0.663  R=0.7939  F1=0.7226\n",
+      "  [val] WF1=0.6732  Acc=0.6725\n",
+      "     high-engagement  P=0.7277  R=0.7121  F1=0.7198\n",
+      "     low-engagement   P=0.5968  R=0.6151  F1=0.6058\n",
+      "  [test] WF1=0.6260  Acc=0.6275\n",
+      "     high-engagement  P=0.6764  R=0.7001  F1=0.688\n",
+      "     low-engagement   P=0.552  R=0.5246  F1=0.5379\n",
+      "  -> saved binary_A to ../outputs/xgboost_v2_evaluation_results.json\n",
+      "\n",
+      "====== binary_B ======\n",
+      "  [train(sample)] WF1=0.7375  Acc=0.7381\n",
+      "     high-engagement  P=0.7984  R=0.6746  F1=0.7313\n",
+      "     low-engagement   P=0.6893  R=0.8091  F1=0.7445\n",
+      "  [val] WF1=0.6787  Acc=0.6778\n",
+      "     high-engagement  P=0.7342  R=0.7126  F1=0.7232\n",
+      "     low-engagement   P=0.6019  R=0.6275  F1=0.6144\n",
+      "  [test] WF1=0.6149  Acc=0.6136\n",
+      "     high-engagement  P=0.6777  R=0.6508  F1=0.664\n",
+      "     low-engagement   P=0.5307  R=0.5607  F1=0.5453\n",
+      "  -> saved binary_B to ../outputs/xgboost_v2_evaluation_results.json\n",
+      "\n",
+      "Evaluation complete. Results saved to ../outputs/xgboost_v2_evaluation_results.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── EVALUATE ALL FOUR MODELS (val + test, persist results to JSON) ───────────\n",
+    "from pyspark.ml.evaluation import MulticlassClassificationEvaluator\n",
+    "from pyspark.mllib.evaluation import MulticlassMetrics\n",
+    "from xgboost.spark import SparkXGBClassifierModel\n",
+    "import json, os\n",
+    "\n",
+    "os.makedirs(\"../outputs\", exist_ok=True)\n",
+    "\n",
+    "LABELS_4 = {0: \"low-engagement\", 1: \"viral\", 2: \"crowd-pleaser\", 3: \"debate-starter\"}\n",
+    "LABELS_B = {0: \"high-engagement\", 1: \"low-engagement\"}  # binary index swap\n",
+    "\n",
+    "def evaluate(model, df, label_col, n_classes, label_map, split_name):\n",
+    "    preds = model.transform(df)\n",
+    "    ev = MulticlassClassificationEvaluator(labelCol=label_col, predictionCol=\"prediction\")\n",
+    "    overall = {}\n",
+    "    for m in (\"f1\", \"accuracy\", \"weightedPrecision\", \"weightedRecall\"):\n",
+    "        ev.setMetricName(m)\n",
+    "        overall[m] = ev.evaluate(preds)\n",
+    "    pl = preds.select(\"prediction\", label_col).rdd.map(lambda r: (float(r[0]), float(r[1])))\n",
+    "    mm = MulticlassMetrics(pl)\n",
+    "    per_class = {}\n",
+    "    for c in range(n_classes):\n",
+    "        per_class[label_map[c]] = {\n",
+    "            \"precision\": round(mm.precision(float(c)), 4),\n",
+    "            \"recall\":    round(mm.recall(float(c)), 4),\n",
+    "            \"f1\":        round(mm.fMeasure(float(c)), 4),\n",
+    "        }\n",
+    "    print(f\"  [{split_name}] WF1={overall['f1']:.4f}  Acc={overall['accuracy']:.4f}\")\n",
+    "    for lbl, m in per_class.items():\n",
+    "        print(f\"     {lbl:16s} P={m['precision']}  R={m['recall']}  F1={m['f1']}\")\n",
+    "    return {\"overall\": overall, \"per_class\": per_class}\n",
+    "\n",
+    "# Model registry: (dir, label_col, n_classes, label_map, results_key)\n",
+    "MODELS = [\n",
+    "    (\"../models/xgb_4class_configA_v2/\", \"label_4class_idx\", 4, LABELS_4, \"4class_A\"),\n",
+    "    (\"../models/xgb_4class_configB_v2/\", \"label_4class_idx\", 4, LABELS_4, \"4class_B\"),\n",
+    "    (\"../models/xgb_binary_configA_v2/\", \"label_binary_idx\", 2, LABELS_B, \"binary_A\"),\n",
+    "    (\"../models/xgb_binary_configB_v2/\", \"label_binary_idx\", 2, LABELS_B, \"binary_B\"),\n",
+    "]\n",
+    "\n",
+    "all_results = {}\n",
+    "RESULTS_PATH = \"../outputs/xgboost_v2_evaluation_results.json\"\n",
+    "\n",
+    "for model_dir, label_col, n_cls, lmap, key in MODELS:\n",
+    "    print(f\"\\n====== {key} ======\")\n",
+    "    try:\n",
+    "        model = SparkXGBClassifierModel.load(model_dir)\n",
+    "        res = {\n",
+    "            \"train\": evaluate(model, train_sample, label_col, n_cls, lmap, \"train(sample)\"),\n",
+    "            \"val\":   evaluate(model, val_split,    label_col, n_cls, lmap, \"val\"),\n",
+    "            \"test\":  evaluate(model, test_split,   label_col, n_cls, lmap, \"test\"),\n",
+    "        }\n",
+    "        all_results[key] = res\n",
+    "        # Persist incrementally so a later failure doesn't lose earlier results\n",
+    "        with open(RESULTS_PATH, \"w\") as f:\n",
+    "            json.dump(all_results, f, indent=2)\n",
+    "        print(f\"  -> saved {key} to {RESULTS_PATH}\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"  !! {key} FAILED: {e}\")\n",
+    "\n",
+    "print(\"\\nEvaluation complete. Results saved to\", RESULTS_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b737155d-8dce-4c39-9a25-2ce11f948b07",
+   "metadata": {},
+   "source": [
+    "### Feature Importance\n",
+    "\n",
+    "Feature importance (split weight) is extracted from each model's underlying booster and plotted, ordered by Config B's 4-class importance. With the leakage correction, the cold-start flags (`is_new_author`, `is_new_subreddit`) and the train-only aggregates are of particular interest: if cold-start status now carries meaningful weight, it confirms the model is actively using the missingness signal we engineered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c5f68252-155c-4e04-9454-cedadafd47d7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABjIAAAMsCAYAAAD+vjuEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd1RUx+M28GfpHQEBG4INGwgqKMHeBTX2hgrYjS328o01GjWW2HvsGnsv2MWCBSxYUYmiaETFAgiiCMz7By/3txeWKsqqz+ecPWf3zsyduWXvzt65M6MQQggQERERERERERERERGpIY38LgAREREREREREREREVFG2JBBRERERERERERERERqiw0ZRERERERERERERESkttiQQUREREREREREREREaosNGUREREREREREREREpLbYkEFERERERERERERERGqLDRlERERERERERERERKS22JBBRERERERERERERERqiw0ZRERERERERERERESkttiQQUREREQ/JF9fXygUCigUCtStWze/i0OUryIiImBsbAyFQgFnZ+f8Lk62pX6HFQoF1q5dm9/FoR/U2rVrZeciUV7XMQYPHiyt78CBA59fQCKibxAbMojoh/TgwQMYGRlJlUFPT890cZKTk1GnTh0pjqmpKcLDw9PFe/36NWbPno0mTZqgSJEi0NfXh4mJCezt7VG3bl1MmjQJgYGBEEJIaR49eiT7s5P60tTUhLGxMcqXL48ePXrg8uXLX3Q/5DU7OztpWyZNmpTj9Kr2SdqXnZ1dnpc7Oz5329RN2j/c/v7++V2kr+57O6bfosTERFStWlV2Lvr6+uZ6fUIIHDhwAF27dkWZMmVgbGwMAwMDlClTBp6enli5ciXevHmTdxugJtT52klfXl7dQP3tt98QGxsLABg/frwsTPmGHG/Sqo8f9ZqXle/l9/3ff//FoEGD4O7ujmLFikFfXx96enooWrQoPD09sWHDBiQnJ6tMGxUVhXHjxsHBwQGGhoYwMTFB1apVMXPmTHz48CFd/NDQULRr1w5FixaFiYkJXF1dsXXrVpXrnj59OhQKBTp06JCn20uZGz16NHR1dQEAI0aMQGJiYj6XiIjo69PK7wIQEeWHUqVKYc6cOejXrx8AwM/PD8uWLZM+A8DcuXNx5swZ6fPChQtRvHhx2XpWrVqFIUOGSH/8U3348AHv3r1DaGgoTp8+jcmTJyMsLCzLG0nJycmIjY3F3bt3cffuXaxfvx67du3Czz///JlbTESkfqZPn46rV6/myboeP36Mzp0748KFC+nC/v33X/z777/w8/PD7du3MW/evDzJk+h7ERoainXr1gEAbG1t0aZNm3wuEWWF17zvX3BwMBYtWpRu+bNnz/Ds2TP4+flh//792LZtmyw8LCwM9erVw+PHj2XLr169iqtXr2LLli04duwYLCwsAABPnz5FtWrVEBUVBX19fRgbG+Py5cvo1KkTXr16hQEDBkjrePjwIaZMmQJTU1PMnz//C2w1ZaRo0aLo0KEDNmzYgHv37mHdunXo2bNnfheLiOirYkMGEf2w+vbti3379uHQoUMAUp5sadSoEUqVKoU7d+5g3LhxUtzWrVvD29tbln7u3LkYNmyY9FmhUKBevXqoXr06TExM8ObNG1y/fh1nz55FfHx8pmVp1KgRGjdujOTkZNy5cwfr16+HEAJJSUmYMGHCD9mQ4eLigo4dO6Zbbmpqmg+lyT/v3r2DsbFxfhfju8H9qT5u3LiBKVOm5Mm6nj9/jjp16shu2pQqVQrNmzeHtbU13rx5g/Pnz+P8+fN5kp8647WTcmPJkiXSk91dunRhrws1p07XvOz8riYmJuLTp0/Q19f/4uX5nmhoaKB8+fKoXr06ihQpAkNDQ4SFhWHr1q149+4dAGD79u24dOkSqlevDiDloahOnTpJ54a5uTn69OmDDx8+YPny5YiPj8e1a9fQr18/bN++HQCwZs0aREVFwcTEBCEhIShcuDA6duyI7du3Y+7cubKGjF9++QXx8fH466+/ULhw4a+8R6hLly7YsGEDAGDx4sVsyCCiH48gIvqBPXv2TFhYWAgAAoBwd3cX8fHxokqVKtIya2tr8fLlS1m6kJAQoaWlJcUpWLCguHDhgso84uLixIoVK0RkZKS0LCwsTEoLQEycOFGWpnnz5lKYrq6uyvVu375deHh4CCsrK6GlpSXMzMxErVq1xOLFi8XHjx9Vprl7967o27evKF26tNDT0xMGBgaibNmyYtCgQSIsLCxd/MjISDF8+HBRoUIFYWBgILS1tYW1tbVwdXUVAwYMkLbZx8dHtj2qXtmhHN/HxydbaRITE8XatWtFgwYNRMGCBYWWlpawtLQUP//8szh58mS6+C9evBAjRowQ9erVE8WLFxdGRkZCW1tbWFlZiUaNGokNGzaI5ORkKX5Otk152Zo1a2T51qlTR+W2pT0XTp48KRYvXiwcHByErq6uqFOnjmw9u3fvFs2bNxeFChUS2trawszMTDRs2FDs3LkzW/sr1Zo1a2T5njp1KsOwqKgoMWjQIFGoUCFhYGAg6tatKy5duiSVv127dqJAgQLCyMhINGnSRNy8eVOWV9ptPHXqlFi/fr2oUqWK0NPTE5aWlqJnz57ixYsXKssaGBgounbtKmxtbYWOjo4wMjISlSpVEmPHjk333RRCCFtbW9l36/jx46J27drC2NhY2v/ZPabbtm0TXl5eomLFisLS0lJoa2sLQ0NDUaFCBTFw4ECV35u0x/ru3buiXbt2wszMTOjp6Qk3NzfZ/lYWGRkpJk6cKFxdXYWpqanQ0dERxYoVE56enmLv3r3p4ufV+fC1JSQkCGdnZwFAuLi4iKJFi+b4u6+sY8eOsuPXv39/8enTp3Txbt26JbZv3y59Vj4X0n7Xli1bJtq1ayfKli0rLCwshJaWljA2NhbOzs5i9OjRsmt6qkePHok+ffpI11hdXV1RpEgR4e7uLoYOHSru3Lkji79mzRpRp04daf0FChQQ9vb2okOHDmLx4sXZ3v7cXDvTfk8uXbokmjZtKoyNjYWhoaFo2LChuH79usq0K1eulK5RRYsWFUOGDBExMTHp1pkqPj5e/O9//xNNmjQRJUqUECYmJkJLS0tYWFiIWrVqiYULF6o8XrnJK9XVq1eFr6+vKFGihNDV1RVGRkbCxcVFzJkzR8THx2e6D9esWSPWr18vnJychJ6enihVqpT466+/hBBCfPr0Sfzxxx+iRIkSQkdHR5QrV06sWLFCZdnj4+PF/PnzRc2aNYWZmZnQ1tYWRYoUEZ07dxZXr15NF3/ixIlSGWxtbcXbt2/FkCFDRLFixYSOjo6wt7cXS5YskeKnvbaqeqnaN2klJiYKMzMzKc2VK1fSxUl73cyuU6dOifbt20vbYGJiImrWrCn+/vtvkZSUlC7+H3/8IX7++WdRunRpYWZmJn0vqlWrJv744w8RGxubLk1Gv72nT58WBgYGUtjPP/8s1Y9yk48QKddcV1dX6bere/fu4vnz5xn+xqcKDQ0V/fv3F2XLlhX6+vpCX19fODg4iAkTJoioqKhs789Uub3mCZFyDq9cuVLUq1dPmJubCy0tLVGwYEHRqFEjsXHjRlkdSIiUY6ic1/3798WUKVNEmTJlhLa2trS9aa+nDx48EB06dBAWFhZCoVDIfveePXsmRo8eLRwdHYWRkZHQ1dUVZcqUEUOHDhUREREqtzkhIUGsWLFCqu9pa2sLS0tL4e7uLmbOnJmuDNmpj759+1ZMmTJFuLi4CBMTE6GjoyNsbW1Fr169RGhoqMpyPHr0SHTq1EmYmZkJAwMDUatWLXHs2LF0dacvadOmTbK8tmzZIoUdOnRIFnb06FEpbMWKFbKwkJAQIYQQvXr1EgBE9erVpbhLliwRAIS2tra0bOPGjQJI+b+U9jzJiZz89uVFPezSpUuiQYMGwtDQUFhZWYn+/fuLd+/eCSFS/k+l1keLFCkihg0bJj58+CBbn6pr8+DBg0XRokWFjo6OqFChgli8eHG6fZJZHUOI3H0PEhMThampqbReVb8lRETfMzZkENEPb9u2bbJKfaVKlWSf9+3bly5Nv379ZHFyetMwo4aMpKQkcefOHVG8eHFZhVlZYmKi6NChQ6Z/0qpVq5buj/HWrVuFnp5ehmmMjY3FkSNHpPjx8fGibNmymeYzevRoIUT+NWTExcWJevXqZZrvH3/8IUsTFBSUZVm7d+8uxf/aDRk1atSQfU7945OUlCS8vLwyLUefPn2ytZ+FyFlDRtWqVdPlpaenJ/bt2ydrCEx9WVhYyBoY0m5j/fr1VZa/dOnS4tWrV7Jyzp07V2hoaGS4zdbW1un+xCnf4HRzcxOamprpzq3sHtNmzZplGs/ExETcuHEjw2NdqVIlYWRklC6djo6OuHXrlizdxYsXhZWVVYZ5KZ83eX0+fG2pNwV0dXXF7du3Zccspw0Zz549EwqFQkrv7Oys8gapKpndZKhYsWKm+7do0aLiv//+k+K/ePFCWFpaZppm6dKl6fZBZud2dmV0nmRGeZ9Xq1ZN1jif+jI3NxfPnz+XpRszZozK8rq6ugpra2vps/IN9MjIyCy/cw0bNhSJiYmfnZcQQixcuDDd9z5t+rS/kcrhqq55AMT48eNF69atVYatWrVKtr4XL14IR0fHDMugpaUl1q1bJ0ujfE5YWFiIcuXKqUyb2nCSVw0ZgYGBUnwDAwOVN8Rz05AxevToTMvWrFkzkZCQIEtjaGiYaRpHR0fpBmQq5fDU397z58/Lrr3t2rWT5ZWbfJYtW6YybokSJWTXi7TfwZ07dwp9ff0M8ypVqpR4/PhxtvapEJ93zYuNjRW1a9fOdNubN28u21dpGzLS1lNUNWSUKVMm3e9Zaj3j3LlzwtzcPMP8raysxLVr12TljoyMzPB7CfxfXTknv+93796V1bfTvgwNDWX1YiFSvnOFChVKF1ehUAgPD48cf0dy6sOHDyIkJET8/PPPsryUHyBR/o9iYmIiu7n++vVrWbo///xTCCHE77//LsX/77//RHJysmjfvr10fqamtbKyEtra2unqLzmR09++z62HVaxYUejq6qZLV7duXTFnzhyV6+zWrVuGZba0tBQODg4q0w0ZMkSWLrM6Rm6+B6kaNWokxZs1a1buDgQR0TeKQ0sR0Q+vffv26NKlCzZt2gQgZbiTVD179kSLFi3SpTl58qT03szMDK1bt/6sMkyePBmTJ09WGTZ69GjZ5z/++EM2Fm6NGjXQoEEDBAcHY9++fQCAwMBA9O3bF1u2bAGQMva1t7c3Pn78CACwtLSEj48PEhMTsXr1asTExODdu3do37497t+/D2tra5w6dQr37t0DAOjp6aFnz54oWrQonj9/jn///RenT5+WytCpUyc4ODhg2rRpePv2LYD/Gy4rt27fvo3Zs2enW+7u7g53d3cAwJAhQ3Dq1CkAgK6uLry8vFCyZElcu3YNu3btApAyeamLi4tUFg0NDVSsWBGurq6wtrZGgQIF8OHDB1y7dg379++HEAJr1qxBv379UK1atS+ybZkJCAhAyZIl0aZNG+jp6eH9+/cAgBkzZuCff/6RtqF9+/ZwcHBAaGgoNm3ahKSkJKxYsQJVq1ZFnz598rRM165dQ69evWBsbIyFCxciMTERHz58wM8//wwDAwMMGTIEb9++lcZXf/36NVatWoUxY8aoXN/JkydRr1491KpVCwEBAThx4gSAlDG9R48ejb///hsAcPr0aQwbNgxCCABAiRIl0KlTJ7x58wZr1qxBQkICXrx4gdatW+PevXvSBIjKLl68CGNjY3Tp0gVFihSRxnzO7jE1MzND06ZNUbZsWZiZmUFHRwcvXrzArl278OTJE8TExGD06NHSEHVp3bhxAwULFkS/fv3w4sULaTiAhIQELFiwAMuXLwcAxMTE4Oeff8bLly+ltI0aNYKbmxuioqLSTcaen+fD5woODsa0adMAAL///jsqVKjwWes7deqUdI4AgI+PDzQ0ND5rnQBgbW2N0qVLo2TJkjA3N4dCocB///2Hbdu24fXr1/jvv/8wdepULFmyBACwc+dOREZGAkg5b7p37w4LCws8e/YMd+/exdmzZ2XrX7p0qfS+QYMGqFevHuLi4vDkyROcO3cuyyEJM5Kda2dagYGBsLW1RefOnXH79m3s378fAPDmzRusXr0aY8eOBQAEBQXhzz//lNJZWVnBx8cH7969w+rVq5GQkKBy/QqFAqVLl5aGRzEzM8OnT59w9+5dbN++HYmJiTh+/Dh27twpTR6b27wCAgIwePBg6ZyoWbMmGjZsiKioKKxbtw5v375FUFAQfvnlF+k7lNaVK1fw008/oWHDhti6dSvu378PANJQaJ6enqhSpQqWLVuGV69eAQBmzpyJHj16SOvo2rUrbt68CSBlWK8uXbqgUKFCOH36NE6cOIHExET06tULVatWRcWKFdOV4fXr14iKikKPHj1gYWGBxYsXS78Hs2fPRu/evWFubo5Zs2bh8uXLskl5Z82aJb3P6Jin3WepHB0doaX1+X8R//nnH9nxa9asGdzc3PDff/9h3bp1iI+Px8GDBzFx4kTpegAAxYsXh4ODA4oXLw4zMzMIIaShdOLi4nDz5k0sWbIEo0aNyjDvK1euwMPDQ5q/rHPnztiwYQM0NTVznc/Tp08xZMgQKb2hoSF69eoFDQ0NrFq1CmFhYSrL8vDhQ3Tp0kWaXLlSpUpo1aoVEhISsGHDBvz333948OABOnfuLDsOmfmca96gQYNk8795eHjA1dUVZ86ckX5nDhw4gPHjx2PGjBkq1xEQEIBKlSqhWbNmSE5OVjlsXWhoKBQKBdq3bw9HR0c8evQIhoaGiI6ORuvWraUJyEuWLIkOHTpAW1sb27Ztw7179/Dy5Uu0adMGISEh0u96t27dcOXKFWn9FStWhIeHB7S0tHD58mU8ePAAQPbro0lJSWjdujXCw8MBpFzvu3TpAlNTUxw4cABBQUGIi4tDhw4dEBoaCktLSwDAwIED8fz5c2k9LVq0QOXKleHn5wc/P79sHYPcmDRpUob/E0aMGAEHBwfps/L/mBIlSsiGiTM3N4epqSmio6Nlcbt3746//voLUVFRKF26NExMTPDixQsAwNChQwEAI0eOxMuXLzFu3DiV16zsyulv3+fWw27fvg1bW1t06dIFly5dkuqc/v7+8Pf3h6OjI1q1aoX9+/cjODgYALBp0ybMmDEDRYoUSbe+yMhIxMTEoF+/fihQoAA2btyIp0+fAgDmzZuHNm3aoFatWpnug9x+D1JVrlwZx44dA5DyfRwxYkSm+RERfVfysRGFiEhtvH37VhQuXFj2JEyxYsVETEyMyvjKQxVUq1ZNFpbRE5Jt27bNMk7aV9++fWVPUiUmJsqe3qlZs6bsKbwePXrIng578uSJEEKIX3/9VVquoaEhG97kzJkzsjynTp0qhBBi165d0rImTZqk2wcfPnwQT58+lS3LaqiPrGRnn6Su9/Xr17Inbv/55x/Zujp16iSFNWrUKF1ejx8/Fjt27BCLFi0Ss2fPFrNmzZINb/P777/neNuUy5nbHhllypQR0dHRsrRJSUmyng/Tpk2ThSs/tVymTJlM9vD/yUmPjNRzQgj5fgUgNm/eLIW5urpKy9u0aZPhNjZu3Fg6r5OTk0Xjxo2lMF1dXREXFyeEEKJly5bScmNjY9lQPuvXr5etc+PGjVKY8rHS0tJK96SeqniZna8JCQnizJkzYtWqVWLu3Lli1qxZonv37rIyKz+9qnysNTQ0ZMPztGrVSgqrUqWKtHz+/Pmy7ZkxY0a6cjx8+FAI8WXOh68lISFBODk5CSClt0zqE/if0yNj5syZsn3n5+eX7bRZDfsQFxcnjh8/LlasWCH++usvMWvWLNl5WbJkSSnuX3/9Jbt2pxUbGyvr3WBiYiLFVzWExIMHD7K9HTm5dqZS3udGRkayMlSuXFnld7lPnz6yc1v5qdy01w1V36kXL16IvXv3iiVLlkjXXeUnW3v06PHZeSn3mGjSpInsN/Tw4cMqfyPT7sMKFSpI32nlNABE06ZNpTSLFy+WhaXWGa5fvy5bfv78eSlNcnKy+Omnn6Sw3r17S2Fpn1RetGiRFDZv3jyVeanaHzk1YsQIKW2LFi1Uxslpjwzlcyht7zDlng1GRkbphsOMiooShw4dEsuWLRNz5swRs2bNkvUiqF+/viy+crmGDh0qqyf5+Phk2FshJ/lMmzYtw+tM2h4LytewoUOHSssdHR1l23r37l1ZuoCAgCz3qxC5v+a9evVKVm/q3LmzFJacnCwaNGgghRkaGkrD66Tdvlq1aqkcwjTtOaI8DFoq5d86KysrWc+ot2/fynoOb9q0SQiR/vvUokWLdL2G0l4vs/p937t3rxSuo6MjHj16JIV9/PhR1lMjtWdv2p4wXbt2ldIkJCSk68WXl1T1YtDS0hIzZ85MN5yRcm/qWrVqpVtXsWLFZNfIVPfv3xdt27YVhQsXlobiS63jnT59WigUClGmTBkRHx8voqKixOLFi8WAAQPEiBEjxKFDh7K9Lbn57fucepiWlpY0/FRsbKzsO2BpaSldS2/fvi3bv8o98tPu/9RzU4iUOq62trYUptybI6M6Rm6+B8pmz54thbu6umZjrxMRfT/YI4OICClP2qU+FZMqMjIS4eHhWT51lBcTYipP9v3w4UOsX78e8fHxWL58ORISErB69WoAwL1792Tl9PLykj2F5+PjI8UVQuDChQto3769bLJHFxcXlC9fXvpcq1YtlChRQnqaMDWuq6srdHV18fHjRxw5cgQVK1ZEpUqVYG9vj8qVK6NBgwYoWrToZ297bl26dAlJSUnSZy8vL3h5eamMq7z9r1+/ho+PDw4ePJjp+lOfrvra+vfvDxMTE9mye/fu4fXr19Ln//3vf/jf//6nMn1oaChevXqFggUL5lmZunTpIr23s7OT3mtra6Ndu3bSZ3t7ewQFBQGA9CSkKl27dpW+NwqFAl26dMHRo0cBAB8/fsStW7dQrVo12XHz8PCQbZOXlxd69uyJT58+AUg5xsrlTNWsWTM4OjrmZHNlNm3ahCFDhkhPXavy8eNHvHr1SuWklz/99BMqVaokfS5btqz0XnkfKT+Ja2xsrPLpuhIlSgDI+/MhJiYGK1asyDA8uzp27AgbG5tM40yZMgXXr1+Hnp4e1q5dK3tCOiMZTVib2sNAKD2ZnJf++usvTJw4UXqqW5X//vtPel+jRg0oFAoIIbBixQoEBQWhQoUKKFu2LFxcXFCvXj1YW1tL8WvVqiVdhxwcHFC9enWUKVMGFStWRL169VC6dOkvsl2qtGzZEoUKFZI+29vb49q1awDk56nyE9FpexJ07doVvXv3RmJiYrr1x8fHo3///li/fr00obQqytfd3Oal/F06cuRIhk+qCyFw8eJF2TUsVfv27aGtrQ1Afs0DUp74TmVvby8Le/v2LYyNjdM9WZ9Zr4iMJmPW1NSUTeKqfO1QzisvREVFSe/T/v7kxvv376UnmwFgxYoVGV5jYmNjcePGDbi4uCA5ORljxozB/PnzM+xxA2T++zx37lzpfe/evbF8+fJ09bTc5KN8PlpaWqJp06bS57p168LOzg6PHj1Ktw7lc+HmzZsqew6mOn/+PNzd3b/YNS9tvalbt27Se4VCAW9vb+lp9bi4ONy4cQOurq7p1jNs2DDo6OhkmlfqBNNpKe+Ply9fokCBAhmu4/z58/Dy8kr3fRo/fny6XkMlS5bMtDyZlSMhISHd9zxtOYCUc0B53yvXObS1tdGhQwdMnDgxR+XIrsaNG8PIyAjv3r3DnTt3sG/fPiQkJGDUqFEICAjA9u3bpWuWchlVnSvKy5S/G2XKlMGOHTvSxU9ISEDfvn0hhMDy5csRERGB2rVry74fs2fPRteuXaVep5nJ6W/f59bDatSoIR1fQ0NDWFpaSr1qmjVrJl1HVV3PVdHW1kbHjh2lz3Z2dqhZs6bUQ/zy5cuZbT6A3H0PlClfp5Wv30REPwI2ZBDRD+/Tp0/o1q2bNOxSqo8fP8Lb2xsXL16U/hykKlq0KEJDQwGk3CgUQkh/BlKHegAg69qeGXd3d9mNSzc3N3Tv3h0AsGbNGvTt2xfVq1dPty4rKyvZZ+WbZMD/VcKV06VNk5outSEjNW6xYsWwdu1aDBo0CK9evcKdO3dw584dKY2RkRH+/vtvWWU+L/n4+GDt2rUZhqdteMpMXFwc4uPjoa+vj549e2bZiAEg3fmQU2n/PGZ3fWn/SAE521YgpREuLxsylBuslG/CWFlZyW4mKL/P7GZlXpy3mpqasLCwkP6MZvQ9U7U/s+vq1avw9vbOdFtSZXR8bW1tZZ+V95/yepWPsY2NTaY3+PP6fHjz5g1GjhyZo3Wq4uLikmlDxpMnTzB9+nQAKUPkpb0xm5GjR4+qHFJj4sSJcHd3R7FixWTL7969K7vJmBt79uzB8OHDs4ynfNyrVauGv/76C+PHj0dsbCyuXr2Kq1evSuEFCxbE9u3bUbduXQApw2t06NABFy9exOvXr9MNi9GhQwds3rw5x8NkZXXtVCW756nyDRPlhg8g5ftfsGBB2bArqcaOHZutMinvz9zmlZPvR+pQYGlldM1LG5b2ZmrqvsqLMlhbW0NPTy/DcmTnupRdyjfRYmJiPnt9b9++zdHN9tR9sGDBAtmwWBnJ7u9p2mF1UuUmn8zOx9RlqhoycnMufKlrXm7rkGll53e1VKlSKn/HcrM/0qbJrNEhu3JTjrQ3jLPaf3kp7dCAZ8+eRe3atQEAe/fuxZIlS/Drr78CACwsLKR47969S7cu5e+4ubl5lnlPnz4dd+/eha+vL+rVq4e2bdvi6dOncHJywpEjRxAcHAwPDw9s3LgRHTt2RPPmzTNdX05++/KiHpb2oSvla2l2rudpWVhYpDu3lY99dv73fe5vhPIxzKwRhIjoe8SGDCL64U2cOFH25GD//v2lMc+vXr2K33//XRoXO1WDBg2khow3b95g3759aNmyJYCUp2RSGyUWLVqUrQptWtWqVZN9vnDhAqpXrw4zMzPZcuXx9AFI49mmSo2vnC5tmrTplON26tQJbdu2RWBgIG7evInQ0FCcOnUK165dQ2xsLHr27InmzZvD0NAwh1v4+dLui5EjR6pspEmlpaWFuLg4HDhwQFrWqVMnzJo1C0WKFIGGhgaqVasm9SjIjdSnsQHIxvhN7WmTHQYGBumWpd3WXr16ZXoTOLP9kBtpG/JS5XYc9azO29Q/ZWZmZtIfuLRpkpKSZL0S0u6jVKr2Z3Zt375d+iNraGiIHTt2oE6dOtDX18ehQ4fQrFmzLNeRdt9l1INL+WbCkydPkJSUlGFjRn6fD7n1+vVr6Qn64cOHZ9hQsG7dOqxbty7bN+Tr1q0r++6tX78egwcP/qx5MpTnGyhSpAh27tyJypUrQ1dXF0uWLMGAAQNUphsyZAj69OmDixcv4vbt2wgNDcXhw4elnjG+vr7SzU4bGxtcuHAB//77LwIDAxEaGoobN25g3759SExMxLZt2+Dh4QFfX99cb0d2Zfc8Vb5hkvY7mZiYmOETs8r7s169elixYgVKlCgBTU1NdOjQAdu3b8+zvJSvG/Xq1YOnp6fKeEBKjylVMrrmAdm77qX9jk6bNi3DdWZ0jcruMckLyuPAZ9SwkhNpb6y1adMmw30N/F9vE+XzxMHBAf/88w/KlSsHbW1tjBo1KluND+XKlcPdu3cBpPRWK1CgAH755RdZnNzkk9n5CEBloxogPxecnJzQtWvXDMuuqveDKrm95uW2DplWdn5XM4qjvM7ixYtj0KBBGa4j9bxIe7P90aNH0pwVuaVcDiMjo0x7UqQ2XKU9r7Paf19SrVq1YGZmJv3H8Pf3lxoyKlWqhAsXLgAAwsLCZA9bRUZGyho3lHuMqnLv3j1Mnz4dlpaW0txLqb12fHx8YG1tjSZNmsDR0RE3btzAiRMnsmzIyMlv35eohynLTT329evX6epoysc+Ow0LufkeKFM+9/KzdzwRUX5gQwYR/dAuXLiAmTNnSp979+6NxYsXIzY2FuvXrweQ8iRS8+bNUb16dSnewIEDsXLlSqmLfr9+/VC8eHFUrlw5T8qV9mZ6aj5ly5aFubm59CTPP//8g759+0p/XlMnWwZSbnq4ubkBSHmSK3Wdly9fRkhIiDS81NmzZ2WTVKY+8fXmzRu8e/cOtra2qFGjBmrUqAEg5Umj1D+VcXFxuHv3LqpWrQpA/mchdVLSL6V69erQ1NSU9o2+vr7K4Xju3LmDN2/eQFtbG5GRkbJhFdq3by892RgSEoLr169nmF92tq1AgQLSn8pLly6hf//+AIC1a9eqvPGRXeXKlYOFhYV04/7jx48qtzU8PBwhISGyp/HU0caNG6XhpYQQ2LRpkxSmo6MjDQXl7u6OvXv3AgAOHz4sGyLpn3/+kYaVSo2bU1kdU+WGkpIlS8qeeN2yZUuO88tMjRo1sG3bNgApT1DOnTs33TF+/PgxbG1t8/x8sLOz+2LDM+WFSZMmYdKkSRmGFylSBO3atZNuhl+7dg1DhgzB3Llz0zUG3b59GyEhISqHE1KmfOyrVq0qXUuTk5NV3nQHgGfPnkFTUxPW1taoX78+6tevL5WnSpUqAFKO4evXr2FhYYHr16/D0dERpUuXlg2l0bJlS+zbtw9AylAmX6MhI7tcXV2lIXYuX76Mf//9Vyr7xo0bVQ71BMj3Z/PmzaU0L1++lIbjyKu8lK8bz58/xy+//JKusT0mJgZ+fn5wdnbOzmbnWNrrUaFChaRelsoCAwMzHWoou9LeqHv//n2OGnGVGxlu3ryZaUNqdhgaGsLJyUn6TX379i2GDh2abp2RkZEICAiQhgVSPk/q1asn/RbEx8dL34msjBo1Cv7+/lIdbsCAATAxMZENA5SbfFxdXbFz504AKTct/f39pd5Vp0+fVtkbA5DXvyIiItC1a9d0PTo+fPiA7du3o06dOgC+3DWvWrVqsnrThg0b4OHhASClF6nysECGhoZZ3uTODXd3d6ncL168QLNmzWTDnQIpDZUHDhxAzZo1AUCqf6b6448/sGPHDtlN6NTfx1RZ/b4rf0djY2NRpUoV6ZqdSgiBkydPSudnlSpVZA1ImzZtkuoFnz59kn7DVVm7dq3sGpDd39xdu3ahWbNm6a4TFy5ckD0opdzQ2aJFCyxfvhxAyrXu6NGjaNKkCQCkK2OLFi0yzb9v3774+PEj/vrrL6kukfqgjvLwYqnv007UrUpOfvu+Zj0suz59+oStW7dKwz09evQI586dk8JdXFyyXEduvgfKlHt7pv1+EBF979iQQUQ/rLi4OHh7e0t/6EqUKIG//voLALBw4UL4+/sjPDwcSUlJ8Pb2xrVr16QbAxUrVsSUKVOkcemfP38OV1dXNG3aFFWrVoWuri4eP36c7aezzp8/j9mzZ0MIIc2RoSz1D5empiYGDx4s/cE9d+4cateujYYNGyI4OFi6eQMA7dq1k4Z56d+/P5YuXYqEhAQkJyejTp068PHxQWJiojSnBpAyNn+vXr0AAPfv38dPP/0EV1dXODk5oUiRItDS0sLhw4dlZVN+8qho0aL4999/AaT8adPT04OJiQlKlSqF1q1bZ2tfZJeFhQV8fX2xatUqAMDvv/+Oixcvws3NDdra2ggPD0dAQADu3LmDiRMnombNmrCyskKBAgWk4QF+/fVXqXfJ2rVrMx0rOzvb5uLigmPHjgFIeULy+fPn0NbWhp+f32dtq4aGBoYMGYLx48cDSLn5EBoaivr168PQ0BDPnj3DxYsXpS74qX9Y1dXRo0fRoEED1K5dG+fOnZOe7gNSxpxO/Z4NGTJEOqdjYmJQrVo1dOrUCW/fvpWdtzY2Nmjbtm2Oy5HVMVV+Cu7mzZvo2LEjHBwc4O/vj5MnT+Zq2zPi6+uLP/74Q2rwGjlyJI4dOwY3NzfExsbi7NmzqFChAtauXfvNng8FChTI8Dj5+flJN5tsbW3h4uKS7aeTAWDevHm4ePEinjx5AiDlGu7n54cWLVrAysoKr1+/lsad//XXX7NsyChbtqz0XT548CB69+6NokWL4uDBgxmOf33mzBl06dIFNWvWRPny5VGkSBEkJSVh165dUhwdHR3o6+sDSJlTJDo6GvXq1UPRokVhbm6OBw8eyIbZyM2QEbdv35aenE1r0KBBn3XjvGfPnli+fDmEEEhKSkKdOnXQrVs3xMTESNdiVcqWLYtbt24BAKZOnYoXL15AoVBgw4YNGfasyG1ew4cPx759+yCEQEhICBwcHNCmTRsULFgQb968QXBwMM6ePYtChQp9saERnZ2d0aBBA+na1rt3b+zfv19qOAkLC8Pp06cRFhaGNWvWwMnJ6bPyS/tErpeXF9zd3aGhoYFu3bplOeSNi4sLTE1NER0djbi4ONy8eTPLRp6MbtYNHz4cnTt3xogRI6Q5GE6dOgUnJyc0b94cpqamePnyJS5fvowLFy6gZs2aaNWqFYCU8yS1t+vKlSuhUChgYmKC7du34969e9nYEyk3dFetWoXIyEj4+flBCAFfX18YGxvj559/znU+Xbt2xaRJk/DhwwcAQKtWrdCjRw8AyPR8HDRoEJYtW4aPHz/i5cuXcHJyQocOHVCkSBHExMTg5s2bOH36NGJjY2VzVmQlN9e8ggULolu3blJPt82bNyMqKgrVqlXD6dOn4e/vL62/f//+edLIlpavry+mTp2K169f4+PHj3Bzc0OHDh1QokQJxMfH486dO/D398ebN28QFhYGMzMzVKpUCU2aNMGRI0cApAylVKVKFXh4eEBbWxvXr1/HnTt38ODBAymfrH7fmzdvjrJly0rHu1mzZmjbti3KlSuHxMRE3L9/H/7+/oiIiMCpU6dQokQJFClSBB4eHtI1euPGjYiJiYGzszP8/Pxw+/btPN9fPXr0gKamJjw8PGBvbw+FQoG7d+9i9+7dsnjKvSA8PDxQtWpVqSHYy8sLffv2RXx8PJYtWybFa926NSpUqJBh3qtXr8bp06fRqFEjWU+iihUr4tq1a9izZw/69euHsLAwqdEyq3kFgZz99n3NelhO9OjRA2fPnkWBAgWwceNG2YM1vXv3zjJ9br4HqZKSkmQPvDVo0CBvN46ISN19nTnFiYjUT9++fQUAAUBoaGiIM2fOyMJPnTolFAqFFGfgwIHp1rFgwQKhp6cnxcns1adPHyldWFhYttIAEN27d5fl+enTJ9GmTZtM01StWlW8efNGlm7z5s1CV1c3wzSGhobi0KFDUvwLFy5kWbY2bdrI8pg/f77KeM2aNcvWMVFO4+Pjk2X82NhYUa9evSzLOXHiRCnNjBkzVMZxcHAQVatWzTD/7Gzb4cOHZedM6svW1laULVtW5brTngunTp1Sua2JiYmic+fOWW5rdvabEEKsWbMmw3zThimbOHGibLuU+fj4SGF16tTJcBubNWumsuwlS5YUkZGRsnXOnj1baGhoZLi9lpaW4vLly7I0tra2Ko99Wlkd09evX4siRYpkuJ+VP4eFhUnrrVOnTobHI7P9d/HiRWFlZZWtY5vX50N+Uz5muS3zw4cPRbVq1bLcJ7/++quUJqNzNjQ0VBgbG6dLq6WlJbp06aLy+7F58+Ys8x42bJgUX/maoOplbm4uO68yk1W+qa+3b9+q3OdpvycZ7RchhBgzZozKdVepUkVYW1tLnydPnpzlvilcuLBo1KhRnuYlRMpvs6amZqb7Iu33TzlszZo10vLMrtGnTp3K8Drw/Plz4ejomOUxUc4rs+tDZnl9+PBBFC5cWOX6g4KCRHYMGjRISjNu3Lh04WmveRm95s6dK6UZOXJklvGVj/nZs2eFlpZWujhGRkayek92jl1sbKyoXr26tFxXV1ecOHHis/JZunRphudS+fLlpc9p6207duwQ+vr6We6LnMrNNS8mJkbUqFEj0/geHh7i48ePUprMzj1lmV03lJ09e1aYm5tnWW7lfCIjI2V1tKy+z9mps4WEhIjixYtnWQ7l7/zDhw8z/J1W/u1Pezwzq1dlxtTUNMvydevWTSQnJ8vShYaGChsbmwzTODk5patvKXv58qUwNzcX+vr64t9//5WFbdu2TVpPwYIFpf8WRYsWlf3GZCQnv31foh6W2W+fqmuJEPJrs7W1dYbn4qBBg2Try+w7kZvvgRBC+Pn5SWGVK1fOcn8TEX1vcj94MBHRN+zw4cNSt2sAGDZsGGrVqiWLU7duXQwdOlT6vHjxYhw/flwWZ9CgQQgLC8Pvv/+O2rVrw8rKCtra2tDX14eNjQ0aNmyICRMmICgoSJZfZrS1tVGkSBE0a9YMW7ZsSfekn5aWFnbs2IEtW7agSZMmKFiwILS0tFCgQAHUqFEDCxYsQEBAQLqxjTt16oRr166hd+/eKFWqFPT09KCnpwd7e3sMGDAAN27ckIYYAFKegpozZw7atGkDe3t7mJqaQlNTE2ZmZqhRowbmz5+frlv3gAEDMGnSJJQsWTLX8yfkhKGhIY4fP47169ejcePGsLS0hLa2NgoWLAgnJyf4+vpi9+7dGD16tJRm9OjRWLx4Mezt7aGtrY1ChQqhd+/eOH36NIyMjDLMKzvb1qRJE2zfvh1OTk7Q0dGBlZUVevfujcDAQJWTg+aEpqYm/vnnH+zduxctW7ZEkSJFoK2tDTMzMzg4OKBjx47YtGkT5s+f/1n5fA0jRozA5s2bUbVqVejp6aFgwYLo0aMHzp8/n25S6uHDh+P8+fPw8vKCjY0NdHR0YGBgAEdHR4wePRo3b96UhjbLqayOqbm5Oc6dO4c2bdrAxMQE+vr6cHV1xa5du77IcD/Vq1fHrVu3MGHCBFStWhUmJibSOdqkSRNZr6bv6XzIKyVKlMCFCxewZ88eeHl5oVSpUjA0NIS+vj5KlSqFpk2bYvny5ZgwYUKW6ypdujTOnDmDxo0bw8DAAEZGRqhTpw5OnDiBhg0bqkxTs2ZN/PHHH2jWrBlKlSoFY2NjaGlpwdLSEg0aNMDatWtlPSWmT5+Ofv36oWrVqihUqBC0tbVhYGCAcuXKoX///rhy5UqeTGqb16ZPn44VK1agYsWK0NHRQeHChTFw4ECcOHFCNva6cm+STp06Ydu2bXBycoK2tjYsLCzQsWNHXLx4UTY/Q17kBaT8Nl++fBk9e/ZE6dKloaenB0NDQ5QpUwZNmzbF/PnzcebMmTzbJ6pYW1sjMDAQCxcuRJ06dWBubg4tLS0UKlQIVatWxS+//IIjR47IhjzKLV1dXRw6dAiNGjWCiYlJrtYxYMAAaZjKTZs25clwczNnzsTp06fRqVMnFC9eHLq6ujAxMUG5cuXQsmVLrFy5UjbUTc2aNXHkyBG4u7tDV1cXpqam8PT0xPnz56Xhn7LL0NAQBw8elJ7o/vjxI1q2bIlLly7lOp9+/fph165dcHFxga6urtTD4cKFC7KJgdOej23btsXNmzcxePBgVKhQAYaGhtDT00PJkiVRr149aTLlnMrNNc/Y2Bj+/v5Yvnw56tSpAzMzM2hpacHCwgINGjTAunXrcODAAdmwQXmtZs2auH37NsaOHYvKlSvD2NgYOjo6KF68OGrUqIHx48enu/4VLFgQ58+fx/Lly1G/fn1YWFhAS0sL5ubmqF69ujSUZ6rs1NnKlSuHGzduYNq0aahevTpMTU2hra2NokWLonr16hg+fLhsUm0gZZ9fvHgRHTp0QIECBaCvr4+ffvoJ+/fvz7ReoDy8aNp58DIza9YsdOrUCWXLloWZmRk0NTVhaGiIcuXKwdvbG8eOHcP69evTzaFTunRpXL9+HWPHjkX58uWhr68PQ0NDVK5cGdOnT8eFCxfS1beUDR06FG/evMGECRNQqlQpWVj79u2xbds2VK5cGTExMdDT00ObNm2kHgpZyclv39euh2WHnp4eTp06haFDh6Jo0aLQ0dFBuXLlsHDhwhzVuXLzPQAgG441o/m6iIi+ZwqRF7VUIiIiogw8evQIJUqUkD6fOnVKGluciL4t8fHx0vBYyg4cOCAbbz0gICBXc9fkV16UMlzKmjVrAAA7duzI1ZB937OMzsfg4GC4uLhIQ5Vu2rRJGj+fCAA8PT3h5+cHDQ0NBAYG5voBDMofkyZNwuTJkwGkDH+Z0Zw4X9rTp09RqlQpJCQkSEM2fo0Hx4iI1AmvekRERERElC3/+9//EBwcjBYtWqBEiRJITExEUFAQli5dKsVxcXGRTSD9LeRFKZMob9++HbGxsZg6dSratGmT7knvH9mKFSuwYcMGtGvXDqVKlYKmpiZu3ryJRYsWSY0YxYoVy/M5wejblpSUhICAAABAnz592IhBuTZz5kxpPr/Zs2ezEYOIfki88hERERERUbYIIeDv7y+bGFhZ6dKlsX379jy5Af418yKgcOHCsiG7SE4IgStXrkiTKKdlbW2NvXv3quy1QT+ua9euISYmBgULFsS0adPyuzj0DVuwYAEWLFiQ38UgIspXbMggIiIiIqJsadWqFV68eIFLly4hMjISHz58QIECBeDg4IDWrVujV69eMDAw+ObyIspK3bp14evri/Pnz+PFixeIjY2V5vxo1qwZfvnlF5ibm+d3MUnNuLi45MmcM0RERMQ5MoiIiIiIiIiIiIiISI1p5HcBiIiIiIiIiIiIiIiIMsKGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIjV16NAhuLu7w8zMDAqFAgqFAvPmzYO/v7/02c7OLr+LmWN///23VP5jx47ld3EoG+rWrSsds7Vr1361fJXPlZMnT361fImIiCh7vtf6ateuXaFQKGBsbIw3b97kd3G+O2vXrpXOj7p16361fN++fQsTExMoFAp4e3t/tXyJKG+wIYOIiH54ycnJ2Lt3Lzp06AA7OzsYGBjA1NQUFStWhI+PDw4cOAAhxFct07Vr1/Dzzz/jwoULiIqK+qp5q9KkSRPpz4ZCoUCLFi1ytZ64uDhMmDABAODq6opGjRqli6OOx+N7N2nSJOmlDudbKm9vbxQrVgwAMGLECB53IiL6Yalj/Ugd6qt2dnayOqpCoYCWlhYsLCzg5uaGadOmIS4uLkfrvHLlCv755x8AwC+//AJzc3OV8aZPny7Lt2DBgkhISPjsbaIvx8zMDP369QMAbNy4EdeuXcvnEhFRTigE/xESEdEP7MWLF+jQoQPOnDmTaby3b9+iQIECX6dQACZOnIjff/8dQMoN/+nTp0NXVxclS5aEoaEhbt68CQDQ09ODi4vLFy3Lf//9h+LFiyM5OVlapqWlhadPn8La2jpH65o7dy6GDRsGAFi3bl26J6HU9Xh87xQKhfQ+LCws3ZOTN2/eRHR0NADA3t4eVlZWX61sU6ZMkRq/9uzZg5YtW361vImIiNSButaP1KG+amdnh8ePH2ca56effsLZs2ehqamZrXW2bNkS+/btg0KhQFhYGGxtbVXGK1euHO7duydbtmPHDrRt2zZ7hf+BvXz5Evfv3wcAmJqawtHR8avlHR4eDjs7Owgh0KpVK+zevfur5U1En0crvwtARESUX+Lj49GkSRNcv34dAKChoQFfX180b94cpqamePLkCfz8/LBr166vXrYnT55I7z08PNCgQQNZeM2aNb9aWdavXy9rxACAxMREbNy4EcOHD8/2eoQQWLZsGQBAX18frVu3loWr8/HID58+fYIQAjo6OvldlK/65zKtzp07Sw0Zy5YtY0MGERH9UNS5fqRO9VUA6N69O3r06IGEhARs2rQJq1evBgBcuHABAQEBqF27dpbrePLkCQ4ePAgAcHd3z7AR48KFC+kaMYCUIZPUsSEjOTkZHz9+hL6+fn4XBQBgZWX1VR+MUVa8eHG4u7sjICAABw4cwH///YeiRYvmS1mIKIcEERHRD2r69OkCgPTavHmzynj37t0THz9+lD4nJyeLDRs2iPr16wtzc3Ohra0tLC0thaenp9i/f3+69La2tlIex44dEzNnzhRlypQROjo6ws7OTsyaNUuKe+rUKVmZ0r7CwsJkcWxtbWV5xcfHi7Fjx4pixYoJXV1dUalSJbFu3TqxZs0aKU2dOnVytJ/Kli0rpe3evbv03sHBIUfruXz5spS2SZMm6cLV8Xik+ueff0SdOnWEubm50NTUFGZmZqJ8+fLCy8tLHDp0SBY3MTFRLFu2TNSsWVMUKFBAaGtri+LFi4tevXqJhw8fyuKGhYXJtjkiIkL4+PgIS0tLoVAoxIwZM6SwUqVKpSvXL7/8IoUPGzZMCCFEUFCQ6Nq1q3B0dBSWlpZCW1tbGBoaiooVK4rhw4eLyMhIKb2Pj0+m59uaNWuEEELUqVMn3bJOnTpJy6ZMmSIr18ePH0WBAgWk8OvXr0thd+7cET179hQlSpQQurq6wtjYWLi7u4s1a9aI5ORkVYdc2NvbCwBCQ0NDvH79WmUcIiKi75E61o/Uqb6qXO6JEydKy9+9e5et/ZbW7NmzpTTTp0/PMF6fPn2keN26dROampoCgNDS0hLPnz9XmWb//v3CxcVF6OrqikKFComBAweKqKiodPtO2erVq0XFihWFjo6OKF68uBg3bpy4e/euLI0y5eXXr18XgwcPFkWKFBEaGhpi9+7dUrwjR46In3/+WVhbWwttbW1RsGBB0aJFC3HmzJl05Q4MDBStW7cWhQsXFtra2sLIyEjY2dmJFi1aiAULFsjiZrfOrOpYHz58OMf1XiGEiIuLE3/++adwdXUVxsbGQkdHR5QuXVoMHTpUvHz5UuWxmDZtmrSuefPmqYxDROqHDRlERPTDUr5B36BBg2ylSUpKEu3atcv0z9vQoUNlaZT/YJUpU0Zlmk2bNgkhPu+PYXJysmjatKnKdFWrVs1VQ8b58+eldAULFhTv3r2T3aC+fPlyttel/MdwwoQJ6cLV8XgIIcTatWszXX/fvn2luO/fvxf16tXLMG6BAgXEpUuXpPhpGzLSlufKlSuiePHi0ueLFy9KaT99+iQKFiwohd26dUsIIcTSpUszLW+JEiXE27dvhRCf15Bx/PhxaVm5cuVk+3j37t1SmKurq2y5np5ehvl16dJFZWNGt27dpDjKf8KJiIi+d+pYP1Kn+qqqhoyEhASxcuVK2bpv376drfU1b95cSnPy5EmVceLj42X14eDgYNk2zZ49O12aTZs2CYVCkek2p+67VMo32zNLoyyzemVqHWr06NEZHjsNDQ2xdOlSaX13794Vurq6GcYvW7asFDcndWZVDRlJSUk5rvdGRkYKBweHDPMsWrRougeJhBDixIkTUpyWLVuqPhmISO1wsm8iIvohxcXFybqDq5p0WpUlS5Zgx44dAFLmiZg4cSL8/Pzw66+/SnHmzp2LAwcOqEz/8OFDTJw4EQcOHJB1b1+wYAEAoHLlyjh79iw8PDyksO7du+Ps2bM4e/YsChcunGHZ/vnnHxw+fFj6/Ouvv+LQoUMYMWIErl69mq3tS2vt2rXS+44dO8LIyAjt2rVTGZ6V1HGSgZR5FpSp6/EAgO3bt0vvJ06ciBMnTmDPnj1YsGABWrZsCWNjYyl80qRJOHXqFACgRIkSWLNmDY4cOYK+ffsCAKKiotC5c2d8+vRJZXnCw8Px+++/48iRI1ixYgWsrKzQvXt3KXzTpk3S+yNHjuDVq1cAADc3N1SsWBEAUKlSJcyePRu7du3CsWPH4O/vj927d6NJkyYAUubA+PvvvwEAv/32G86ePSsrw/bt26XzzdPTU2U5AaB+/fooUaIEAODu3buyc0y5nD179gQAREZGolu3bvjw4QMAoF+/fjh8+DDWr1+P4sWLS+nWrFmTLq+yZctK72/cuJFhmYiIiL4n6lo/Urf6aqrJkydDoVBAR0cHvXv3BgBoa2tjxowZqFChQrbWkVl9NdXu3bulyc0rVqwIJycndO3aVQpPWz+OjY3FgAEDpMnYXVxcsGvXLqxduxbPnj1Tmcfjx4+loTUBoEmTJti3bx8WLVqE0NDQbG3LgwcPMHz4cPj5+WHDhg0oVaoU/Pz88OeffwJIGep15syZOHbsGGbPng1dXV0kJydj0KBB0vwV+/fvx8ePHwEA7dq1w+HDh+Hn54e///4bPXr0kA3JlJM6syoaGho5rvcOGDAAt27dAgA4Oztjy5Yt8PPzQ5s2bQCkzPXn4+OTLi/WLYm+UfndkkJERJQfnj59KntaZ+XKldlKV6VKFSnNL7/8Igvz9PSUwtq2bSstV35SbMCAAdLyCxcuSMvNzc1l61J+Ul65m7wQIsMn3Fq0aCEtb9q0qSxN69atc/yEW9qnzS5cuCCEEMLf319aZmFhIRvGIDPK+8fPz08Wps7Hw8vLS1q+devWDLuoJycnC0tLSynuX3/9Jc6ePSu9ChcuLIUdPnxYCJG+R0ba7vlCCPHo0SOhoaEhAAgrKyvx6dMnIYQQnTt3Vrm/Pn36JBYuXChq1qwpdetXzgOAaNOmjSwP5bC0QxoIobpHhhBC/P7779Ly1C7+0dHRUq8LAwMDER0dLYQQYuHChVJcBwcH2b757bffpDA3N7d0+S9ZskQK79+/v8r9T0RE9L1R5/qREOpRX1Uut6qXkZGR+O2330RSUlK21mdgYCCljY+PVxmncePGUpzU4afi4uKEkZGRtFy51/LOnTul5VpaWuLJkydS2N69e1XWw+bMmSOrb8fFxUlp5s+fL0ujTHm58vBLqdq2bSuFd+vWTVYfUz43xowZI4QQYsWKFdKykSNHikePHmW4L7NbZxZCdY8MIXJW73379q2snvvPP/9I23Lq1Cmhra0thd29e1eW//v376UwAwODDMtJROqFPTKIiOiHVKBAAdnn169fZytdSEiI9D7tBIbKT6wpx1NWv3596X3BggWl92/evMlW/plRfjqrVq1asrA6derkeH3KT5uVLFkSbm5uAFK2M3Xiw9evX2P//v3ZWp/4/0+hpX0PqPfx6Nu3LzQ1NQGk9EqxsrKCmZkZatWqhalTp+Lt27cAUnocREZGSumGDRuGWrVqSa+IiAgp7Pbt2yrLo2pySFtbW2nyzJcvX+L48eOIjY3F3r17AQCGhobo2LGjFL9Hjx4YNGgQzp07hzdv3iApKSndOlPL/Lm6d+8ODY2U6uSWLVuQnJyMnTt3Sr0u2rVrBxMTEwDAnTt3pHS3bt2S7Zs//vhDClO1b5TPF4VCkSdlJyIiUnfqXD/KrbyurypL7RXi7++PxYsXw8zMDLGxsfjjjz8wZcqUHK8vbX0VSHnC//jx4wBS6iSdO3cGABgYGKB169ZSPOVeGcrbXKJECRQrVkz6nNE2K6epUqUKDAwMskyTlqp6pXJ9bMOGDbL62KFDh6Sw1PpYq1atUKRIEQDArFmzYGdnB0NDQzg7O+PXX3+V9RjKbp05Mzmp996/f19Wz/Xy8pK2pV69erIe0Gnrl6xbEn2b2JBBREQ/JENDQ1mX4tQ/JJ9D1Z+dtMzNzaX3Wlpan51nRtJWyLNTtrSU/4A9fPgQCoUCCoUCGhoaePz4scp4mbGyspLep/0jrM7Ho3bt2rh27ZrUMFGoUCFERUXh3LlzGD9+PJo0aaKysSAz7969U7k8o6EYUodnAlK62e/Zswfv378HkPJHMbWr/n///YcNGzZIcQcPHowjR47g7NmzGDVqlLQ8OTk5R+XNSLFixdC4cWMAwLNnz3Dq1CnZMAC9evXK8TpV7Rvl88XS0jIXJSUiIvr2qHP9KC/kRX1VWfHixVGzZk3UqVMH/fv3x8iRI6WwVatWZWsdyvUMVQ0369evl+pRQgjY2dlJdWTlOtjmzZuRkJCQLn1ubprndj9lNsRXVlLrY5aWlrh69Sr++OMPNG3aFCVKlEBCQgKuX7+OBQsWwM3NDU+ePAGQd3Xm7NZ7c7M9qVi3JPo2sSGDiIh+WL6+vtL748ePy8Z1VXb//n3pj0j58uWl5QEBAbJ4586dk96XK1cuD0uaPcrj+J4/f14WdubMmRytS/lps6wcPnwYL168yDKeo6Oj9F756a1U6no8hBBwdHTEnDlzcObMGURERODZs2ews7MDAAQFBSE0NBSWlpaypxaPHDkCIUS6V0xMDCZOnKgyr4z+3LZu3RoWFhYAgD179mDlypVSmPKfvdQ/kkDKTYj58+ejcePGqFmzZqbHSDnfnDZyKDdWzJ49W5ojpEyZMrInLZWPlbu7u8p9k7p/0lI+X5TPIyIiou+dutaPcisv66tZUb7hr9xrNjNZ1VfXrVuXrfUo91pW3uawsDA8f/5c+nz69GmV6ZXTXL16VertCmR/P6mqVyqfG2PHjlVZF/v06ZPUO0MIAWtra/zvf/+Dn58fHj58iJiYGKn3SVRUFA4ePCjFzU6dOSvZrffa29tLPUCAlOOVUd0y7TwZrFsSfZu+XNM6ERGRmvv111+xZcsWXL9+HQDQuXNnHD16FM2bN4eJiQmePHkCPz8/7Ny5Ey9fvoSOjg66d+8uTUS4cuVKFCpUCK6urjh69KhUiQcgm6jua+nYsSP27dsHADh48CBGjhyJBg0a4OTJk9izZ0+O1qX8tFmZMmUwePDgdHHmzp2Lhw8fIjExERs3bsTw4cMzXWfdunWl94GBgenC1fV4DBkyBP/++y8aN24MGxsbmJmZITQ0VPaH+MOHD1AoFOjevTtmzZoFAPD29saYMWPg4OCAuLg4hIeH4+TJkzh8+DDi4+NzVAYdHR107doV8+fPR2xsrPQHtly5cnB3d5filSxZUnr/5s0b/P7773Bzc8ORI0ewfv36DNdvYWEhTaC4bNkyNG/eHBoaGqhWrRp0dHQyLdvPP/8MS0tLREZGyibvVP6jCaScn//73/8QGxuL8+fPo127dvDy8oKpqSn+++8/hISEYNeuXejcuTMmTZokS5t6vigUCtmQGERERN87da0f5VZe1lfTCg8Px7lz55CUlISQkBDMmTNHClO+gZ+ZunXrSpOgBwYGyobZunDhgnQDXFNTE3PmzJHdSAeAAwcO4MiRIwBSei23bdsWjRs3hpmZGd6+fYtPnz6hTZs2GD16NKKiojB27FiV5Wjbti1GjRqFxMREvHr1Cu3bt0e/fv3w6NEjjB8/Pvs7JY2ePXti165dAFKGikpKSkKdOnWgoaGBJ0+e4PLly9i1axe2b9+OunXrYtu2bZgzZw5+/vlnlC5dGtbW1nj9+rVsWLLURpbs1pmzkt16b4ECBdCmTRupcc/T0xMjR45E6dKlERUVhcePH+PIkSN4+PBhugYU5f8inzukGRF9RV90Bg4iIiI1FxERIWrXrp3pJIEAxNu3b4UQQiQmJsomyVP1GjJkiCwP5UkIT506JS1PO9GzstxMnpicnCyaNm2qskyVK1fO0eSJZcuWleL//vvvKuMoT9Ds4OCQ5TqTk5OFvb29ACD09fVFTExMujjqeDz69u2b6fqrVKkiTXr4/v17Ubdu3SzLn1Weqty4cSPdembNmpUunvJEi8qvevXqZXgOKE+gqPxKnYwyo8m+Uw0bNkyWTktLS0RERKSLt2vXLmki8Ixeac/30NBQKaxRo0aZ7iMiIqLvkTrWj4TI//pq2nJn9NLW1hZ+fn7ZWl94eLg0gXSNGjVkYX369JHWWb9+fZXpjx07JqsPPX/+XAghxMaNG4VCoch0m4H/m+xbCCGmTZuW5X5Ke0wyWpeyUaNGZbnPUs+BzZs3ZxrPxMREPH78WAiRszpzRpN9p8puvffly5fCwcEh03yVz79UNWrUEACEpqamCA8PV7mfiEj9cGgpIiL6oRUqVAinTp3C7t270a5dOxQvXhx6enowMjJC2bJl4eXlhb1798LU1BRAytNX27dvx/r161GvXj2YmZlBS0sLBQsWhIeHB/bt24e5c+fmy7YoFArs3r0bY8aMQdGiRaGjo4OKFSti9erV8Pb2luIZGhpmup6LFy/Kulu3a9dOZTzlCQRv3bqFK1euZFm+vn37AgDi4+Oxe/fudHHU8Xh4eXmhd+/eqFSpEgoWLAgtLS0YGBjAwcEBo0ePxokTJ6QJr/X19XH8+HGsWLECdevWhbm5ObS0tGBtbY2qVati6NCh0tBLOeXo6AhXV1fps7a2tuy4plq5ciVGjBgBW1tb6OnpwdnZGVu3blUZN9X8+fPRsWNHmJub52rs5rS9Lzw9PVGoUKF08Vq3bo1r166hT58+KF26NPT09GBoaIjSpUujefPmWLZsGfr37y9Ls3nzZun9L7/8kuOyERERfevUsX6UW3lVX82Krq4uSpYsiW7duuHixYto2rRpttLZ2NjA09MTQMrQV6nzwn348AHbtm2T4mVUP65bt640LFJqr2UA6NKlC/bu3QsXFxfo6urCysoK/fr1w86dO2Xplbd77NixWLVqFSpUqAAdHR0UK1YMY8eOxZIlS6Q4ypOAZ9eff/6Jo0ePonXr1ihcuDC0tbVhZmaGChUqwNvbGzt27ICbmxsAoHr16hgxYgTc3d1RuHBh6OjoQEdHB3Z2dvDx8cGlS5dQvHhxADmrM2clu/VeS0tLBAYGYvbs2XBzc4OpqSm0tbVRpEgRuLm54bfffku3j8PDw6VhzZo1awYbG5sc70Miyh8KIT5zNiUiIiJSG0IIlTeiW7duLXXXHzZsmKyr/dcUFxeHMmXKICIiAq6uriqHmCJKlZCQgFKlSuHp06dwdnbGlStXsv0HmIiIiNSTutdXr1y5AldXVwghMHLkSMycOfOz15nRNu/duxetWrUCkDLUZ2RkpBQvozTz58/HkCFDAABVqlTJ8mEikhs1ahRmzZoFhUKBoKAgVK1aNb+LRETZxDkyiIiIviMDBw6ElZUVGjZsCFtbW0RGRmLDhg3Sn0KFQoFu3brlW/kMDQ0xZcoU9OrVC0FBQTh69CgaN26cb+Uh9bZhwwY8ffoUQMpE4mzEICIi+vape321atWq6NKlCzZu3IilS5dizJgxMDc3/6x1Hjt2DH///Te6deuG8uXLQwiBixcvYvTo0VIcb29vWcPF6tWrcfHiRbRr1w729vb48OEDTp48iQkTJkhx0k5iTZmLiorCsmXLAKT0kmEjBtG3hT0yiIiIviOdOnXC1q1bVYZpaGhgzpw50hNcRERERERf249YXz18+DA8PDwyDK9Vqxb8/PxkQ0stW7Ys02E127dvj82bN6ebcJyI6HvFHhlERETfkTZt2iAqKgq3bt3Cq1evoFAoULRoUdSsWRMDBgyQjTVLRERERPS1/Yj1VXt7e3h7e+PSpUuIiIjA+/fvYWZmBicnJ3Tq1Am+vr7pGiSqVauGDh064PLly3jx4gUSEhJQsGBBVK1aFd7e3mjfvn0+bQ0RUf5gjwwiIiIiIiIiIiIiIlJbHGiYiIiIiIiIiIiIiIjUFhsyiL4jQgjExMSAHa2IiIiI6GtiPZSIiIiIviQ2ZBB9R969ewdTU1O8e/cuv4tCRERERD8Q1kOJiIiI6EtiQwYREREREREREREREaktNmQQEREREREREREREZHaYkMGERERERERERERERGpLTZkEBERERERERERERGR2mJDBhERERERERERERERqS02ZBARERERERERERERkdpiQwYREREREREREREREaktNmQQEREREREREREREZHaYkMGERERERERERERERGpLTZkEBERERERERERERGR2mJDBhERERERERERERERqS02ZBARERERERERERERkdpiQwYREREREREREREREaktNmQQEREREREREREREZHaYkMGERERERERERERERGpLTZkEBERERERERERERGR2mJDBhERERERERERERERqS02ZBARERERERERERERkdpiQwYREREREREREREREaktNmQQEREREREREREREZHaYkMGERERERERERERERGpLTZkEBERERERERERERGR2mJDBhERERERERERERERqS02ZBARERERERERERERkdpiQwYREREREREREREREaktNmQQEREREREREREREZHaYkMGERERERERERERERGpLTZkEBERERERERERERGR2mJDBhERERERERERERERqS02ZBARERERERERERERkdrSyu8CEFHeG7DiLHT0DfO7GEREREQEYNWAuvldhK9nQxVAXzO/S0FEREREANDjXn6XIM+wRwYREREREREREREREaktNmQQEREREREREREREZHaYkMGERERERERERERERGpLTZkEBERERERERERERGR2mJDBhERERERERERERERqS02ZBARERERERERERERkdpiQ4Yas7Ozw7x5875afgqFAnv27Mkw/NGjR1AoFAgODgYA+Pv7Q6FQICoq6quUj4iIiIjoe9S4cWNUqlQJzs7OqFWrllTffvnyJZo2bYoyZcrAwcEB586dk6VbsmQJypcvDwcHB1SqVAkfPnwAACxYsEBa5uzsjK1bt37tTSIiIiKib4CdnR3KlSsHZ2dnWb2xe/fuUl3S1dUVJ06ckNL89ttvcHR0TJcGACZNmgQrKysprEuXLrL8Tp8+DVdXV1SsWBHlypXDhQsXsl1Wrc/cVvqBubu7IyIiAqampgCAtWvXYsiQIWrVsKGOZcoOf39/1KtXD2/fvkWBAgXyuzhERERE9AVt27ZNqvPt2bMHPXr0wNWrVzFmzBi4ubnh8OHDCAoKQrt27fDgwQNoaWlh79692LRpEy5evAhTU1O8fPkS2traAICKFSsiICAApqamePLkCapUqQI3NzfY2trm41YSERERkTrasWMHHBwcZMvmzp0r1U+Dg4PRsGFDREZGQqFQYOTIkfjjjz8AAM+ePUO5cuXQuHFjmJmZAQC8vb0xe/bsdPk8e/YMPj4+8PPzQ/ny5fHhwwfpQZzsYEPGd+bTp0/SH5gvTUdHB4UKFfoqeRERERERfa+UH1yJjo6GhkZKx/lt27YhLCwMAODq6gpra2ucO3cOdevWxaxZszB58mTpoSIrKytpHQ0aNJDe29jYwNraGk+ePGFDBhERERFli3L9NCoqCgqFQmXYu3fvoFAokJycnOU6lyxZgq5du6J8+fIAAD09Pejp6WW7TBxa6gvbsWMHHB0doa+vDwsLCzRs2BBxcXGoW7cuhgwZIovbqlUr+Pr6ypa9e/cOXl5eMDIyQpEiRbBw4UJZuEKhwLJly9CyZUsYGhpi6tSpAID9+/ejatWq0NPTQ8mSJTF58mQkJiZK6UJDQ1G7dm3o6emhQoUKOHbsWLqyBwYGonLlytDT04OLiwuuXbsmC1ceWsrf3x/du3dHdHQ0FAoFFAoFJk2alOX+sbOzw5QpUzLdxvDwcLRs2RJGRkYwMTFBhw4d8OLFCyn8+vXrqFevHoyNjWFiYoKqVavi8uXLuS7Tx48fMWrUKNjY2EBXVxdlypTBqlWrpPDTp0+jWrVq0NXVReHChTFmzBjZvlU1JJizs7Msb4VCgb///hutW7eGgYEBypQpg3379gFIGcKrXr16AAAzMzMoFIp054VyWWNiYmQvIiIiIvr2eHt7w8bGBuPGjcO6devw+vVrJCcnw9LSUopjZ2eH8PBwAMCdO3dw+fJl1KhRAy4uLliwYIHK9R4/fhxv375F1apV87S8rIcSERERfR+6dOkCR0dH9OrVC5GRkdLyMWPGoFSpUmjTpg22b98ua8xYsGABypYtiypVqmDFihWwsLCQwjZv3gwnJyfUr18fp06dkpbfuXMH8fHxaNiwIZydnTFo0CC8f/8+2+VkQ8YXFBERgc6dO6NHjx4ICQmBv78/2rRpAyFEttcxa9YsVKpUCVevXsXYsWMxdOjQdI0OEydORMuWLXHz5k306NEDR44cQdeuXTF48GDcuXMHy5cvx9q1a6UuP8nJyWjTpg00NTVx8eJFLFu2DKNHj5atMy4uDs2bN0fZsmVx5coVTJo0CSNGjMiwnO7u7pg3bx5MTEwQERGBiIiITONndxuFEGjVqhXevHmD06dP49ixY3jw4AE6duwope/SpQuKFSuGoKAgXLlyBWPGjIG2tnauy+Tt7Y0tW7ZgwYIFCAkJwbJly2BkZAQA+O+//+Dp6QlXV1dcv34dS5cuxapVq6QGpJyYPHkyOnTogBs3bsDT0xNdunTBmzdvYGNjg507dwIA7t27h4iICMyfP1/lOqZPnw5TU1PpZWNjk+NyEBEREVH+W79+PZ48eYKpU6di5MiRACD7swhA9j8iMTERDx48wJkzZ3D06FGsXLkShw4dksW/efMmunfvjq1bt0JfXz9Py8t6KBEREdG378yZM7h+/TquXr0KCwsL+Pj4SGEzZszAgwcPsG3bNowcORIJCQlS2ODBg3Hv3j2cP38eU6dOxevXrwEA/fr1w6NHj3D9+nVMmTIFHTt2xOPHjwGkjCTk7++P7du34/Lly4iOjs7WQ+epOLTUFxQREYHExES0adNG6sbt6OiYo3XUqFEDY8aMAQDY29sjICAAc+fORaNGjaQ4Xl5e6NGjh/S5W7duGDNmjHTilSxZElOmTMGoUaMwceJEHD9+HCEhIXj06BGKFSsGAJg2bRo8PDykdWzatAlJSUlYvXo1DAwMULFiRTx9+hS//PKLynLq6OjA1NQUCoUix8NNZbaNx48fx40bNxAWFib9OdqwYQMqVqyIoKAguLq6Ijw8HCNHjkS5cuUAAGXKlJHWndMy3b9/H9u2bcOxY8fQsGFDaf+lWrJkCWxsbLBo0SIoFAqUK1cOz549w+jRozFhwgRpGIDs8PX1RefOnQGk7P+FCxciMDAQTZs2hbm5OYCUIQIymyNj7NixGDZsmPQ5JiaGfyKJiIiIvmE+Pj7o16+f9DkyMlLqlfH48WMUL14cAFC8eHF07twZmpqaMDc3h4eHBwIDA+Hp6Qkg5Ym35s2bY/Xq1ahZs2ael5P1UCIiIqJvX2rdUltbG0OGDIG9vX26OA0bNsTAgQNx8+bNdL18nZycULRoUfj7+6Nt27aye7A1atRA5cqVcfnyZdja2sLW1haVK1eW5tLo1KkTZs6cme2yskfGF+Tk5IQGDRrA0dER7du3x8qVK/H27dscreOnn35K9zkkJES2zMXFRfb5ypUr+P3332FkZCS9evfujYiICLx//x4hISEoXry41IihKp+QkBA4OTnBwMAgwzh5JbNtDAkJgY2NjexPUYUKFVCgQAEpzrBhw9CrVy80bNhQainMreDgYGhqaqJOnToqw0NCQvDTTz/Jno6rUaMGYmNj8fTp0xzlValSJem9oaEhjI2N8fLlyxytQ1dXFyYmJrIXEREREX07YmJi8OzZM+nz7t27YWFhAXNzc7Rv3x6LFy8GAAQFBeH58+dSo4SXlxcOHz4MAPjw4QNOnz4NJycnACl1Vk9PT6xYsUL2AFReYj2UiIiI6NsWFxeHqKgo6fPmzZtRuXJlJCYmIjQ0VFoeGBiIly9fSg97K9+bfvDgAa5du4YKFSoAgOz+aGhoKIKDg6UH+728vHDq1Cl8/PgRAHD48GGp/pod7JHxBWlqauLYsWM4f/48jh49ioULF+K3337DpUuXoKGhkW6IqU+fPmVrvWm7mBsaGso+JycnY/LkyWjTpk26tHp6eiqHtsqs23p+SC2PECJd2dIunzRpEry8vHDw4EH4+flh4sSJ2LJlC1q3bp3jfLPqcq+qPKn7KnV5do9t2knZszsxDhERERF9P6Kjo9G2bVvEx8dDQ0MDlpaWOHDgABQKBf78809069YNZcqUgY6ODjZs2AAtrZS/cEOHDkXfvn1RoUIFKBQKtG/fXqr/Dh48GNHR0Rg9erQ0hOyff/6JJk2a5Nt2EhEREZF6efHiBdq2bYukpCQIIVCyZEmsX78eSUlJ8PX1RXR0NDQ1NWFoaIgdO3ZIPSnGjBmDf//9F9ra2tDS0sKiRYukCbx/++03XLlyBVpaWtDU1MTixYulXh7u7u5o0aIFnJ2doaWlBQcHByxbtizb5WVDxhemUChQo0YN1KhRAxMmTICtrS12794NS0tLRERESPGSkpJw69YtaZLnVBcvXkz3OXUIpYxUqVIF9+7dQ+nSpVWGV6hQAeHh4Xj27BmKFCkCALhw4UK6OBs2bEB8fLx0cz9tWdLS0dFBUlJSpnFUyWwbU8v65MkTqVfGnTt3EB0dLX1BgJQhqezt7TF06FB07twZa9asQevWrXNcJkdHRyQnJ+P06dPS0FLKKlSogJ07d8oaNM6fPw9jY2MULVoUANId25iYGISFhWW7DEDKvgSQq/1JRERERN8OGxsbBAYGqgyztrbG0aNHVYbp6+tj/fr1KsPSzqlHRERERJRWyZIlce3aNZVhAQEBGabbu3dvhmHr1q3LNM9Ro0Zh1KhR2StgGhxa6gu6dOkSpk2bhsuXLyM8PBy7du1CZGQkypcvj/r16+PgwYM4ePAg7t69i/79+8u68qQKCAjAzJkzcf/+fSxevBjbt2/Hr7/+mmm+EyZMwPr16zFp0iTcvn0bISEh2Lp1K8aNGwcgZVyzsmXLwtvbG9evX8fZs2fx22+/ydbh5eUFDQ0N9OzZE3fu3MGhQ4cwe/bsTPO1s7NDbGwsTpw4gVevXmV71vnMtrFhw4aoVKkSunTpgqtXryIwMBDe3t6oU6cOXFxcEB8fj4EDB8Lf3x+PHz9GQEAAgoKCpEaOnJbJzs4OPj4+6NGjB/bs2YOwsDD4+/tj27ZtAID+/fvjyZMnGDRoEO7evYu9e/di4sSJGDZsmDQ/Rv369bFhwwacPXsWt27dgo+PDzQ1NbO1L1LZ2tpCoVDgwIEDiIyMRGxsbI7SExEREREREREREX0v2JDxBZmYmODMmTPw9PSEvb09xo0bhzlz5sDDwwM9evSAj4+PdFO+RIkS6XpjAMDw4cNx5coVVK5cGVOmTMGcOXOy7BLepEkTHDhwAMeOHYOrqyvc3Nzw119/SROOa2hoYPfu3fj48SOqVauGXr164Y8//pCtw8jICPv378edO3dQuXJl/Pbbb/jzzz8zzdfd3R39+vVDx44dYWlpme3JWjLbRoVCgT179sDMzAy1a9dGw4YNUbJkSWzduhVAyvBdr1+/hre3N+zt7dGhQwd4eHhg8uTJuS7T0qVL0a5dO/Tv3x/lypVD7969ERcXBwAoWrQoDh06hMDAQDg5OaFfv37o2bOn1EgEpEx8WLt2bTRv3hyenp5o1aoVSpUqla19kapo0aKYPHkyxowZA2trawwcODBH6YmIiIiIiIiIiIi+FwqR35Mh0A/Nzs4OQ4YMwZAhQ/K7KN+FmJgYmJqaouusA9DRN8w6ARERERF9casG1M3vInxxqfXQ6EWlYKKfs97IRERERPSF9LiX3yXIM+yRQUREREREREREREREaosNGfTFnD17FkZGRhm+WCYiIiIiIiIiIiIiyopWfheAvl8uLi4IDg7ONM6jR4++SllSZadMRERERERERERERKQ+2JBBX4y+vj5Kly6d38WQUccyEREREREREREREVHGONk30XdEmmQxOhomJib5XRwiIiIi+kGwHkpEREREXxLnyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitaWV3wUgorw3YMVZ6Ogb5ncxiOgHsWpA3fwuAhERqYsNVQB9zfwuBRERUYoe9/K7BESUR9gjg4iIiIiIiIiIiIiI1BYbMoiIiIiIiIiIiIiISG2xIYOIiIiIiIiIiIiIiNQWGzKIiIiIiIiIiIiIiEhtsSGDiIiIiIiIiIiIiIjUFhsyiIiIiIiIiIiIiIhIbbEhgwAAdnZ2mDdvXn4Xg4iIiIiIiIiIiIhIhg0ZP5i1a9eiQIEC+V2Mr+Zb3V5/f38oFApERUXld1GIiD7b4MGDYWdnB4VCgVu3bqULX7duHRQKBQ4cOCAt+9///ofy5cvDyckJ1apVw8mTJ6WwBQsWwMHBAZUqVYKzszO2bt36VbaDiIiIiIi+L40bN5b+V9SqVQvBwcEAACEEJk2aBHt7ezg4OKBu3bqydEuWLEH58uWl/yUfPnwAAEyaNAlWVlZwdnaGs7MzunTpki7PyMhIWFtbo127dl9684i+K1r5XQD6fiUkJEBHRye/i0FERPmsXbt2GDVqFGrWrJku7OnTp1i+fDnc3Nxky2vVqoXx48dDX18f169fR926dREREQE9PT1UrFgRAQEBMDU1xZMnT1ClShW4ubnB1tb2a20SERERERF9B7Zt2yY9ALtnzx706NEDV69exYIFC3Dz5k3cunULOjo6iIiIkNLs3bsXmzZtwsWLF2FqaoqXL19CW1tbCvf29sbs2bMzzLN///7w9PTEu3fvvth2EX2P2CPjG3P48GHUrFkTBQoUgIWFBZo3b44HDx4AUP0Uf3BwMBQKBR49egR/f390794d0dHRUCgUUCgUmDRpkhT3/fv36NGjB4yNjVG8eHGsWLFClvfNmzdRv3596Ovrw8LCAn369EFsbKwU7uvri1atWmH69OkoUqQI7O3ts9weOzs7TJkyBV5eXjAyMkKRIkWwcOFCWZzw8HC0bNkSRkZGMDExQYcOHfDixQsp/Pr166hXrx6MjY1hYmKCqlWr4vLly1lub0Y+fvyIUaNGwcbGBrq6uihTpgxWrVolhZ8+fRrVqlWDrq4uChcujDFjxiAxMVG2TWmH6XJ2dpblrVAo8Pfff6N169YwMDBAmTJlsG/fPgDAo0ePUK9ePQCAmZkZFAoFfH19syw3EZG6ql27NooVK6YyrE+fPpg7dy50dXVlyz08PKCvrw8AcHR0RFJSEl69egUAaNCgAUxNTQEANjY2sLa2xpMnT77gFhARERER0fdIeRSP6OhoaGik3CqdNWsW/vzzT+kB3cKFC0vxZs2ahcmTJ0v/SaysrKCpqZmt/DZt2gRra2vUqVMnj7aA6MfBhoxvTFxcHIYNG4agoCCcOHECGhoaaN26NZKTk7NM6+7ujnnz5sHExAQRERGIiIjAiBEjpPA5c+bAxcUF165dQ//+/fHLL7/g7t27AFIaOZo2bQozMzMEBQVh+/btOH78OAYOHCjL48SJEwgJCcGxY8dkQ4RkZtasWahUqRKuXr2KsWPHYujQoTh27BiAlK58rVq1wps3b3D69GkcO3YMDx48QMeOHaX0Xbp0QbFixRAUFIQrV65gzJgx0NbWznJ7M+Lt7Y0tW7ZgwYIFCAkJwbJly2BkZAQA+O+//+Dp6QlXV1dcv34dS5cuxapVqzB16tRsbauyyZMno0OHDrhx4wY8PT3RpUsXvHnzBjY2Nti5cycA4N69e4iIiMD8+fNVruPjx4+IiYmRvYiIvhVLly5FxYoVUb169UzjrVmzBqVKlVLZGHL8+HG8ffsWVatW/VLFJCIiFVgPJSKi74W3tzdsbGwwbtw4rFu3DjExMYiMjMTu3bvh5uYGNzc32XC2d+7cweXLl1GjRg24uLhgwYIFsvVt3rwZTk5OqF+/Pk6dOiUtf/bsGf766y/MmDHjq20b0feEQ0t9Y9q2bSv7vGrVKlhZWeHOnTtZptXR0YGpqSkUCgUKFSqULtzT0xP9+/cHAIwePRpz586Fv78/ypUrh02bNiE+Ph7r16+HoaEhAGDRokVo0aIF/vzzT1hbWwMADA0N8ffff+doSKkaNWpgzJgxAAB7e3sEBARg7ty5aNSoEY4fP44bN24gLCwMNjY2AIANGzagYsWKCAoKgqurK8LDwzFy5EiUK1cOAFCmTBlp3Zltryr379/Htm3bcOzYMTRs2BAAULJkSSl8yZIlsLGxwaJFi6BQKFCuXDk8e/YMo0ePxoQJE6SW++zw9fVF586dAQDTpk3DwoULERgYiKZNm8Lc3BxASqt+ZnN8TJ8+HZMnT852nkRE6iIsLAwrV65EQEBApvFOnDiByZMnSw3cym7evInu3btj69atUu8NIiL6OlgPJSKi78X69esBpMzdN3LkSGzYsAEJCQmIj4/HxYsXER4ejp9++gkVK1aEg4MDEhMT8eDBA5w5cwbR0dGoU6cOSpcuDU9PT/Tr1w+//fYbtLW1ERAQgNatWyMoKAi2trbo3bs3Zs6cKT0sS0Q5wx4Z35gHDx7Ay8sLJUuWhImJCUqUKAEgZfilz1WpUiXpferN/5cvXwIAQkJC4OTkJDViACkNEMnJybh37560zNHRMcfzYvz000/pPoeEhEj52tjYSI0YAFChQgUUKFBAijNs2DD06tULDRs2xIwZM6ShtnIjODgYmpqaGXbxCwkJwU8//QSFQiEtq1GjBmJjY/H06dMc5aW8vw0NDWFsbCzt7+waO3YsoqOjpReHViGib8WFCxfw7NkzlC9fHnZ2drh48SJ69uyJlStXSnFOnz6N7t27Y//+/Shbtqws/Z07d9C8eXOsXr1a5dwbRET0ZbEeSkRE3xsfHx+pB4WRkRG6du0KAChevDhq1KiBy5cvS587d+4MTU1NmJubw8PDA4GBgQCAQoUKSfNl1KhRA5UrV5bSXbhwAT179oSdnR1GjBgBPz8/NGnS5GtvJtE3iw0Z35gWLVrg9evXWLlyJS5duoRLly4BSJlYO7U3gBBCiv/p06dsr1t5YiIgpTEjdcgqIYTs5n3aeKmUGzo+R+o6M8pXefmkSZNw+/ZtNGvWDCdPnkSFChWwe/fuXOWb1RO9qsqTur9Tl2toaMiOAaD6OGS2v7NLV1cXJiYmshcR0bfAy8sLz58/x6NHj/Do0SO4ublh1apV6N27NwDgzJkz6NatG/bu3QsnJydZ2pCQEHh6emLFihVo1KhRfhSfiOiHx3ooERF962JiYvDs2TPp8+7du2FhYQFzc3N07twZhw8fBgC8ffsWgYGB0gOpXl5eUtiHDx9w+vRp6T+L8kOuoaGhCA4OhqOjIwDgzZs30v+f2bNnw8PDA0eOHPkq20r0PWBDxjfk9evXCAkJwbhx49CgQQOUL18eb9++lcItLS0BABEREdKy4OBg2Tp0dHSQlJSU47wrVKiA4OBgxMXFScsCAgKgoaGRrUm9M3Px4sV0n1OHiapQoQLCw8NlT3jduXMH0dHRKF++vLTM3t4eQ4cOxdGjR9GmTRusWbMGQM6319HREcnJyTh9+rTK8AoVKuD8+fOyhorz58/D2NgYRYsWBZByHJSPQUxMDMLCwrJdhtRyA8jVsSIiUjcDBgxAsWLF8PTpUzRs2BClS5fOMk3Pnj3x8eNHdO/eHc7OznB2dsbNmzcBAIMHD0Z0dDRGjx4thfEPABERERER5UR0dDRatWoFR0dHODk5YfHixThw4AAUCgWmTZsGPz8/ODg4oFatWhg7diyqVKkCABg6dCieP3+OChUqoGrVqvDw8EDr1q0BAL/99hscHBzg7OyMTp06YfHixZ9934yIUnCOjG+ImZkZLCwssGLFChQuXBjh4eHS3BIAULp0adjY2GDSpEmYOnUqQkNDMWfOHNk67OzsEBsbixMnTsDJyQkGBgYwMDDIMu8uXbpg4sSJ8PHxwaRJkxAZGYlBgwahW7du0vwYuRUQEICZM2eiVatWOHbsGLZv346DBw8CABo2bIhKlSqhS5cumDdvHhITE9G/f3/UqVMHLi4uiI+Px8iRI9GuXTuUKFECT58+RVBQkDSXSE63187ODj4+PujRowcWLFgAJycnPH78GC9fvkSHDh3Qv39/zJs3D4MGDcLAgQNx7949TJw4EcOGDZN6xNSvXx9r165FixYtYGZmhvHjx0NTUzNH+8TW1hYKhQIHDhyAp6cn9PX1OYYiEX2zFi9ejMWLF2cax9/fX/Y5NDQ0w7iq5ssgIiIiIiLKCRsbG2lIqLQKFiyI/fv3qwzT19eX5tVIa926ddnK29fXF76+vtmKS0Qp2CPjG6KhoYEtW7bgypUrcHBwwNChQzFr1iwpXFtbG5s3b8bdu3fh5OSEP//8E1OnTpWtw93dHf369UPHjh1haWmJmTNnZitvAwMDHDlyBG/evIGrqyvatWuHBg0aYNGiRZ+9XcOHD8eVK1dQuXJlTJkyBXPmzJHGCFQoFNizZw/MzMxQu3ZtNGzYECVLlsTWrVsBAJqamnj9+jW8vb1hb2+PDh06wMPDQ5p4MDfbu3TpUrRr1w79+/dHuXLl0Lt3b6knStGiRXHo0CEEBgbCyckJ/fr1Q8+ePTFu3Dgp/dixY1G7dm00b94cnp6eaNWqFUqVKpWjfVK0aFFMnjwZY8aMgbW1NQYOHJij9ERERERERERERETfC4VIO5g/0VdkZ2eHIUOGYMiQIfldlO9CTEwMTE1N0XXWAejo5818JUREWVk1oG5+F4GIiPJZaj00elEpmOjnrDcyERHRF9PjXn6XgIjyCHtkEBERERERERERERGR2mJDBn0xZ8+ehZGRUYYvlomIiIiIiIiIiIiIssLJvumLcXFxQXBwcKZxHj169FXKkio7ZSIiIiIiIiIiIiIi9cGGDPpi9PX1Ubp06fwuhow6lomIiIiIiIiIiIiIMsbJvom+I9Iki9HRMDExye/iEBEREdEPgvVQIiIiIvqSOEcGERERERERERERERGpLTZkEBERERERERERERGR2mJDBhERERERERERERERqS02ZBARERERERERERERkdpiQwYREREREREREREREaktrfwuABHlvQErzkJH3zC/i0FERKSWVg2om99FIPp+bagC6GvmdymIiCi/9biX3yUgou8Me2QQEREREREREREREZHaYkMGERERERERERERERGpLTZkEBERERERERERERGR2mJDBhERERERERERERERqS02ZBARERERERERERERkdpiQwYREREREREREREREaktNmQQEREREREREREREZHaYkPGD8TOzg7z5s3L72IQERERqa0PHz6gVatWsLe3h7OzM5o2bYpHjx4BAHr06IGyZcvC2dkZtWvXRnBwsJSuXbt2cHZ2ll4aGhrYt28fAOD169do1aoVKlWqhPLly8PHxwfx8fH5sHVERERE6qFx48aoVKkSnJ2dUatWLale1b17d2m5q6srTpw4IaXJrL61ePFiODo6wtnZGY6OjliwYIEsv6lTp6JUqVIoVaoUxo8f/9W2k4jyjlZ+F4Dy3tq1azFkyBBERUXld1GIiIiIvjl9+vSBh4cHFAoFFi1ahD59+uDo0aNo1aoVVqxYAS0tLRw4cAAdOnTA/fv3AQA7duyQ0l++fBlNmzZFkyZNAKT8cS5ZsiT27NmDpKQkNGvWDGvWrEH//v3zZfuIiIiI8tu2bdtQoEABAMCePXvQo0cPXL16FXPnzpWWBwcHo2HDhoiMjIRCoci0vtW1a1cMGDAAABATEwMHBwfUrVsXlSpVwpkzZ7B582bcuHEDWlpaqFGjBmrWrCmlJaJvA3tk0GdJSEjI7yJ8F4QQSExMzO9iEBER/fD09PTg6ekJhUIBAHBzc8PDhw8BAD///DO0tLSk5Y8fP0ZycnK6daxevRpdu3aFrq6utOzdu3dITk5GQkIC3r9/j2LFin2FrSEiIiJST6mNFQAQHR0NDQ2NdMujoqKkOllaaetbpqamUtj79++RmJgopd26dSt8fX1haGgIXV1d9OjRA5s3b87jLSKiL40NGWro8OHDqFmzJgoUKAALCws0b94cDx48AAD4+/tDoVDIelsEBwdDoVDg0aNH8Pf3R/fu3REdHQ2FQgGFQoFJkyZJcd+/f48ePXrA2NgYxYsXx4oVK2R537x5E/Xr14e+vj4sLCzQp08fxMbGSuG+vr5o1aoVpk+fjiJFisDe3j7L7bGzs8PUqVPh7e0NIyMj2NraYu/evYiMjETLli1hZGQER0dHXL58WZbu/PnzqF27NvT19WFjY4PBgwcjLi5OCt+4cSNcXFxgbGyMQoUKwcvLCy9fvpTCU/fViRMn4OLiAgMDA7i7u+PevXvZOg7Xr19HvXr1YGxsDBMTE1StWlVWxoCAANSpUwcGBgYwMzNDkyZN8PbtWwDAx48fMXjwYFhZWUFPTw81a9ZEUFBQurIdOXIELi4u0NXVxdmzZyGEwMyZM1GyZEno6+vDyclJ9sRBWh8/fkRMTIzsRURERHlnwYIFaNGiRbrl8+fPh6enp/SnO9WHDx+wefNm9OzZU1o2fvx4/PvvvyhUqBCsrKxQvnx5/Pzzz1+87ERfEuuhRET0uby9vWFjY4Nx48Zh3bp10vIxY8agVKlSaNOmDbZv356uMUNVfQtI6SFbsWJF2NraYuTIkXB0dAQAhIeHw9bWVopnZ2eH8PDwL7hlRPQlsCFDDcXFxWHYsGEICgrCiRMnoKGhgdatW6t84i8td3d3zJs3DyYmJoiIiEBERARGjBghhc+ZMwcuLi64du0a+vfvj19++QV3794FkNLI0bRpU5iZmSEoKAjbt2/H8ePHMXDgQFkeJ06cQEhICI4dO4YDBw5ka5vmzp2LGjVq4Nq1a2jWrBm6desGb29vdO3aFVevXkXp0qXh7e0NIQSAlAaVJk2aoE2bNrhx4wa2bt2Kc+fOycqSkJCAKVOm4Pr169izZw/CwsLg6+ubLu/ffvsNc+bMweXLl6GlpYUePXpkq8xdunRBsWLFEBQUhCtXrmDMmDHQ1tYGkNJ41KBBA1SsWBEXLlzAuXPn0KJFCyQlJQEARo0ahZ07d2LdunXS9jVp0gRv3ryR5TFq1ChMnz4dISEhqFSpEsaNG4c1a9Zg6dKluH37NoYOHYquXbvi9OnTKss4ffp0mJqaSi8bG5tsbRsRERFlbdq0aQgNDcUff/whW75x40Zs27YNy5cvT5dm586dKFOmjPTHGQC2b9+OSpUqISIiAs+ePcP9+/exdu3aL118oi+K9VAiIvpc69evx5MnTzB16lSMHDlSWj5jxgw8ePAA27Ztw8iRI9ONBqKqvgWkzKFx+/Zt3Lt3D+vXr5c9yKrcGJJ674mIvi0KwW+v2ouMjISVlRVu3ryJV69eoV69enj79q1szMDKlSsjLCwMdnZ2Gc6RYWdnh1q1amHDhg0AUi7chQoVwuTJk9GvXz+sXLkSo0ePxpMnT2BoaAgAOHToEFq0aIFnz57B2toavr6+OHz4MMLDw6Gjo5Ot8qfN9/nz5yhcuDDGjx+P33//HQBw8eJF/PTTT4iIiEChQoXg7e0NfX192Q2Cc+fOoU6dOoiLi4Oenl66fIKCglCtWjW8e/cORkZG8Pf3R7169XD8+HE0aNBA2p5mzZohPj5e5TqUmZiYYOHChfDx8UkX5uXlhfDwcJw7dy5dWFxcHMzMzLB27Vp4eXkBAD59+gQ7OzsMGTIEI0eOlMq2Z88etGzZUkpXsGBBnDx5Ej/99JO0vl69euH9+/f4559/0uX18eNHfPz4UfocExMDGxsbdJ11ADr6hpluHxER0Y9q1YC6WcaZPXs2tmzZguPHj8uGONi6dSvGjRuHEydOoHjx4unS1a9fHx07dkTfvn2lZQ4ODli9ejWqVasGIGUyysDAQNmTh0TfmozqodGLSsFEXzMfS0ZERGqhR/ZGw0ilr6+Pp0+fwsLCQra8XLly2LRpE6pWrSotU1XfSqtfv34oU6YMhg8fjgEDBsDOzk5qLFmyZAkCAwP5YAnRN4Y9MtTQgwcP4OXlhZIlS8LExAQlSpQAgDzp9lapUiXpvUKhQKFChaThmEJCQuDk5CQ1YgBAjRo1kJycLGvFdnR0zHYjhqp8ra2tpfWkXZZalitXrmDt2rUwMjKSXk2aNEFycjLCwsIAANeuXUPLli1ha2sLY2Nj1K1bF0D6/aScd+HChWX5ZGbYsGHo1asXGjZsKD0NkCq1R4YqDx48wKdPn1CjRg1pmba2NqpVq4aQkBBZXBcXF+n9nTt38OHDBzRq1Ei23evXr5flrUxXVxcmJiayFxEREX2ev/76C5s3b8axY8dkjRjbtm3DuHHjcPz4cZWNGGFhYQgMDETnzp1ly0uWLAk/Pz8AKQ83HD58GA4ODl90G4i+NNZDiYgot2JiYvDs2TPp8+7du2FhYQETExOEhoZKywMDA/Hy5UuULFlSWpZRfUv5fktkZCROnDgh3Q9q37491q1bh7i4OHz8+BGrV69Gp06dvtTmEdEXopXfBaD0WrRoARsbG6xcuRJFihRBcnIyHBwckJCQACMjIwDybnCfPn3K9rpTh0ZKpVAopCGrhBAZTqKkvFy5oSM3+aauS9Wy1LIkJyejb9++GDx4cLp1FS9eHHFxcWjcuDEaN26MjRs3wtLSEuHh4WjSpEm6LoeZ5ZOZSZMmwcvLCwcPHoSfnx8mTpyILVu2oHXr1tDX188wXeqxSbsvVe1f5X2ZWqaDBw+iaNGisnjKk4USERHRl/P06VMMHz4cJUuWRL169QCk/A5funQJXbp0QaFChaTelEDKkJupTw6uXr0abdu2TXdDd/78+ejXrx8cHByQnJyMGjVqqKzjEBEREf0IoqOj0bZtW8THx0NDQwOWlpY4cOAAkpOT4evri+joaGhqasLQ0BA7duyAmZmZlDaj+tbChQtx+vRpaGtrQwiBoUOHolGjRgCAunXrokOHDtIDtZ06dULTpk2/3gYTUZ5gQ4aaef36NUJCQrB8+XLUqlULAGTDF1laWgIAIiIipAt5cHCwbB06OjrSXA05UaFCBamFOvUGe0BAADQ0NLI1qXdeqlKlCm7fvo3SpUurDE8dZmvGjBnSeLxpJwvPC/b29rC3t8fQoUPRuXNnrFmzBq1bt0alSpVw4sQJTJ48OV2a0qVLQ0dHB+fOnZMNLXX58mUMGTIkw7wqVKgAXV1dhIeHo06dOnm+LURERJS1YsWKZThuclYPj0yZMkXl8hIlSuDIkSOfXTYiIiKi74GNjQ0CAwNVhgUEBGSaNqP61pIlSzJNN2HCBEyYMCF7BSQitcShpdSMmZkZLCwssGLFCvz77784efIkhg0bJoWXLl0aNjY2mDRpEu7fv4+DBw9izpw5snXY2dkhNjYWJ06cwKtXr/D+/fts5d2lSxfo6enBx8cHt27dwqlTpzBo0CB069ZNGvrpaxk9ejQuXLiAAQMGIDg4GKGhodi3bx8GDRoEIKVXho6ODhYuXIiHDx9i3759Gf6Y5UZ8fDwGDhwIf39/PH78GAEBAQgKCkL58uUBAGPHjkVQUBD69++PGzdu4O7du1i6dClevXoFQ0ND/PLLLxg5ciQOHz6MO3fuoHfv3nj//j169uyZYZ7GxsYYMWIEhg4dinXr1uHBgwe4du0aFi9ezDG0iYiIiIiIiIiI6IfFhgw1o6GhgS1btuDKlStwcHDA0KFDMWvWLClcW1sbmzdvxt27d+Hk5IQ///wTU6dOla3D3d0d/fr1Q8eOHWFpaYmZM2dmK28DAwMcOXIEb968gaurK9q1a4cGDRpg0aJFebqN2VGpUiWcPn0aoaGhqFWrFipXrozx48dLc1xYWlpi7dq12L59OypUqIAZM2Zg9uzZeZa/pqYmXr9+DW9vb9jb26NDhw7w8PCQemDY29vj6NGjuH79OqpVq4affvoJe/fuhZZWSienGTNmoG3btujWrRuqVKmCf//9F0eOHJF1h1RlypQpmDBhAqZPn47y5cujSZMm2L9/vzRPChEREREREREREdGPRiEy6jtPRN+cmJgYmJqaouusA9DRz/lcJkRERD+CVQPq5ncRiL47qfXQ6EWlYKKvmd/FISKi/NbjXn6XgIi+M+yRQUREREREREREREREaosNGfRZzp49CyMjowxf6qxixYoZlnvTpk35XTwiIiIiIiIiIiIiAqCV3wWgb5uLiwuCg4Pzuxi5cujQIXz69Ell2Nee3JyIiIiIiIiIiIiIVGNDBn0WfX19lC5dOr+LkSu2trb5XQQiIiIiIiIiIiIiygIn+yb6jkiTLEZHw8TEJL+LQ0REREQ/CNZDiYiIiOhL4hwZRERERERERERERESkttiQQUREREREREREREREaosNGUREREREREREREREpLbYkEFERERERERERERERGqLDRlERERERERERERERKS2tPK7AESU9wasOAsdfcP8LgYR/UBWDaib30UgIiJ1sKEKoK+Z36Ugou9Zj3v5XQIiIsoH7JFBRERERERERERERERqiw0ZRERERERERERERESkttiQQUREREREREREREREaosNGUREREREREREREREpLbYkEFERERERERERERERGqLDRlERERERERERERERKS22JCRh+zs7DBv3ryvlp9CocCePXsyDH/06BEUCgWCg4MBAP7+/lAoFIiKivoq5ftcafdnVttLRETqafDgwbCzs4NCocCtW7fSha9btw4KhQIHDhyQlv3vf/9D+fLl4eTkhGrVquHkyZPp0t27dw8GBgYYMWLEFy0/EREREX0bPnz4gFatWsHe3h7Ozs5o2rQpHj16JIujqu6Zyt/fH5qamli0aJG0bPDgwXB2dpZeenp6WLBggRR++vRpuLq6omLFiihXrhwuXLjwxbaPiOhHxoaMH4i7uzsiIiJgamoKAFi7di0KFCiQv4XKgYiICHh4eOR3MYiIKIfatWuHc+fOwdbWNl3Y06dPsXz5cri5ucmW16pVC1evXsX169excuVKtG3bFh8+fJDCk5KS0LdvX7Rq1epLF5+IiIiIviF9+vTBvXv3EBwcjObNm6NPnz5SWEZ1TwB49+4dRo8ene6+w4IFCxAcHIzg4GAcPnwYCoUCHTp0AAA8e/YMPj4+WL9+PW7fvo3g4GCUL1/+y24gEdEPig0Z+ezTp09fLS8dHR0UKlQICoXiq+WZlwoVKgRdXd38LsYX8TXPAyKir6127dooVqyYyrA+ffpg7ty56a7vHh4e0NfXBwA4OjoiKSkJr169ksJnzJiB5s2bw97e/ssVnIiIiIi+KXp6evD09JTue7i5ueHhw4dSeEZ1TwAYNmwYRo4ciYIFC2a4/vXr16NJkyYoVKgQAGDJkiXo2rWr1Hihp6f3TT0wSkT0LWFDRho7duyAo6Mj9PX1YWFhgYYNGyIuLg5169bFkCFDZHFbtWoFX19f2bJ3797By8sLRkZGKFKkCBYuXCgLVygUWLZsGVq2bAlDQ0NMnToVALB//35UrVoVenp6KFmyJCZPnozExEQpXWhoKGrXrg09PT1UqFABx44dS1f2wMD/x959x1Vd////vx1AlghuwBy4UESGprlyY87SyBy5EEe+02y43y6sHJk7tdRUyvw4c5Q5UgxybxzJ24EimZhaCuJABX5/+PP19QQ4EDyo9+vlci5xXs/xerxeoj3Pebyez+duKlWqhL29PVWqVOHAgQNm5fcvLRUeHk7Xrl2Jj4/HZDJhMpkICQl56P3x8PDgs88+o3Pnzjg5OVGiRAlWr17NxYsXadmyJU5OTvj4+LB3716zdtu3b6dOnTo4ODhQrFgx+vbty7Vr14zyCxcu8Prrr+Pg4EDJkiVZuHBhmnP/e2mpQYMG4enpiaOjI6VKlWL48OFmCYGQkBD8/f1ZsGABHh4euLi40K5dO65evfrQ64SMfxfumTdvHt7e3tjZ2eHu7k6fPn2MstjYWON+ODs706ZNG/766680sc2bN49SpUphZ2dHamoq8fHx9OzZk8KFC+Ps7EyDBg04ePBghjEmJSWRkJBg9hIReVZ89dVXeHt7U61atQfWmz9/PqVLlzaSIYcOHWLDhg189NFHTyNMERFJh8ahIvIsmDZtGq+//jrw4LHnunXruHLlCq1bt35gf/PmzaNbt27G+6NHj3Ljxg0CAgLw9/fn/fff5/r161l7ESIiAiiRYSYuLo727dsTHBxMVFQU4eHhBAYGkpqa+sh9fPHFF/j6+rJ//36GDBnCRx99lCbpMHLkSFq2bMnhw4cJDg5mw4YNdOzYkb59+3L06FFmzZpFaGgoo0ePBiAlJYXAwECsra3ZuXMnX3/9NYMGDTLr89q1a7Ro0YJy5cqxb98+QkJCHrhmeM2aNZkyZQrOzs7ExcURFxf3yGuMT548mVq1anHgwAGaN29Op06d6Ny5Mx07dmT//v2UKVOGzp07G/ft8OHDNG7cmMDAQA4dOsSSJUvYunWr2Rf/QUFBxMTEsHnzZpYvX87MmTO5cOHCA+PIkycPoaGhHD16lKlTpzJnzhwmT55sVic6OppVq1axZs0a1qxZQ0REBOPGjXvoNT7sd+Grr76id+/e9OzZk8OHD/Pjjz9SpkwZAFJTU2nVqhX//PMPERERbNy4kejoaNq2bWt2jpMnT7J06VJ++OEHYx+T5s2bc/78edauXcu+ffuoXLkyDRs25J9//kk3zrFjx+Li4mK8ihUr9tBrExHJCU6fPs2cOXP45JNPHlgvLCyMUaNGsXjxYuDuDLYePXrw9ddfY21t/TRCFRGRdGgcKiI53ZgxYzhx4gSjR49+4NjzypUrDB48mBkzZjywv23btpGQkECzZs2MY7dv3yY8PJxly5axd+9e4uPjH+khUREReXw2lg4gJ4mLi+POnTsEBgYa63j7+Pg8Vh+1atVi8ODBAHh6erJt2zYmT55Mo0aNjDrvvPMOwcHBxvtOnToxePBgunTpAkCpUqX49NNPGThwICNHjmTTpk1ERUURExNjPI06ZswYs3UbFy5cSHJyMvPmzcPR0RFvb2/Onj3Lf/7zn3TjtLW1xcXFBZPJZEyJfFTNmjXj3XffBWDEiBF89dVXVK1albfffhu4O1OiRo0a/PXXX7i5ufHFF1/wzjvvGDNaypYty7Rp06hbty5fffUVsbGxrFu3jp07dxpPRsydO/eh60oOGzbM+NnDw4N+/fqxZMkSBg4caBxPSUkhNDSUPHnyAHfvdVhYmJEkysjDfhc+++wz+vXrxwcffGAcq1q1KgCbNm3i0KFDnD592vhAt2DBAry9vdmzZ49R79atWyxYsIBChQoBsHnzZg4fPsyFCxeMaa4TJkxg1apVLF++3Gxdz3uGDBnCxx9/bLxPSEjQh0gReSbs2LGDc+fOGf/Wnz9/nm7duvHZZ5/Ro0cP4O7GiV27duWnn36iXLlywN1/n6Ojo40PkFeuXCE1NZXLly8zd+5cy1yMiMgLSONQEcnJJkyYwIoVK9i0aROOjo4PHHt6eXkRFxfHK6+8AsClS5f46aefuHjxIqNGjTL6nDt3Ll26dDF7mKZEiRJUqlSJfPnyAdCuXTvGjx//FK9UROTFoUTGffz8/GjYsCE+Pj40btyY1157jdatWxv/Q3oUNWrUSPN+ypQpZseqVKli9n7fvn3s2bPH7Mv15ORkbt68yfXr14mKiqJ48eJm64v/+zxRUVH4+fnh6OiYYZ2s4uvra/zs6uoKmH/Jf+/YhQsXcHNzY9++fZw8edJsuajU1FRSUlI4ffo0x48fx8bGxuy+lC9f/qHrSi5fvpwpU6Zw8uRJEhMTuXPnDs7OzmZ1PDw8jCQGgLu7+0NnesCDfxcuXLjAuXPnaNiwYbpto6KiKFasmNkHuQoVKpA3b16ioqKMREaJEiWMJAbc/T1ITEykQIECZv3duHGD6OjodM9lZ2f33O4bIiLPt3feeYd33nnHeF+vXj369+9PixYtAPjtt9/o1KkTq1evxs/Pz6hXvHhxs70yQkJCSExMZMKECU8veBER0ThURHKsSZMmsWjRIjZt2mR8r/Cwsef93xMEBQVRpUoVs1UkEhMTWb58Ofv27TM71zvvvMOgQYNISkrCzs6O9evXm41dRUQk6yiRcR9ra2s2btzI9u3b+eWXX/jyyy8ZOnQou3btwsrKKs0SU4+6QfO/N9fOnTu32fuUlBRGjRpFYGBgmrb29vbpLm317z4fZ/mrJ5UrV640caR3LCUlxfjvu+++S9++fdP0Vbx4cY4dO2bW7lHs3LmTdu3aMWrUKBo3boyLiwuLFy9m4sSJGcZ67xz34nqQB/0uPGjjL7j7Z5Hetfz7eHq/B+7u7oSHh6dpq83CRORZ1rt3b1avXs358+cJCAjAycmJkydPPrBNt27dSEpKomvXrsaxBQsWPPZMSRERERF5cZw9e5Z+/fpRqlQp6tevD9xNvO7ateuJ+l2yZAmVKlWibNmyZsdr1qzJ66+/jr+/PzY2NlSsWJGvv/76ic4lIiLpUyLjX0wmE7Vq1aJWrVqMGDGCEiVKsHLlSgoVKkRcXJxRLzk5mSNHjhj/Y7xn586dad6XL1/+geesXLkyx44dM/ZY+LcKFSoQGxvLuXPnKFKkCHB3SY5/11mwYAE3btzAwcEh3Vj+zdbWluTk5AfWyQqVK1fm999/z/D6vLy8uHPnDnv37jWmch47dowrV65k2Oe2bdsoUaIEQ4cONY6dOXMmS+PO6Hfh448/xsPDg7CwsDR//vD//rz++OMPY1bG0aNHiY+Pf+ByWZUrV+b8+fPY2Njg4eGRpdciImJJM2bMeOiaw/9O4p44ceKR+tYaxCIiIiJyT9GiRR/pQc/0HiC8JzQ0NM2xbt26mW3yfb+BAweaLXEtIiLZQ5t932fXrl2MGTOGvXv3Ehsby4oVK7h48SJeXl40aNCAn3/+mZ9//pn//e9/vPfee+l+0b5t2zbGjx/P8ePHmTFjBsuWLTPbRyE9I0aM4LvvviMkJITff/+dqKgolixZYuwBERAQQLly5ejcuTMHDx5ky5YtZl/gw93pjFZWVnTr1o2jR4+ydu3ahy6z4eHhQWJiImFhYVy6dInr168/3g17RIMGDWLHjh307t2byMhITpw4wY8//sj7778PQLly5WjSpAk9evRg165d7Nu3j+7duxsJmfSUKVOG2NhYFi9eTHR0NNOmTWPlypVZFvODfhfg7hdnEydOZNq0aZw4cYL9+/fz5ZdfAnf/vHx9fenQoQP79+9n9+7ddO7cmbp166ZZVux+AQEB1KhRg1atWrFhwwZiYmLYvn07w4YNY+/evVl2bSIiIiIiIiIiIiLPEiUy7uPs7Mxvv/1Gs2bN8PT0ZNiwYUycOJGmTZsSHBxMly5djC+kS5Ysme7T+P369WPfvn1UqlSJTz/9lIkTJ9K4ceMHnrdx48asWbOGjRs3UrVqVapXr86kSZOMTaatrKxYuXIlSUlJvPLKK3Tv3j3NZtVOTk789NNPHD16lEqVKjF06FA+//zzB563Zs2a9OrVi7Zt21KoUKFs25DK19eXiIgITpw4Qe3atalUqRLDhw/H3d3dqDN//nyKFStG3bp1CQwMpGfPnhQuXDjDPlu2bMlHH31Enz598Pf3Z/v27QwfPjzLYn7Q7wJAly5dmDJlCjNnzsTb25sWLVoYTw+bTCZWrVpFvnz5qFOnDgEBAZQqVYolS5Y88Jwmk4m1a9dSp04dgoOD8fT0pF27dsTExBj7joiIiIiIiIiIiIi8aEypT3NzBRHJVgkJCbi4uNDxizXYOuR+eAMRkSwyt3c9S4cgIiIWdG8cGj+9NM4O1pYOR0SeZ8HHLB2BiIhYgGZkiIiIiIiIiIiIiIhIjqVEhhi2bNmCk5NThq/nSWxs7AOvNTY21tIhioiIiIiIiIiIiAhgY+kAJOeoUqUKkZGRlg7jqShSpMgDr7VIkSJPLxgRERERERERERERyZASGWJwcHCgTJkylg7jqbCxsXlhrlVERERERERERETkWabNvkWeI8Ymi/HxODs7WzocEREREXlBaBwqIiIiItlJe2SIiIiIiIiIiIiIiEiOpUSGiIiIiIiIiIiIiIjkWEpkiIiIiIiIiIiIiIhIjqVEhoiIiIiIiIiIiIiI5FhKZIiIiIiIiIiIiIiISI5lY+kARCTr9Z69BVuH3JYOwyLm9q5n6RBEREREXlwLKoODtaWjEJHnVfAxS0cgIiIWohkZIiIiIiIiIiIiIiKSYymRISIiIiIiIiIiIiIiOZYSGSIiIiIiIiIiIiIikmMpkSEiIiIiIiIiIiIiIjmWEhkiIiIiIiIiIiIiIpJjKZEhIiIiIiIiIiIiIiI5lhIZ8kIIDw/HZDJx5cqVB9bz8PBgypQpWXLOkJAQ/P39s6QvyTqvvfYavr6++Pv7U7t2bSIjIwEYM2YM5cqVw8rKijVr1pi1OXHiBI0aNcLPzw9vb2+WLFligchFREREREQkIzdv3qRVq1Z4enri7+9PkyZNiImJMavz7bffYjKZ0nzmg7vfG1hbWzN9+nTjWEpKCu+//z6lS5emTJkyzJw50ygLDQ0lb968+Pv74+/vT/369bPt2kRERIkMeU7Vq1ePDz/80Hhfs2ZN4uLicHFxAf7fgENePEuXLuXQoUNERkbSr18/goODAWjYsCFr166lTp06adoEBQXRoUMHDh48yObNmxkwYAB//vnn0w5dREREREREHqBnz54cO3aMyMhIWrRoQc+ePY2ys2fPMmvWLKpXr56m3dWrVxk0aBBNmzY1O/79999z9OhRjh8/zu7duxk/fjz/+9//jPKAgAAiIyOJjIzk119/zb4LExERJTLkxWBra4ubmxsmk8nSoYiF3Z/Aio+Px8rq7j+D1apVo3Tp0um2OXjwIM2aNQPA1dUVPz8/zcoQERERERHJQezt7WnWrJnxub969eqcOnXKKO/ZsyeTJ0/Gzs4uTduPP/6YAQMGULBgQbPjS5YsoVevXlhbW5M/f37atGnD4sWLs/dCREQkXUpkyHMnKCiIiIgIpk6dislkwmQyERoaaiwtFR4eTteuXYmPjzfKQ0JC0u0rPj6enj17UrhwYZydnWnQoAEHDx7MdGzz58/Hy8sLe3t7ypcvbzYtNSYmBpPJxIoVK6hfvz6Ojo74+fmxY8eODPtLSkoiISHB7CUP17lzZ4oVK8awYcP49ttvH1q/atWqfP/99wBER0ezffv2NFOURURERF4kGoeKSE43bdo0Xn/9dQC++uorvL29qVatWpp669at48qVK7Ru3TpNWWxsLCVKlDDee3h4EBsba7yPiIjA39+fWrVqsXz58my4ChERucfG0gGIZLWpU6dy/PhxKlasyCeffALA77//bpTXrFmTKVOmMGLECI4dOwaAk5NTmn5SU1Np3rw5+fPnZ+3atbi4uDBr1iwaNmzI8ePHyZ8//2PFNWfOHEaOHMn06dOpVKkSBw4coEePHuTOnZsuXboY9YYOHcqECRMoW7YsQ4cOpX379pw8eRIbm7R/XceOHcuoUaMeKw6B7777Dri7PuqAAQNYu3btA+uHhobSv39//P39KVWqFAEBAeTKletphCoiIiKSI2kcKiI52ZgxYzhx4gRff/01p0+fZs6cOWzbti1NvStXrjB48GA2btyYYV/3r+yQmppq/NyiRQvatGmDo6MjUVFRvPbaaxQtWjTdpatEROTJaUaGPHdcXFywtbXF0dERNzc33NzcsLa2NsptbW1xcXHBZDIZ5eklMn799VcOHz7MsmXLqFKlCmXLlmXChAnkzZs3U09afPrpp0ycOJHAwEBKlixJYGAgH330EbNmzTKr179/f5o3b46npyejRo3izJkznDx5Mt0+hwwZQnx8vPH6448/HjuuF1mXLl349ddf+fvvvx9Yr0SJEixbtozIyEhWrFhBfHw8FSpUeEpRioiIiOQ8GoeKSE41YcIEVqxYwbp163B0dGTHjh2cO3cOLy8vPDw82LlzJ926dWPOnDkcOXKEuLg4XnnlFTw8PFi+fDkjR45k5MiRABQvXtxsNv6ZM2coXrw4AAULFsTR0REALy8vmjVrlm6yREREsoZmZIhkYN++fSQmJlKgQAGz4zdu3CA6Ovqx+rp48SJ//PEH3bp1o0ePHsbxO3fuGBuQ3+Pr62v87O7uDsCFCxcoX758mn7t7OzSXd9T0peQkEBiYiJFihQBYOXKlRQoUOChs2v++usvChcujMlkYsOGDRw9epR33nnnaYQsIiIikiNpHCoiOdGkSZNYtGgRmzZtMvZHfOedd8w+v9WrV4/+/fvTokUL4O7n7XuCgoKoUqUKffr0AeDtt99m1qxZBAYGEh8fz5IlS1i/fj0Af/75Jy+99BJw9zPj5s2badu27dO4TBGRF5ISGSIZSElJwd3dnfDw8DRl928Y/ah9wd3lpf69Juf9s0UAsyWL7k1hvddenkx8fDxvvfUWN27cwMrKikKFCrFmzRpMJhNjx45lxowZXLx4kaCgIOzt7Tlw4ACFChXip59+Yty4cdjY2ODu7s7atWtxcHCw9OWIiIiIiIjI/+/s2bP069ePUqVKUb9+feBu0nXXrl2Z7rNTp07s2bMHT09PAAYMGICXlxcAM2bMYPXq1eTKlYuUlBQ++ugjGjRo8OQXIiIi6VIiQ55Ltra2JCcnZ7ocoHLlypw/fx4bGxs8PDyeKB5XV1deeuklTp06RYcOHZ6oL8m8YsWKsXv37nTLhgwZwpAhQ9It6969O927d8/O0EREREREROQJFC1a1GwPi4yk97DiPaGhoWbvra2tmTFjRrp1x4wZw5gxYx4nRBEReQJKZMhzycPDg127dhETE4OTk1OaGQ0eHh4kJiYSFhaGn58fjo6OxtqW9wQEBFCjRg1atWrF559/Trly5Th37hxr166lVatWVKlS5bFiCgkJoW/fvjg7O9O0aVOSkpLYu3cvly9f5uOPP37iaxYRERERERERERF5Hmmzb3ku9e/fH2traypUqEChQoWIjY01K69Zsya9evWibdu2FCpUiPHjx6fpw2QysXbtWurUqUNwcDCenp60a9eOmJgYXF1dHzum7t2788033xAaGoqPjw9169YlNDSUkiVLZvo6RURERERERERERJ53ptRHmXcnIs+EhIQEXFxc6PjFGmwdcls6HIuY27uepUMQEREReeHcG4fGTy+Ns4P1wxuIiGRG8DFLRyAiIhaiGRkiIiIiIiIiIiIiIpJjKZEhkkne3t44OTml+1q4cKGlwxMRERERERERERF5Lmizb5FMWrt2Lbdv3063LDN7aIiIiIiIiIiIiIhIWkpkiGRSiRIlLB2CiIiIiIiIiIiIyHNPm32LPEeMTRbj43F2drZ0OCIiIiLygtA4VERERESyk/bIEBERERERERERERGRHEuJDBERERERERERERERybGUyBARERERERERERERkRxLiQwREREREREREREREcmxlMgQEREREREREREREZEcy8bSAYhI1us9ewu2DrktHYaIPKK5vetZOgQREZGssaAyOFhbOgoRyemCj1k6AhERecZoRoaIiIiIiIiIiIiIiORYSmSIiIiIiIiIiIiIiEiOpUSGiIiIiIiIiIiIiIjkWEpkiIiIiIiIiIiIiIhIjqVEhoiIiIiIiIiIiIiI5FhKZIiIiIiIiIiIiIiISI71TCcyPDw8mDJlylM7n8lkYtWqVRmWx8TEYDKZiIyMBCA8PByTycSVK1eeSnxP6t/382HXKyIiIiIiIiIiIiKS3Z7pREZOV7NmTeLi4nBxcQEgNDSUvHnzWjaoxxAXF0fTpk0tHcZz61n7fRARy+jbty8eHh6YTCaOHDliHB8zZgzlypXDysqKNWvWmLWJjo6mYcOG+Pv7U758efr160dKSgoAP//8M1WqVMHOzo7+/fs/1WsREREREXmYmzdv0qpVKzw9PfH396dJkybExMQA0LVrV3x9ffH396dq1aqEhYUZ7f773//i5eWFn58fr7zyCps3bzbKHjQGXrlypdGnt7c3Q4cOJTU19alcq4iIPLoXLpFx+/btp3YuW1tb3NzcMJlMT+2cWcnNzQ07OztLhyEi8kJr3bo1W7dupUSJEmbHGzZsyNq1a6lTp06aNv3796dly5ZERkYSGRnJL7/8wvr16wEoW7Ysc+fOZcCAAU8lfhERERGRx9WzZ0+OHTtGZGQkLVq0oGfPngBMnjyZQ4cOERkZyZw5c2jbtq2RdKhduzb79+/n4MGDzJkzh7feeoubN28CDx4DBwQEGOPmAwcOsHHjRn766aend7EiIvJILJ7IWL58OT4+Pjg4OFCgQAECAgK4du0a9erV48MPPzSr26pVK4KCgsyOXb16lXfeeQcnJyeKFCnCl19+aVZuMpn4+uuvadmyJblz5+azzz4D4KeffuLll1/G3t6eUqVKMWrUKO7cuWO0O3HiBHXq1MHe3p4KFSqwcePGNLHv3r2bSpUqYW9vT5UqVThw4IBZ+f1LS4WHh9O1a1fi4+MxmUyYTCZCQkIeen88PDz47LPP6Ny5M05OTpQoUYLVq1dz8eJFWrZsiZOTEz4+Puzdu9es3fbt26lTpw4ODg4UK1aMvn37cu3aNaP8woULvP766zg4OFCyZEkWLlyY5tz/Xlpq0KBBeHp64ujoSKlSpRg+fLhZYigkJAR/f38WLFiAh4cHLi4utGvXjqtXrz70OgFSUlL4/PPPKVOmDHZ2dhQvXpzRo0cb5YcPH6ZBgwbG70rPnj1JTEw0yoOCgmjVqhVjxozB1dWVvHnzGn+uAwYMIH/+/BQtWpR58+YZbe4tB7Z06VJq166Ng4MDVatW5fjx4+zZs4cqVarg5OREkyZNuHjxolm88+fPx8vLC3t7e8qXL8/MmTPT9LtixQrq16+Po6Mjfn5+7NixA+CBvw8zZ86kbNmy2Nvb4+rqSuvWrR/p/onI86lOnToULVo0zfFq1apRunTpDNvFx8cDcOPGDW7fvo27uzsAnp6e+Pn5YWNjkz0Bi4iIiIg8AXt7e5o1a2Y8FFq9enVOnToFYLaqwZUrV8weHG3atCkODg4A+Pj4kJyczKVLl4AHj4Hz5MmDldXdr8du3rxJUlKS8V5ERHIOi/7LHBcXR/v27QkODiYqKorw8HACAwMfawrfF198ga+vL/v372fIkCF89NFHaZIOI0eOpGXLlhw+fJjg4GA2bNhAx44d6du3L0ePHmXWrFmEhoYaX5qnpKQQGBiItbU1O3fu5Ouvv2bQoEFmfV67do0WLVpQrlw59u3bR0hIyAOX6KhZsyZTpkzB2dmZuLg44uLiHnlJj8mTJ1OrVi0OHDhA8+bN6dSpE507d6Zjx47s37+fMmXK0LlzZ+O+HT58mMaNGxMYGMihQ4dYsmQJW7dupU+fPkafQUFBxMTEsHnzZpYvX87MmTO5cOHCA+PIkycPoaGhHD16lKlTpzJnzhwmT55sVic6OppVq1axZs0a1qxZQ0REBOPGjXuk6xwyZAiff/45w4cP5+jRo/zf//0frq6uAFy/fp0mTZqQL18+9uzZw7Jly9i0aZPZNQFs3ryZc+fO8dtvvzFp0iRCQkJo0aIF+fLlY9euXfTq1YtevXrxxx9/mLUbOXIkw4YNY//+/djY2NC+fXsGDhzI1KlT2bJlC9HR0YwYMcKoP2fOHIYOHcro0aOJiopizJgxDB8+nG+//das36FDh9K/f38iIyPx9PSkffv23LlzJ8Pfh71799K3b18++eQTjh07xvr169N92vqepKQkEhISzF4iIlOmTGHZsmUUKVKEIkWK0LlzZypVqmTpsERE5DmicaiIPC3Tpk3j9ddfN94PHjyY0qVLExgYyLJly9JdBWP+/PmULl063QeC0rN9+3Z8fX0pXLgwDRs2pHnz5lkWv4iIZA2LPo4ZFxfHnTt3CAwMNJbM8PHxeaw+atWqxeDBg4G7GfZt27YxefJkGjVqZNR55513CA4ONt536tSJwYMH06VLFwBKlSrFp59+ysCBAxk5ciSbNm0iKiqKmJgY4396Y8aMMdsvYuHChSQnJzNv3jwcHR3x9vbm7Nmz/Oc//0k3TltbW1xcXDCZTLi5uT3WNTZr1ox3330XgBEjRvDVV19RtWpV3n77beDuTIkaNWrw119/4ebmxhdffME777xjzGgpW7Ys06ZNo27dunz11VfExsaybt06du7cSbVq1QCYO3cuXl5eD4xj2LBhxs8eHh7069ePJUuWMHDgQON4SkoKoaGh5MmTB7h7r8PCwsxmVqTn6tWrTJ06lenTpxt/LqVLl+bVV18F7t7vGzdu8N1335E7d24Apk+fzuuvv87nn39uJDzy58/PtGnTsLKyoly5cowfP57r16/z3//+F7ibLBk3bhzbtm2jXbt2xvn79+9P48aNAfjggw9o3749YWFh1KpVC4Bu3boRGhpq1P/000+ZOHEigYGBAJQsWdJIit2L/16/9wZAo0aNwtvbm5MnT1K+fPl0fx9iY2PJnTs3LVq0IE+ePJQoUeKBXz6OHTuWUaNGPfDeisiLZ9asWXTq1IkBAwZw4cIFGjRoQPXq1WnQoIGlQxMRkeeExqEi8jSMGTOGEydO8PXXXxvHxo0bx7hx49i0aRMDBgxg27Zt2NraGuVhYWGMGjUq3ZU1MlKzZk0OHTrExYsXCQwMZMuWLQ98qFBERJ4+i87I8PPzo2HDhvj4+PD2228zZ84cLl++/Fh91KhRI837qKgos2NVqlQxe79v3z4++eQTnJycjFePHj2Ii4vj+vXrREVFUbx4cbPM/b/PExUVhZ+fH46OjhnWySq+vr7Gz/e+sL8/4XPv2L0ZFfv27SM0NNTs+ho3bkxKSgqnT58mKioKGxsbs/tSvnz5h248vXz5cl599VXc3NxwcnJi+PDhxMbGmtXx8PAwkhgA7u7uD53pAXfvZ1JSEg0bNsyw3M/Pz0hiwN0kVkpKCseOHTOOeXt7m00BdXV1NbtX1tbWFChQIE1Mj3KP77W5ePEif/zxB926dTO7x5999hnR0dEZ9ntvWZcH3Y9GjRpRokQJSpUqRadOnVi4cCHXr1/PsP6QIUOIj483Xv+eaSIiL6Zp06YZSdXChQvTtGlTIiIiLByViIg8TzQOFZHsNmHCBFasWMG6devMvnu5JyAggKtXr3L48GHjWEREBF27duWnn36iXLlyj33OQoUK0bx5c5YtW/ZEsYuISNazaCLD2tqajRs3sm7dOipUqMCXX35JuXLlOH36NFZWVmmWmHrUjbr/Pa3w/i+/4e6sgVGjRhmbOUVGRnL48GFOnDiBvb19uktb/bvPx1n+6knlypUrTRzpHUtJSTH+++6775pd38GDBzlx4gSlS5c2Yn+cTch37txJu3btaNq0KWvWrOHAgQMMHTqUW7duZRjrvXPci+tB7q1jmZHU1NQM473/eHrnf5SYHuUe339/4e7yUvff4yNHjrBz586H9vug+5EnTx7279/PokWLcHd3Z8SIEfj5+XHlypV069vZ2eHs7Gz2EhEpVaoU69atA+4uhbh582YqVqxo4ahEROR5onGoiGSnSZMmsWjRIjZu3Gg8dHnnzh1OnDhh1Nm9ezcXLlygVKlSAPz222906tSJ1atX4+fn98jnOnbsmPE5/erVq6xZs8bsoUQREckZLL57kclkolatWowaNYoDBw5ga2vLypUrKVSoEHFxcUa95ORkjhw5kqb9v7843rlzJ+XLl3/gOStXrsyxY8coU6ZMmpeVlRUVKlQgNjaWc+fOGW3ubdJ8T4UKFTh48CA3btzIMJZ/s7W1JTk5+YF1skLlypX5/fff070+W1tbvLy8uHPnjtkG4ceOHcvwy3KAbdu2UaJECYYOHUqVKlUoW7YsZ86cybKYy5Yti4ODA2FhYemWV6hQgcjISLMNy7dt24aVlRWenp5ZFsejcHV15aWXXuLUqVNp7m/JkiUfuZ+Mfh9sbGwICAhg/PjxHDp0yNjLREReTL1796Zo0aKcPXuWgIAAypQpA9xd0qNo0aLs2LGDoKAgihYtysWLFwH49ttvmT17Nr6+vlSpUoXXXnuN1q1bAxAeHk7RokWZNGkSs2bNomjRovz4448Wuz4RERERkfudPXuWfv36ceXKFerXr4+/vz/VqlUjOTmZoKAgKlasiJ+fHx9++CHLly8nX758wN0loZOSkujatSv+/v74+/sbszUeNAZetmyZ0WeNGjUICAige/fuFrt+ERFJn0X3yNi1axdhYWG89tprFC5cmF27dnHx4kW8vLzInTs3H3/8MT///DOlS5dm8uTJ6X7Rvm3bNsaPH0+rVq3YuHEjy5Yt4+eff37geUeMGEGLFi0oVqwYb7/9NlZWVhw6dIjDhw/z2WefERAQQLly5ejcuTMTJ04kISGBoUOHmvXxzjvvMHToULp168awYcOIiYlhwoQJDzyvh4cHiYmJhIWFGctSpTc98kkNGjSI6tWr07t3b3r06EHu3LmJiopi48aNxqyXJk2a0KNHD2bPno2NjQ0ffvjhA2dFlClThtjYWBYvXkzVqlX5+eefWblyZZbFbG9vz6BBgxg4cCC2trbUqlWLixcv8vvvv9OtWzc6dOjAyJEj6dKlCyEhIVy8eJH333+fTp06GUtBPU0hISH07dsXZ2dnmjZtSlJSEnv37uXy5ct8/PHHj9RHer8Pmzdv5tSpU9SpU4d8+fKxdu1aUlJSMjUlVkSeDzNmzGDGjBlpjg8ZMoQhQ4ak26ZSpUps27Yt3bJ69epx9uzZLI1RRERERCSrFC1aNMNVMDIa4wJmszX+7UFj4GHDhpntCSoiIjmTRWdkODs789tvv9GsWTM8PT0ZNmwYEydOpGnTpgQHB9OlSxc6d+5M3bp1KVmyJPXr10/TR79+/di3bx+VKlUyNmC+t2lzRho3bsyaNWvYuHEjVatWpXr16kyaNMnYcNzKyoqVK1eSlJTEK6+8Qvfu3dNsVu3k5MRPP/3E0aNHqVSpEkOHDuXzzz9/4Hlr1qxJr169aNu2LYUKFWL8+PGPecceja+vLxEREZw4cYLatWtTqVIlhg8fbuzRADB//nyKFStG3bp1CQwMpGfPnhQuXDjDPlu2bMlHH31Enz598Pf3Z/v27QwfPjxL4x4+fDj9+vVjxIgReHl50bZtW2M/CUdHRzZs2MA///xD1apVad26NQ0bNmT69OlZGsOj6t69O9988w2hoaH4+PhQt25dQkNDH2tGRnq/D3nz5mXFihU0aNAALy8vvv76axYtWoS3t3c2Xo2IiIiIiIiIiIhIzmVKfZqbPYhItkpISMDFxYWOX6zB1iH3wxuISI4wt3c9S4cgIiLyRO6NQ+Onl8bZwdrS4YhIThd8zNIRiIjIM8bie2SIiIiIiIiIiIiIiIhkRIkMC9qyZQtOTk4Zvp4nsbGxD7zW2NhYS4coIiIiIiIiIiIiIjmQRTf7ftFVqVKFyMhIS4fxVBQpUuSB11qkSJGnF4yIiIiIiIiIiIiIPDOUyLAgBwcHypQpY+kwngobG5sX5lpFREREREREREREJOtos2+R54ixyWJ8PM7OzpYOR0REREReEBqHioiIiEh20h4ZIiIiIiIiIiIiIiKSYymRISIiIiIiIiIiIiIiOZYSGSIiIiIiIiIiIiIikmMpkSEiIiIiIiIiIiIiIjmWEhkiIiIiIiIiIiIiIpJj2Vg6ABHJer1nb8HWIbelw5Dn2Nze9SwdgoiIiORECyqDg7WloxCRJxF8zNIRiIiIpKEZGSIiIiIiIiIiIiIikmMpkSEiIiIiIiIiIiIiIjmWEhkiIiIiIiIiIiIiIpJjKZEhIiIiIiIiIiIiIiI5lhIZIiIiIiIiIiIiIiKSYymRISIiIiIiIiIiIiIiOZYSGSIiIiIiIiIiIiIikmMpkSHPjJiYGEwmE5GRkcaxbdu24ePjQ65cuWjVqpXFYkuPyWRi1apVlg5D5Km7cuUK/v7+xsvT0xMbGxv++ecfUlNTCQkJwdPTk4oVK1KvXj2j3dChQ/Hx8THaLVmyxHIXISIiIiIiady8eZNWrVrh6emJv78/TZo0ISYmBoAxY8ZQrlw5rKysWLNmjVm769ev0759e8qUKYOnpycrVqwwyn7++WeqVKmCnZ0d/fv3T3O+oKAgfHx8qFixIm+88QaXLl3K9usUEZGcR4kMeaZ9/PHH+Pv7c/r0aUJDQwkJCcHf3z/Lz5Nd/Yo8j/LmzUtkZKTx6tmzJ02bNiV//vxMmzaNw4cPc+TIEY4cOcKiRYuMdgMGDODw4cNERkaydu1aevToweXLly14JSIiIiIi8m89e/bk2LFjREZG0qJFC3r27AlAw4YNWbt2LXXq1EnTZsKECdjZ2XHy5Ek2bNjAe++9Z4z1y5Yty9y5cxkwYECadrNmzSIxMZFDhw5x5MgRXF1dGT9+fPZeoIiI5EhKZMgzLTo6mgYNGlC0aFHy5s1r6XBEJB3z58+nW7duAHzxxRd8/vnn2NraAuDu7m7Uu//v8NWrVzGZTKSkpDzVWEVEREREJGP29vY0a9YMk8kEQPXq1Tl16hQA1apVo3Tp0um2W7JkCb179wagZMmS1KlTh9WrVwPg6emJn58fNjY26ba9fv06t2/f5s6dOyQmJlK0aNGsviwREXkGKJEhT93y5cvx8fHBwcGBAgUKEBAQwLVr14C7X3h6eXlhb29P+fLlmTlzZrp93Ftm6u+//yY4OBiTyURoaCijRo3i4MGDmEwm4xhAfHw8PXv2pHDhwjg7O9OgQQMOHjwIwMWLF3Fzc2PMmDFG/7t27cLW1pZffvnlgf0+jj///JO2bduSL18+ChQoQMuWLY0puABBQUG0atWKCRMm4O7uToECBejduze3b9/OsM+kpCQSEhLMXiI5yY4dO/j7779p0aIFCQkJXLx4kZUrV1K9enWqV6+eZvmoadOmUa5cOSpXrszs2bMpUKCAhSIXERGRB9E4VETg7vj99ddff2i92NhYSpQoYbz38PAgNjb2oe3effddnJ2dKVy4MK6ursTHx9OnT58nillERJ5NSmTIUxUXF0f79u0JDg4mKiqK8PBwAgMDSU1NZc6cOQwdOpTRo0cTFRXFmDFjGD58ON9++22afooVK0ZcXBzOzs5MmTKFuLg42rZtS79+/fD29iYuLs44lpqaSvPmzTl//jxr165l3759VK5cmYYNG/LPP/9QqFAh5s2bR0hICHv37iUxMZGOHTvy3nvv8dprr2XY7+O4fv069evXx8nJid9++42tW7fi5OREkyZNuHXrllHv119/JTo6ml9//ZVvv/2W0NDQByZNxo4di4uLi/EqVqzYY8Ulkt3mzZtH586dsbGx4fbt29y6dYsbN26wc+dOli5dyscff8yRI0eM+n379uXYsWNs376dzz77jL///tuC0YuIiEhGNA4VkTFjxnDixAlGjx79SPXvzeIASE1NfaQ2mzZtwmQycf78eeLi4sibNy+ffPJJpuIVEZFnmxIZ8lTFxcVx584dAgMD8fDwwMfHh/feew8nJyc+/fRTJk6cSGBgICVLliQwMJCPPvqIWbNmpenH2toaNzc3TCYTLi4uuLm54eDggJOTEzY2Nri5uRnHfv31Vw4fPsyyZcuoUqUKZcuWZcKECeTNm5fly5cD0KxZM3r06EGHDh3o1asX9vb2jBs3DiDDfh/H4sWLsbKy4ptvvsHHxwcvLy/mz59PbGws4eHhRr18+fIxffp0ypcvT4sWLWjevDlhYWEZ9jtkyBDi4+ON1x9//PFYcYlkp2vXrrFkyRKCg4MBKFCgAE5OTnTs2BGA4sWLU6tWLfbu3ZumrZ+fHy+99JLZ3w8RERHJOTQOFXmxTZgwgRUrVrBu3TocHR0fWr948eJmKxKcOXOG4sWLP7Td119/zZtvvom9vT22trZ06NCBX3/99UlCFxGRZ5QSGfJU+fn50bBhQ3x8fHj77beZM2cOly9f5uLFi/zxxx9069YNJycn4/XZZ58RHR39ROfct28fiYmJxpeo916nT58263vChAncuXOHpUuXsnDhQuzt7Z/0cs1iOHnyJHny5DHOnz9/fm7evGkWg7e3N9bW1sZ7d3d3Lly4kGG/dnZ2ODs7m71Ecoply5bh6+tL+fLljWPt27dn/fr1AFy+fJndu3fj6+sLQFRUlFEvOjqaAwcOUKFChacbtIiIiDwSjUNFXlyTJk1i0aJFbNy48ZH3qnz77beZMWMGAKdPnyYiIoI33njjoe1KlSrFhg0bSE1NJTU1lTVr1lCxYsUnCV9ERJ5R6e+kJJJNrK2t2bhxI9u3b+eXX37hyy+/ZOjQofz0008AzJkzh2rVqqVp8yRSUlJwd3dP98nu+wddp06d4ty5c6SkpHDmzBnjy9WskJKSwssvv8zChQvTlBUqVMj4OVeuXGZl2uxYnmVz5841Nvm+Z8yYMXTt2tXY/2bIkCFUrlwZgMGDB3Py5Ely5cqFjY0N06dPx8vL66nHLSIiIiIi6Tt79iz9+vWjVKlS1K9fH7ib2Ny1axdjx45lxowZXLx4kaCgIOzt7Tlw4ACFChViwIABBAcHU6ZMGaysrJgxYwb58+cHIDw8nI4dO5KQkEBqaiqLFy9m5syZvPHGG4SEhNCzZ0+8vb0xmUxUqFAh3VUbRETk+adEhjx1JpOJWrVqUatWLUaMGEGJEiXYtm0bL730EqdOnaJDhw6Z7tvW1pbk5GSzY5UrV+b8+fPY2Njg4eGRbrtbt27RoUMH2rZtS/ny5enWrRuHDx/G1dU1w34fR+XKlVmyZImx2bjIi2DLli1pjhUsWNBIXP7b6tWrszskERERERF5AkWLFs1wf4shQ4YwZMiQdMty587NkiVL0i2rV68eZ8+eTbcsf/78xpLQIiLyYtPSUvJU7dq1izFjxrB3715iY2NZsWIFFy9exMvLi5CQEMaOHcvUqVM5fvw4hw8fZv78+UyaNOmR+/fw8OD06dNERkZy6dIlkpKSCAgIoEaNGrRq1YoNGzYQExPD9u3bGTZsmLE2/9ChQ4mPj2fatGkMHDgQLy8vsyfJ0+v3cXTo0IGCBQvSsmVLtmzZYkyl/eCDDzIcsImIiIiIiIiIiIiIEhnylDk7O/Pbb7/RrFkzPD09GTZsGBMnTqRp06Z0796db775htDQUHx8fKhbty6hoaGULFnykft/6623aNKkCfXr16dQoUIsWrQIk8nE2rVrqVOnDsHBwXh6etKuXTtiYmJwdXUlPDycKVOmsGDBApydnbGysmLBggVs3bqVr776KsN+H4ejoyO//fYbxYsXJzAwEC8vL4KDg7lx44ZmaIiIiIiIiIiIiIg8gCk1ozmBIvLMSUhIwMXFhY5frMHWIbelw5Hn2Nze9SwdgoiIiOQg98ah8dNL4+zwZHvciYiFBR+zdAQiIiJpaEaGiIiIiIiIiIiIiIjkWEpkiGTCwoULcXJySvfl7e1t6fBEREREREREREREnhs2lg5A5Fn0xhtvUK1atXTLcuXK9ZSjEREREREREREREXl+KZEhkgl58uQhT548lg5DRERERERERERE5Lmnzb5FniPGJovx8Tg7O1s6HBERERF5QWgcKiIiIiLZSXtkiIiIiIiIiIiIiIhIjqVEhoiIiIiIiIiIiIiI5FhKZIiIiIiIiIiIiIiISI6lRIaIiIiIiIiIiIiIiORYSmSIiIiIiIiIiIiIiEiOZWPpAEQk6/WevQVbh9xP3M/c3vWePBgREREReXEsqAwO1paOQuTxBR+zdAQiIiLyAJqRISIiIiIiIiIiIiIiOZYSGSIiIiIiIiIiIiIikmMpkSEiIiIiIiIiIiIiIjmWEhkiIiIiIiIiIiIiIpJjKZEhIiIiIiIiIiIiIiI5lhIZIiIiIiIiIiIiIiKSYymRIQ8VHh6OyWTiypUrD6zn4eHBlClTnkpM2SUoKIhWrVpZOoxnxvr166lSpQq+vr5Ur16dgwcPAlCvXj1KlSqFv78//v7+TJ482cKRioiIiIiIZF7fvn3x8PDAZDJx5MgR4/iDPvv897//xcvLCz8/P1555RU2b95s1ucPP/yAj48P3t7eVKhQgZiYGLPyixcv4urqSuvWrbP12kRERJ4FNpYOQHKeevXq4e/vbyQlatasSVxcHC4uLgCEhoby4YcfPjSxkZPFxMRQsmRJDhw4gL+/v3F86tSppKamWi6w+5hMJlauXJljEyuXL1+mY8eObNmyBS8vLyIiIujQoYMxqJ82bRotWrSwcJQiIiIiIiJPrnXr1gwcOJBXX301TVlGn31q167N8OHDcXBw4ODBg9SrV4+4uDjs7e05cOAAw4YNIywsjCJFipCQkICNjflXNO+99x7NmjXj6tWr2XZdIiIizwrNyJCHsrW1xc3NDZPJZOlQsp2Liwt58+a1dBjPhOjoaAoXLoyXlxcAdevW5cyZM+zfv9/CkYmIiIiIiGStOnXqULRo0cdq07RpUxwcHADw8fEhOTmZS5cuATBx4kT69etHkSJFAHB2dsbR0dFou3DhQlxdXalbt24WXYGIiMizTYkMMRMUFERERARTp07FZDJhMpkIDQ01lpYKDw+na9euxMfHG+UhISHp9hUfH0/Pnj0pXLgwzs7ONGjQwFh66GEOHjxI/fr1yZMnD87Ozrz88svs3bvXKN++fTt16tTBwcGBYsWK0bdvX65du2aUe3h4MGbMGIKDg8mTJw/Fixdn9uzZRnnJkiUBqFSpEiaTiXr16hnXf/8MiHr16vH+++/z4Ycfki9fPlxdXZk9ezbXrl2ja9eu5MmTh9KlS7Nu3Tqz+I8ePUqzZs1wcnLC1dWVTp06GQPWe/327duXgQMHkj9/ftzc3Mzuo4eHBwBvvvkmJpPJeP9vSUlJJCQkmL2elrJly3Lx4kV27twJwMqVK0lMTDSmQw8YMAAfHx/atm3LqVOnnlpcIiIiIpL9LDkOFclpHuWzz/z58yldurSRDDl69CixsbHUrVuXSpUqMXz4cJKTkwE4d+4ckyZNYty4cU/tGkRERHI6JTLEzNSpU6lRowY9evQgLi6OuLg4ihUrZpTXrFmTKVOm4OzsbJT3798/TT+pqak0b96c8+fPs3btWvbt20flypVp2LAh//zzz0Pj6NChA0WLFmXPnj3s27ePwYMHkytXLgAOHz5M48aNCQwM5NChQyxZsoStW7fSp08fsz4mTpxIlSpVOHDgAO+99x7/+c9/+N///gfA7t27Adi0aRNxcXGsWLEiw1i+/fZbChYsyO7du3n//ff5z3/+w9tvv03NmjXZv38/jRs3plOnTly/fh2AuLg46tati7+/P3v37mX9+vX89ddftGnTJk2/uXPnZteuXYwfP55PPvmEjRs3ArBnzx7g7mA3Li7OeP9vY8eOxcXFxXjd/2eV3VxcXPjhhx8YPHgwL7/8MuHh4VSoUIFcuXKxYMECoqKiOHToELVr19YSUyIiIiLPGUuOQ0Vykkf57BMWFsaoUaNYvHixcez27dvs27eP9evXs23bNnbs2MGsWbMA6NGjB+PHj8fJyempXYeIiEhOZ0rNKRsCSI7x7z0ywsPDqV+/PpcvXyZv3rwZ7pHh4eHBhx9+yIcffsjmzZt58803uXDhAnZ2dkadMmXKMHDgQHr27PnAGJydnfnyyy/p0qVLmrLOnTvj4OBgDPIAtm7dSt26dbl27Rr29vZ4eHhQu3ZtFixYANxNrLi5uTFq1Ch69eqV4R4ZQUFBXLlyhVWrVhn3Ijk5mS1btgCQnJyMi4sLgYGBfPfddwCcP38ed3d3duzYQfXq1RkxYgS7du1iw4YNRr9nz56lWLFiHDt2DE9PzzT9Arzyyis0aNDAeOrmUfbISEpKIikpyXifkJBAsWLF6PjFGmwdcj/wHj+Kub3rPXLdpKQk3Nzc2LNnD2XKlDErs7e3588//6RAgQJPHJOIiIiIWF5G49D46aVxdrC2YGQimRR87JGqeXh4sGbNGipWrJhu+b8/+0RERNCpUyd++ukn/Pz8jHotWrQgMDCQ4OBgAGbOnMnu3bsJDQ0lf/78ODs7A5CYmMiNGzd49dVXzT5jioiIvGi02bdki3379pGYmJjmi+sbN24QHR390PYff/wx3bt3Z8GCBQQEBPD2229TunRpo++TJ0+ycOFCo35qaiopKSmcPn3a2LPB19fXKDeZTLi5uXHhwoXHvpb7+7G2tqZAgQL4+PgYx1xdXQGMvvft28evv/6a7tMz0dHReHp6pukXwN3d/bHjs7OzM0sUPW1xcXG4u7sD8Omnn9KgQQM8PDz466+/jPvyww8/4OrqqiSGiIiIyHPE0uNQkZzgzp07/P333xl+9vntt9/o1KkTq1evNktiALzzzjv8+OOPBAUFkZqaysaNG6lTpw6A2SoGoaGhrFmzhuXLlz+lqxIREcmZlMiQbJGSkoK7uzvh4eFpyh5lM+2QkBDeeecdfv75Z9atW8fIkSNZvHgxb775JikpKbz77rv07ds3TbvixYsbP99biuoek8lESkrKY19Lev3cf+zeJuj3+k5JSeH111/n888/T9PXvS/9szI+Sxo+fDhbt27lzp071KhRg7lz55KUlETz5s1JSkrCysqKggUL8uOPP1o6VBERERERkUzr3bs3q1ev5vz58wQEBODk5MTBgwcf+NmnW7duJCUl0bVrV+PYggUL8PHxoV27duzduxdvb2+sra2pU6dOmuWSRURE5P9RIkPSsLW1NTYZy0w5QOXKlTl//jw2NjYZblT9MJ6ennh6evLRRx/Rvn175s+fz5tvvknlypX5/fff0yxf9DhsbW0BHnodmVG5cmV++OEHPDw8sLHJ/F+xXLlyZUt8Wembb75J9/j9G7OLiIiIiIg862bMmMGMGTPSHH/QZ58TJ05kWGZlZcWkSZOYNGnSA88bFBREUFDQI8cpIiLyvNJm35KGh4cHu3btIiYmhkuXLqWZJeDh4UFiYiJhYWFcunTJ2OT6fgEBAdSoUYNWrVqxYcMGYmJi2L59O8OGDXvol9w3btygT58+hIeHc+bMGbZt28aePXuMJaMGDRrEjh076N27N5GRkZw4cYIff/yR999//5GvsXDhwjg4OBgbccfHxz9y24fp3bs3//zzD+3bt2f37t2cOnWKX375heDg4MdKTHh4eBAWFsb58+e5fPlylsUnIiIiIiIiIiIi8ixRIkPS6N+/P9bW1lSoUIFChQoRGxtrVl6zZk169epF27ZtKVSoEOPHj0/Th8lkYu3atdSpU4fg4GA8PT1p164dMTExxvqhGbG2tubvv/+mc+fOeHp60qZNG5o2bcqoUaOAu3tLREREcOLECWrXrk2lSpUYPny42bJND2NjY8O0adOYNWsWRYoUoWXLlo/c9mGKFCnCtm3bSE5OpnHjxlSsWJEPPvgAFxcXrKwe/a/cxIkT2bhxI8WKFaNSpUpZFp+IiIiIiIiIiIjIs8SUmpqaaukgRCRrJCQk4OLiQscv1mDrkPuJ+5vbu96TByUiIiIiz71749D46aVxdrC2dDgijy/4mKUjEBERkQfQjAwREREREREREREREcmxlMgQi/D29sbJySnd18KFCy0dnoiIiIiIiIiIiIjkEDaWDkBeTGvXruX27dvplj1sDw0REREREREREREReXEokSEWUaJECUuHICIiIiIiIiIiIiLPAG32LfIcMTZZjI/H2dnZ0uGIiIiIyAtC41ARERERyU7aI0NERERERERERERERHIsJTJERERERERERERERCTHUiJDRERERERERERERERyLCUyREREREREREREREQkx1IiQ0REREREREREREREciwbSwcgIlmv9+wt2DrkzvbzzO1dL9vPISIiIiLPkAWVwcHa0lHIsy74mKUjEBERkRxGMzJERERERERERERERCTHUiJDRERERERERERERERyLCUyREREREREREREREQkx1IiQ0REREREREREREREciwlMkREREREREREREREJMdSIkNERERERERERERERHIsJTIkW9WrV48PP/zQ0mFkyuzZsylWrBhWVlZMmTLlsduHhITg7++f5XGJiIiIiIiIiIiIvEiUyBBJR0JCAn369GHQoEH8+eef9OzZ09IhPXP69u2Lh4cHJpOJI0eOGMe7du2Kr68v/v7+VK1albCwMKNs6NCh+Pj44O/vj7+/P0uWLLFE6CIiIiIikkNl9DkjODiYcuXK4e/vT506dYiMjDTKWrdubXzG8Pf3x8rKih9//NGs32PHjuHo6Ej//v2NY6GhoeTNm9doV79+/Wy/PhEREUmfjaUDEMlqt27dwtbW9on6iI2N5fbt2zRv3hx3d/csiuzF0rp1awYOHMirr75qdnzy5MnkzZsXgMjISAICArh48SImk4kBAwYwevRoAM6dO0f58uV57bXXyJcv39MOX0REREREcqCMPme0atWK2bNnY2Njw5o1a2jTpg3Hjx8HYPny5Ua9vXv30qRJExo3bmwcS05O5t1336VVq1ZpzhcQEGDWXkRERCxDMzIk26WkpDBw4EDy58+Pm5sbISEhRllsbCwtW7bEyckJZ2dn2rRpw19//WWUBwUFpRlMfvjhh9SrV894X69ePfr06cPHH39MwYIFadSo0UNjetB5Q0ND8fHxAaBUqVKYTCZiYmIe2ue4ceNwdXUlT548dOvWjZs3b5qV79mzh0aNGlGwYEFcXFyoW7cu+/fvN8qDg4Np0aKFWZs7d+7g5ubGvHnzHnr+nKZOnToULVo0zfF7SQyAK1euYDKZ0i27evUqJpOJlJSU7AxTRERERESeIRl9znjjjTewsbn7rGb16tU5c+ZMup8l5s2bR8eOHbGzszOOjRs3jhYtWuDp6Zl9gYuIiMgTUSJDst23335L7ty52bVrF+PHj+eTTz5h48aNpKam0qpVK/755x8iIiLYuHEj0dHRtG3bNlPnsLGxYdu2bcyaNeuBdR923rZt27Jp0yYAdu/eTVxcHMWKFXtgn0uXLmXkyJGMHj2avXv34u7uzsyZM83qXL16lS5durBlyxZ27txJ2bJladasGVevXgWge/furF+/nri4OKPN2rVrSUxMpE2bNumeNykpiYSEBLPXs2Dw4MGULl2awMBAli1bZpbMmDZtGuXKlaNy5crMnj2bAgUKWDBSEREREUnPszoOlRfD1KlTadasGVZW5l953Lx5k0WLFtGtWzfj2KFDh9iwYQMfffRRun1FRETg7+9PrVq1NDNDRETEgrS0lGQ7X19fRo4cCUDZsmWZPn26sS/CoUOHOH36tJEoWLBgAd7e3uzZs4eqVas+8jnKlCnD+PHjH6nupk2bHnree1+eFypUCDc3t4f2OWXKFIKDg+nevTsAn332GZs2bTKbldGgQQOzNrNmzSJfvnxERETQokULatasSbly5ViwYAEDBw4EYP78+bz99ts4OTmle96xY8cyatSoR7runGTcuHGMGzeOTZs2MWDAALZt22YsB9a3b1/69u3LwYMH6dixIwEBAUpmiIiIiOQwz+o4VJ5/33//PUuXLmXLli1pyn744QfKli1rzMC/ffs2PXr0YP78+VhbW6ep36JFC9q0aYOjoyNRUVG89tprFC1alOrVq2f7dYiIiIg5zciQbOfr62v23t3dnQsXLhAVFUWxYsXMZjtUqFCBvHnzEhUV9VjnqFKlyiPXzcrz3t9njRo1zI79+/2FCxfo1asXnp6euLi44OLiQmJiIrGxsUad7t27M3/+fKP+zz//THBwcIbnHTJkCPHx8cbrjz/+yFT8lhIQEMDVq1c5fPhwmjI/Pz9eeuklwsPDn35gIiIiIvJAz/o4VJ5PS5YsYdSoUWzcuJHChQunKZ87d67ZbIy4uDiio6Np1qwZHh4eTJkyhTlz5hh1ChYsiKOjIwBeXl40a9aMbdu2PZ2LERERETOakSHZLleuXGbv7+17kJqaarak0D33H7eysiI1NdWs/Pbt22na5M6d+5HjeZTzZoegoCAuXrzIlClTKFGiBHZ2dtSoUYNbt24ZdTp37szgwYPZsWMHO3bswMPDg9q1a2fYp52dndnarjndnTt3OH36NGXLlgXuLt114cIFSpUqBdxNCHl5eQEQHR3NgQMHqFChgsXiFREREZH0PWvjUHn+LV26lGHDhrFp0yaKFy+epvz06dPs3r2bVatWGceKFy/OpUuXjPchISEkJiYyYcIEAP78809eeuklAP766y82b96cqaWQRURE5MkpkSEWU6FCBWJjY/njjz+M2RFHjx4lPj7e+DK7UKFCHDlyxKxdZGRkmuRIVp/3cXl5ebFz5046d+5sHNu5c6dZnS1btjBz5kyaNWsGwB9//GE2aAYoUKAArVq1Yv78+ezYsYOuXbtmKp6coHfv3qxevZrz588TEBCAk5MTv//+O0FBQcTHx2NtbU3u3LlZvnw5+fLlA+7unXHy5Ely5cqFjY0N06dPz/SfiYiIiIiIPH/S+5xx8uRJOnTogJubGy1btjTqhoWFGcvUzps3j7feegtnZ+dHPteMGTNYvXo1uXLlIiUlhY8++ijNksEiIiLydCiRIRYTEBCAr68vHTp0YMqUKdy5c4f33nuPunXrGktFNWjQgC+++ILvvvuOGjVq8P3333PkyBEqVaqUred9XB988AFdunShSpUqvPrqqyxcuJDff//dmGkAd/fxWLBgAVWqVCEhIYEBAwbg4OCQpq/u3bvTokULkpOT6dKlS6av09JmzJjBjBkz0hx/0FTs1atXZ2dIIiIiIiLyjMvoc0Z6M/fv9+mnnz6075CQELP3Y8aMYcyYMY8Vn4iIiGQP7ZEhFmMymVi1ahX58uWjTp06BAQEUKpUKZYsWWLUady4McOHD2fgwIFUrVqVq1evms16yK7zPq62bdsyYsQIBg0axMsvv8yZM2f4z3/+Y1Zn3rx5XL58mUqVKtGpUyf69u2b7rqtAQEBuLu707hxY4oUKZLpmERERERERERERESeB6bUf29AICIWdf36dYoUKcK8efMIDAx8rLYJCQm4uLjQ8Ys12Do8+r4hmTW3d71sP4eIiIiI5Hz3xqHx00vj7GBt6XDkWRd8zNIRiIiISA6jpaVEcoiUlBTOnz/PxIkTcXFx4Y033rB0SCIiIiIiIiIiIiIWp6Wl5LmzcOFCnJyc0n15e3tnqk9vb+8M+1y4cGGWxB0bG8tLL73E0qVLmTdvHjY2yjOKiIiIiIiIiIiI6JtSee688cYbVKtWLd2yXLlyZarPtWvXZrh5nKura6b6/DcPDw+00puIiIiIiIiIiIiIOSUy5LmTJ08e8uTJk6V9lihRIkv7ExEREREREREREZFHo82+RZ4jxiaL8fE4OztbOhwREREReUFoHCoiIiIi2Ul7ZIiIiIiIiIiIiIiISI6lRIaIiIiIiIiIiIiIiORYSmSIiIiIiIiIiIiIiEiOpUSGiIiIiIiIiIiIiIjkWEpkiIiIiIiIiIiIiIhIjmVj6QBEJOv1nr0FW4fcj91ubu96WR+MiIiIiLw4FlQGB2tLRyGPI/iYpSMQEREReSjNyBARERERERERERERkRxLiQwREREREREREREREcmxlMgQEREREREREREREZEcS4kMERERERERERERERHJsZTIEBERERERERERERGRHEuJDBERERERERERERERybGUyHiBxMTEYDKZiIyMNI5t27YNHx8fcuXKRatWrSwWW06R3j0SEREREREREREREctRIuMF9/HHH+Pv78/p06cJDQ0lJCQEf3//LD9PdvX7JIKCgtIkb4oVK0ZcXBwVK1a0TFD3yWn37MqVK/j7+xsvT09PbGxs+Oeff+jatSu+vr74+/tTtWpVwsLCLB2uiIiIiIhkgfXr11OlShV8fX2pXr06Bw8eBKBevXqUKlXK+HwwefJko83QoUPx8fExypYsWWKUTZs2jYoVKxqfH+4vExEREcmIjaUDEMuKjo6mV69eFC1a1NKh5AjW1ta4ublZOowcKW/evGYzVSZMmEBERAT58+dn8uTJ5M2bF4DIyEgCAgK4ePEiJpPJMsGKiIiIiMgTu3z5Mh07dmTLli14eXkRERFBhw4dOHLkCHA3KdGiRYs07QYMGMDo0aMBOHfuHOXLl+e1114jX758eHt7s23bNlxcXPjjjz+oXLky1atXp0SJEk/12kREROTZohkZz6Dly5fj4+ODg4MDBQoUICAggGvXrgEwf/58vLy8sLe3p3z58sycOTPdPu4tofT3338THByMyWQiNDSUUaNGcfDgQUwmk3EMID4+np49e1K4cGGcnZ1p0KCB8STOxYsXcXNzY8yYMUb/u3btwtbWll9++eWB/T5ISEgIxYsXx87OjiJFitC3b1+j7NatWwwcOJCXXnqJ3LlzU61aNcLDw43y0NBQ8ubNy4YNG/Dy8sLJyYkmTZoQFxdn9P3tt9+yevVqI6bw8PA0S0uFh4djMpnYsGEDlSpVwsHBgQYNGnDhwgXWrVuHl5cXzs7OtG/fnuvXrxvnT01NZfz48ZQqVQoHBwf8/PxYvny5UX6v37CwMKpUqYKjoyM1a9bk2LFjRvyZuWdP0/z58+nWrRuAkcSAuzM3lMAQEREREXn2RUdHU7hwYby8vACoW7cuZ86cYf/+/Q9sd//ng6tXr2IymUhJSQGgYcOGuLi4AHdnxLu6uvLHH39kzwWIiIjIc0MzMp4xcXFxtG/fnvHjx/Pmm29y9epVtmzZQmpqKnPmzGHkyJFMnz6dSpUqceDAAXr06EHu3Lnp0qWLWT/3llAqV64cn3zyCW3btsXFxYUjR46wfv16Nm3aBICLiwupqak0b96c/Pnzs3btWlxcXJg1axYNGzbk+PHjFCpUiHnz5tGqVStee+01ypcvT8eOHXnvvfd47bXXuHHjRrr9Psjy5cuZPHkyixcvxtvbm/PnzxuJE4CuXbsSExPD4sWLKVKkCCtXrqRJkyYcPnyYsmXLAnD9+nUmTJjAggULsLKyomPHjvTv35+FCxfSv39/oqKiSEhIYP78+QDkz5+fc+fOpRtPSEgI06dPx9HRkTZt2tCmTRvs7Oz4v//7PxITE3nzzTf58ssvGTRoEADDhg1jxYoVfPXVV5QtW5bffvuNjh07UqhQIerWrWv0O3ToUCZOnEihQoXo1asXwcHBbNu2jbZt2z7SPUtKSiIpKcl4n5CQ8MD7mlV27NjB33//bfb01eDBg1m2bBmXL19mxYoVSmaIiIiIPMcsNQ6Vp6ts2bJcvHiRnTt3Ur16dVauXEliYiIxMTHA3ZkXQ4YMoUKFCowdO5ZSpUoZbadNm8aMGTM4e/Ys8+bNo0CBAmn637RpE5cvX+bll19+WpckIiIizyglMp4xcXFx3Llzh8DAQGPqrY+PDwCffvopEydOJDAwEICSJUty9OhRZs2alSaRcW8JJZPJhIuLi7GckpOTEzY2NmbLK23evJnDhw9z4cIF7OzsgLvLCq1atYrly5fTs2dPmjVrRo8ePejQoQNVq1bF3t6ecePGAeDg4JBuvw8SGxuLm5sbAQEB5MqVi+LFi/PKK68Ad58KWrRoEWfPnqVIkSIA9O/fn/Xr1zN//nxjZsjt27f5+uuvKV26NAB9+vThk08+Ma7TwcGBpKSkR4rps88+o1atWgB069aNIUOGEB0dbQzUW7duza+//sqgQYO4du0akyZNYvPmzdSoUQOAUqVKsXXrVmbNmmWWyBg9erTxfvDgwTRv3pybN28+8j0bO3Yso0aNeqR7mpXmzZtH586dsbH5f/+EjBs3jnHjxrFp0yYGDBjAtm3bsLW1feqxiYiIiEj2s9Q4VJ4uFxcXfvjhBwYPHszVq1d59dVXqVChArly5WLBggUUK1aM1NRUZsyYQYsWLTh69KjRtm/fvvTt25eDBw/SsWNHAgICzJIZhw8fpmvXrixZsgQHBwdLXJ6IiIg8Q7S01DPGz8+Phg0b4uPjw9tvv82cOXO4fPkyFy9e5I8//qBbt244OTkZr88++4zo6OgnOue+fftITEykQIECZn2fPn3arO8JEyZw584dli5dysKFC7G3t8/0Od9++21u3LhBqVKl6NGjBytXruTOnTsA7N+/n9TUVDw9Pc3iiYiIMIvH0dHRSGIAuLu7c+HChUzF4+vra/zs6uqKo6Oj2dNGrq6uRt9Hjx7l5s2bNGrUyCy+7777Ls2fxf39uru7AzxWjEOGDCE+Pt54PY0p2deuXWPJkiUEBwenWx4QEMDVq1c5fPhwtsciIiIiIpZhiXGoWEadOnUIDw9n3759jB8/nnPnzuHl5UWxYsUAMJlM9OnTh1OnTvH333+nae/n58dLL71kthTw0aNHadGiBfPmzePVV199WpciIiIizzDNyHjGWFtbs3HjRrZv384vv/zCl19+ydChQ/npp58AmDNnDtWqVUvT5kmkpKTg7u5uNvC85/61T0+dOsW5c+dISUnhzJkzZl/SP65ixYpx7NgxNm7cyKZNm3jvvff44osviIiIICUlBWtra/bt25fm2pycnIyfc+XKZVZmMplITU3NVDz392UymdLt+96ar/f++/PPP/PSSy+Z1bs3oyWjfu9v/yjs7OzS9Jndli1bhq+vL+XLlwfgzp07nD592ljSa/fu3Vy4cMEs0SMiIiIizxdLjEPFMuLi4oyHrj799FMaNGiAh4cHf/31F66urgD88MMPuLq6GjMuoqKijH01oqOjOXDgABUqVDDKmjVrxuzZs2nUqJEFrkhERESeRUpkPINMJhO1atWiVq1ajBgxghIlSrBt2zZeeuklTp06RYcOHTLdt62tLcnJyWbHKleuzPnz57GxscHDwyPddrdu3aJDhw60bduW8uXL061bNw4fPmwMbNPr92EcHBx44403eOONN+jduzfly5fn8OHDVKpUieTkZC5cuEDt2rUzdZ2ZjelRVKhQATs7O2JjY82WkXpc2RXfk5o7d66xyTdAcnIyQUFBxMfHY21tTe7cuVm+fDn58uWzYJQiIiIiIpIVhg8fztatW7lz5w41atRg7ty5JCUl0bx5c5KSkrCysqJgwYL8+OOPRpvBgwdz8uRJcuXKhY2NDdOnTzcSG3379iU+Pp5BgwYZewx+/vnnNG7c2CLXJyIiIs8GJTKeMbt27SIsLIzXXnuNwoULs2vXLi5evIiXlxchISH07dsXZ2dnmjZtSlJSEnv37uXy5ct8/PHHj9S/h4cHp0+fJjIykqJFi5InTx4CAgKoUaMGrVq14vPPP6dcuXKcO3eOtWvX0qpVK6pUqcLQoUOJj49n2rRpODk5sW7dOrp168aaNWsy7PdBT3CFhoaSnJxMtWrVcHR0ZMGCBTg4OFCiRAkKFChAhw4d6Ny5MxMnTqRSpUpcunSJzZs34+PjQ7NmzR75Wjds2MCxY8coUKDAQzcgf1R58uShf//+fPTRR6SkpPDqq6+SkJDA9u3bcXJySrNfyYPie5x79rRs2bLF7L2dnR3btm2zUDQiIiIiIpKdvvnmm3SP7927N8M2q1evzrBs48aNTxyTiIiIvHieaI+M33//nXbt2lG6dGns7OzYv38/AEOHDmXdunVZEqCYc3Z25rfffqNZs2Z4enoybNgwJk6cSNOmTenevTvffPMNoaGh+Pj4ULduXUJDQylZsuQj9//WW2/RpEkT6tevT6FChVi0aBEmk4m1a9dSp04dgoOD8fT0pF27dsTExODq6kp4eDhTpkxhwYIFODs7Y2VlxYIFC9i6dStfffVVhv0+SN68eZkzZw61atXC19eXsLAwfvrpJ2Oq8vz58+ncuTP9+vWjXLlyvPHGG+zatctYp/VR9OjRg3LlylGlShUKFSqUpV/Gf/rpp4wYMYKxY8fi5eVF48aN+emnn574z0JERERERERERETkRWNKzeSmARs3bqR58+ZUrlyZhg0bMnbsWPbu3UvlypUJCQlh3759xr4NIvJ0JCQk4OLiQscv1mDrkPux28/tXS/rgxIRERGR5969cWj89NI4OzzZHn3ylAUfs3QEIiIiIg+V6RkZQ4YMoV27duzcuZNRo0aZlVWqVIkDBw48cXAiIiIiIiIiIiIiIvJiy3Qi48iRI3Tq1Am4u/n0/fLmzculS5eeLDJ5ri1cuBAnJ6d0X97e3pYOT0RERERERERERERyiExv9p0/f37OnTuXbtnx48dxd3fPdFDy/HvjjTeoVq1aumW5cuV6ytGIiIiIiIiIiIiISE6V6URGq1atGDlyJNWrV6dMmTLA3ZkZ58+fZ8KECbz11ltZFqQ8f/LkyUOePHksHYaIiIiIiIiIiIiI5HCZ3uw7Pj6egIAADh06hI+PD/v378fPz49Tp05Rrlw5Nm/ejJOTU1bHKyIPYGyyGB+Ps7OzpcMRERERkReExqEiIiIikp0yPSPDxcWF7du38/3337Nx40by589P/vz56d27N507d8bW1jYr4xQRERERERERERERkRdQpmZk3Lx5kzZt2tCvXz/q1q2bHXGJSCboSTgRERERsQSNQ0VEREQkO1llppG9vT0RERGkpKRkdTwiIiIiIiIiIiIiIiKGTCUyAF577TU2btyYlbGIiIiIiIiIiIiIiIiYyfQeGV27dqVXr14kJibStGlTChcujMlkMqtTuXLlJw5QREREREREREREREReXJnaIwPAysp8Msf9SYzU1FRMJhPJyclPFp2IPJZ7axN3/GINtg65LR3OC2lu73qWDkFERETkqTP2yJheGmcHa0uHkzMFH7N0BCIiIiLPrEzPyPj111+zMg4REREREREREREREZE0Mp3IqFu3blbGISIiIiIiIiIiIiIikkamN/sWERERERERERERERHJbpmekWFlZZVmc+9/0x4ZIiIiIiIiIiIiIiLyJDKdyBg/fnyaRMY///zDxo0b+euvv3j//fefODgREREREREREREREXmxZTqR0b9//3SPjx49mo4dO5KQkJDpoERERERERERERERERCCb9sjo3Lkzs2fPzo6uRURERERERERERETkBZItiYzjx49rfwwxU69ePT788ENLhyGSY4waNQqTycSRI0cAqFmzJv7+/vj7+1OxYkVMJhOHDh0CICgoiKJFixrlAwYMsGToIiIiIpINkpKS6NOnD2XLlsXb25uOHTsCEBwcTLly5fD396dOnTpERkYabVq3bm2MEf39/bGysuLHH38EYMaMGfj4+ODv74+Pjw/Tpk2zxGWJiIiIZIlMLy01adKkNMdu3bpFVFQUy5Yt45133nmiwOT5smLFCnLlyvVEfdSrVw9/f3+mTJmSNUFlc79PIifGJFln//797Ny5k+LFixvHtm/fbvy8fPlyRo0aha+vr3Fs8ODB9OnT56nGKSIiIiJPz+DBg7GysuL48eOYTCbi4uIAaNWqFbNnz8bGxoY1a9bQpk0bjh8/DtwdN96zd+9emjRpQuPGjQHo2LEjvXv3BiAhIYGKFStSr149szGmiIiIyLMiS/fIsLOzo2jRonzwwQcMHz78iQKT50v+/PktHYJIjpCUlETv3r35v//7P+rXr59unXnz5tGtW7enHJmIiIiIWMq1a9eYP38+Z8+exWQyAeDu7g7AG2+8YdSrXr06Z86cISUlBSsr8wUW5s2bR8eOHbGzswPAxcXFKLt+/Tp37twx+hYRERF51mR6aamUlJQ0rxs3bnDixAnGjh2Lo6NjVsYpz7j7l5aaOXMmZcuWxd7eHldXV1q3bv3Q9kFBQURERDB16lRMJhMmk4mYmBgAjh49SrNmzXBycsLV1ZVOnTpx6dIlAMLDw7G1tWXLli1GXxMnTqRgwYLExcU9sN+MhIeHYzKZ+Pnnn/Hz88Pe3p5q1apx+PBhs3o//PAD3t7e2NnZ4eHhwcSJE83KM7oPjxNTUlISCQkJZi/J2UaMGEHHjh0pWbJkuuV//vkn4eHhxlIC90yaNAlfX19atGhhtpyAiIiIiCVoHJq1oqOjKVCgAJ999hlVqlShdu3ahIWFpak3depUmjVrliaJcfPmTRYtWpTmYZjly5fj7e1NiRIlGDBgAD4+Ptl6HSIiIiLZJdOJjO+++46///473bJ//vmH7777LtNByfNr79699O3bl08++YRjx46xfv166tSp89B2U6dOpUaNGvTo0YO4uDji4uIoVqwYcXFx1K1bF39/f/bu3cv69ev566+/aNOmDfD/EiidOnUiPj6egwcPMnToUObMmYO7u3uG/T6KAQMGMGHCBPbs2UPhwoV54403uH37NgD79u2jTZs2tGvXjsOHDxMSEsLw4cMJDQ196H14nJjGjh2Li4uL8XrU2MUyduzYwZ49e3jvvfcyrBMaGkqLFi0oWLCgcWz06NGcPHmSQ4cO0a1bN5o2bUpiYuLTCFlEREQkXRqHZq3bt29z6tQpKlSowN69e5k+fTrt2rXj4sWLRp3vv/+epUuXMmvWrDTtf/jhB8qWLZsmUdG6dWt+//13jh07xnfffcexY8ey/VpEREREskOmExldu3YlOjo63bLTp0/TtWvXTAclz6/Y2Fhy585NixYtKFGiBJUqVaJv374Pbefi4oKtrS2Ojo64ubnh5uaGtbU1X331FZUrV2bMmDGUL1+eSpUqMW/ePH799Vdj3djPPvuM/Pnz07NnTzp06ECnTp148803H9jvoxg5ciSNGjXCx8eHb7/9lr/++ouVK1cCd5+eb9iwIcOHD8fT05OgoCD69OnDF1988dD78DgxDRkyhPj4eOP1xx9/PFLsYhkRERH873//o2TJknh4eHD27FkaN27MunXrAEhNTWX+/PlpnqR76aWXjKfu3nzzTZydnfUhVERERCxK49CsVaJECaysrOjQoQMAfn5+lCxZkt9//x2AJUuWMGrUKDZu3EjhwoXTtJ87d+4Dlyb18PCgWrVqrFmzJnsuQERERCSbZTqRkZqammHZ5cuXyZMnT2a7ludYo0aNKFGiBKVKlaJTp04sXLiQ69evZ7q/ffv28euvv+Lk5GS8ypcvD2Ak2mxtbfn+++/54YcfuHHjRpZtoF2jRg3j5/z581OuXDmioqIAiIqKolatWmb1a9WqxYkTJ0hOTs6y+2BnZ4ezs7PZS3KuwYMHc+7cOWJiYoiJiaFo0aJs2LCBpk2bAncTHbdu3aJRo0Zm7c6ePWv8vHPnTv7++2/KlCnzVGMXERERuZ/GoVmrYMGCNGzYkA0bNgBw5swZTp8+Tbly5Vi6dCnDhg1j06ZNFC9ePE3b06dPs3v3btq3b292/N5nE4CLFy8SFhamjb5FRETkmfVYm32vW7fOeHIY7u414Orqalbn5s2bbN68GX9//ywJUJ4vefLkYf/+/YSHh/PLL78wYsQIQkJC2LNnD3nz5n3s/lJSUnj99df5/PPP05Td2xwPYPv27cDdZc/++ecfcufOnelreJB7m+elpqam2Ujv/uRfVt8HeT7MnTuXrl27plnzOCgoiL/++gtra2scHBxYtmyZ2eaNIiIiIvLs+/rrrwkODmbQoEFYW1sze/Zs3N3d6dChA25ubrRs2dKoGxYWRoECBYC7m3y/9dZbaZJJX375JREREeTKlYvU1FQ++uijNA/MiIiIiDwrHiuRcfz4cX766Sfg7he2W7Zswc7OzqyOra0tFStWZMyYMVkXpTxXbGxsCAgIICAggJEjR5I3b142b95MYGDgA9vZ2tqSnJxsdqxy5cr88MMPeHh4YGOT/q9zdHQ0H330EXPmzGHp0qV07tyZsLAw48vi9Pp9FDt37jSeiLp8+TLHjx83ZoNUqFCBrVu3mtXfvn07np6exjJRD7oPmY1Jni3/3sR9wYIF6dbbtGnTU4hGRERERCypVKlShIeHpzl+bx++jHz66afpHp85c2ZWhCUiIiKSIzxWIuODDz7ggw8+AKBkyZKsWrUKPz+/bAlMnk9r1qzh1KlT1KlTh3z58rF27VpSUlIoV67cQ9t6eHiwa9cuYmJicHJyIn/+/PTu3Zs5c+bQvn17BgwYQMGCBTl58iSLFy9mzpw5AHTq1InXXnuNrl270rRpU3x8fJg4cSIDBgzIsN9/PxGfnk8++YQCBQrg6urK0KFDKViwIK1atQKgX79+VK1alU8//ZS2bduyY8cOpk+fbnyYeNh9yGxMIiIiIiIiIiIiIs+bTH8zevr0aSUx5LHlzZuXFStW0KBBA7y8vPj6669ZtGgR3t7eD23bv39/rK2tqVChAoUKFSI2NpYiRYqwbds2kpOTady4MRUrVuSDDz7AxcUFKysrRo8eTUxMDLNnzwbAzc2Nb775hmHDhhEZGZlhv49i3LhxfPDBB7z88svExcXx448/YmtrC9ydKbJ06VIWL15MxYoVGTFiBJ988glBQUGPdB8yG5OIiIiIiIiIiIjI88aU+qBdux/ByZMnOX78ODdv3kxT9rClgkSeReHh4dSvX5/Lly/nuP0sEhIScHFxoeMXa7B1yJ59QOTB5vauZ+kQRERERJ66e+PQ+OmlcXawtnQ4OVPwMUtHICIiIvLMeqylpe6XkJBAYGAgv/76K/D/NjK+f4NjrfEvIiIiIiIiIiIiIiJPItNLSw0aNIi4uDi2bNlCamoqK1euJDw8nG7dulGyZEl27tyZlXHKcy42NhYnJ6cMX09zaaVevXplGEevXr2eWhwiIiIiIiIiIiIi8gQzMtavX8/o0aOpVq0aAEWKFKFq1arUqVOH/v37M3HiRBYvXpxlgcrzrUiRIsaeFRmVPy2ffPIJ/fv3T7fM2dmZwoUL84QrsomIiIiIiIiIiIjII8p0IuPChQsUK1YMa2trcufOzd9//22UNW3alLfeeitLApQXg42NDWXKlLF0GAAULlyYwoULWzoMEREREREREREREeEJEhnFihXj0qVLAJQtW5Yff/yRJk2aALB9+3bs7e2zJkIReWwzetbG2dnZ0mGIiIiIyIum037QOFREREREslimExmNGjVi06ZNvPnmm3z00Ud06dKFXbt2YWtry+7du+nXr19WxikiIiIiIiIiIiIiIi8gU2omF/u/fv06169fp2DBggCsXLmS5cuXc+PGDRo1asS7776LlVWm9xIXkUxISEjAxcWF+Ph4zcgQERERkadG41ARERERyU6ZTmSISM6jD5AiIiIiYgkah4qIiIhIdsr00lL3REVFsXfvXv744w+Cg4Nxc3Pj5MmTuLq6kidPnqyIUUREREREREREREREXlCZTmRcv36d7t27s3TpUgBSU1Np0qQJbm5uDBkyhJIlSzJ+/PgsC1RERERERERERERERF48mU5k9O/fn82bN7NmzRpq165tNvuiWbNmTJ48WYkMEQvpPXsLtg65LR0Gc3vXs3QIIiIiIvI0LagMDtaWjiJnCT5m6QhEREREnnmZTmQsX76cL774giZNmpCcnGxW5uHhQUxMzJPGJiIiIiIiIiIiIiIiLzirzDZMTEzE3d093bJr165lOiAREREREREREREREZF7Mp3I8PX15Ycffki37Oeff6ZKlSqZDkpERERERERERERERASeYGmp4cOH07JlS65fv87bb7+NyWRi9+7dLFq0iHnz5rF27dqsjFNERERERERERERERF5AmZ6R0bx5cxYvXszWrVtp1aoVqampvPfeeyxZsoSFCxfSsGHDrIxTREREREREREREREReQI81I6NChQosWbIEHx8fAFq3bs3Nmzfx9PTkzp075M+fn/Lly2dLoCIiIiIiIiIiIiIi8uJ5rBkZ//vf/7hx44bxPjk5mS5dumBjY0PNmjWVxMihwsPDMZlMXLly5YH1PDw8mDJlSpacMyQkBH9//yzp61ljMplYtWqVpcPI8fr27YuHhwcmk4kjR44Yx2vWrIm/vz/+/v5UrFgRk8nEoUOHAPjvf/+Ll5cXfn5+vPLKK2zevNlS4YuIiIiIZImkpCT69OlD2bJl8fb2pmPHjgBcuHCBJk2aULZsWSpWrMjWrVuNNkFBQRQtWtQYNw8YMMAoS0lJ4f3336d06dKUKVOGmTNnPvVrEhEREclqmd4j457U1NSsiEOyUL169fD39zeSEjVr1iQuLg4XFxcAQkND+fDDDx+a2BDJTq1bt2bgwIG8+uqrZse3b99u/Lx8+XJGjRqFr68vALVr12b48OE4ODhw8OBB6tWrR1xcHPb29k81dhERERGRrDJ48GCsrKw4fvw4JpOJuLg443j16tVZv349e/bsoXXr1kRHR2NjY2OU9+nTJ01/33//PUePHuX48ePEx8dTuXJlGjRooAcPRURE5JmW6T0y5Nlha2uLm5sbJpPJ0qFIJt26dcvSIWS5OnXqULRo0QfWmTdvHt26dTPeN23aFAcHBwB8fHxITk7m0qVL2RqniIiIiEh2uXbtGvPnz2fMmDHG5zV3d3cAli5dSu/evQGoWrUqrq6uZrMyMrJkyRJ69eqFtbU1+fPnp02bNixevDj7LkJERETkKXjsREZ6X4brC/KcIygoiIiICKZOnYrJZMJkMhEaGmosLRUeHk7Xrl2Jj483ykNCQtLtKz4+np49e1K4cGGcnZ1p0KABBw8efKx4FixYgIeHBy4uLrRr146rV68aZevXr+fVV18lb968FChQgBYtWhAdHW2U37p1iz59+uDu7o69vT0eHh6MHTv2kc5rMpn45ptvePPNN3F0dKRs2bL8+OOPRnloaCh58+Y1a7Nq1Sqz3+V7y2PNmzeP4sWL4+TkxH/+8x+Sk5MZP348bm5uFC5cmNGjR6c5f1xcnPGle8mSJVm2bJlZ+Z9//knbtm3Jly8fBQoUoGXLlsTExBjlQUFBtGrVirFjx1KkSBE8PT3Tvc6kpCQSEhLMXs+LP//8k/DwcGNq/b/Nnz+f0qVLPzQZIiIiIiJZ73kehz5N0dHRFChQgM8++4wqVapQu3ZtwsLC+Pvvv0lJSaFQoUJGXQ8PD2JjY433kyZNwtfXlxYtWhAZGWkcj42NpUSJEhm2ExEREXkWPXYio379+jg7O+Ps7Ey+fPmAu8u93Dt273VvGSN5uqZOnUqNGjXo0aMHcXFxxMXFUaxYMaO8Zs2aTJkyBWdnZ6O8f//+afpJTU2lefPmnD9/nrVr17Jv3z4qV65Mw4YN+eeffx4plujoaFatWsWaNWtYs2YNERERjBs3zii/du0aH3/8MXv27CEsLAwrKyvefPNNUlJSAJg2bRo//vgjS5cu5dixY3z//fd4eHg88r0YNWoUbdq04dChQzRr1owOHTo8cuz3X8O6detYv349ixYtYt68eTRv3pyzZ88SERHB559/zrBhw9i5c6dZu+HDh/PWW29x8OBBOnbsSPv27YmKigLg+vXr1K9fHycnJ3777Te2bt2Kk5MTTZo0MZt5ERYWRlRUFBs3bmTNmjXpxjd27FhcXFyM1/1/1s+60NBQWrRoQcGCBdOUhYWFMWrUKD1ZJiIiImIhz/M49Gm6ffs2p06dokKFCuzdu5fp06fTrl077ty5k+aBwfuXdR49ejQnT57k0KFDdOvWjaZNm5KYmGiU399Wy0GLiIjI8+Cx9sgYOXJkdsUhWcTFxQVbW1scHR1xc3MD7m7Sfo+trS0uLi6YTCajPD2//vorhw8f5sKFC9jZ2QEwYcIEVq1axfLly+nZs+dDY0lJSSE0NJQ8efIA0KlTJ8LCwowZDG+99ZZZ/blz51K4cGGOHj1KxYoViY2NpWzZsrz66quYTCazp4oeRVBQEO3btwdgzJgxfPnll+zevZsmTZo8ch8pKSnMmzePPHnyUKFCBerXr8+xY8dYu3YtVlZWlCtXjs8//5zw8HCqV69utHv77bfp3r07AJ9++ikbN27kyy+/ZObMmSxevBgrKyu++eYb4wPG/PnzyZs3L+Hh4bz22msA5M6dm2+++QZbW9sM4xsyZAgff/yx8T4hIeG5+BCZmprK/PnzmTFjRpqyiIgIunbtyk8//US5cuUsEJ2IiIiIPK/j0KetRIkSWFlZ0aFDBwD8/PwoWbKk8RDUxYsXjVkZZ86coXjx4gC89NJLRh9vvvkmgwcP5tixY7z88ssUL16cmJgYqlatmqadiIiIyLNKiQxJ1759+0hMTKRAgQJmx2/cuGG2/NODeHh4GEkMuLvW64ULF4z30dHRDB8+nJ07d3Lp0iVjJkZsbCwVK1YkKCiIRo0aUa5cOZo0aUKLFi2ML/kfxb0NouFuUiBPnjxm58/MNbi6umJtbY2VlZXZsX/3W6NGjTTv70333rdvHydPnjTrF+DmzZtm99bHx+eBSQwAOzs7I9H0PImIiODWrVs0atTI7Phvv/1Gp06dWL16NX5+fhaKTkRERESe13Ho01awYEEaNmzIhg0baNasGWfOnOH06dOUK1eOt99+mxkzZhASEsKePXs4f/48r776KgBnz541lljduXMnf//9N2XKlAHuPlQ1a9YsAgMDiY+PZ8mSJaxfv95i1ygiIiKSFR4rkSEvjpSUFNzd3QkPD09T9u+9JTKSK1cus/cmk8lIVgC8/vrrFCtWjDlz5lCkSBFSUlKoWLGisbxS5cqVOX36NOvWrWPTpk20adOGgIAAli9f/sTnt7KySjPF+vbt24/Ux8OuKyP3Zl+kpKTw8ssvs3DhwjR17l8DN3fu3A/t81nWu3dvVq9ezfnz5wkICMDJyYmTJ08Cd2fndO3a1SxhBNCtWzeSkpLo2rWrcWzBggX4+Pg81dhFRERERLLK119/TXBwMIMGDcLa2prZs2fj7u7O559/TqdOnShbtiy2trYsWLAAG5u7H+GDgoL466+/sLa2xsHBgWXLlhnLO3fq1Ik9e/YY++wNGDAALy8vi12fiIiISFZQIuM5ZGtrS3JycqbL4W4S4fz589jY2DzWvhSP6u+//yYqKopZs2ZRu3ZtALZu3ZqmnrOzM23btqVt27a0bt2aJk2a8M8//5A/f/4nOn+hQoW4evUq165dMxIG92+Q96R27txJ586dzd5XqlQJuHtvlyxZYmyi/qKaMWNGuktHwd3kRHpOnDiRnSGJiIiIiDx1pUqVSvcBMldXV3755Zd022zatCnD/qytrTMcZ4uIiIg8qx57s2/J+Tw8PNi1axcxMTFmSzbdX56YmEhYWBiXLl3i+vXrafoICAigRo0atGrVig0bNhATE8P27dsZNmwYe/fufeIY8+XLR4ECBZg9ezYnT55k8+bNZmvsAkyePJnFixfzv//9j+PHj7Ns2TLc3NweeUbIg1SrVg1HR0f++9//cvLkSf7v//6P0NDQJ+73nmXLljFv3jyOHz/OyJEj2b17N3369AGgQ4cOFCxYkJYtW7JlyxZOnz5NREQEH3zwAWfPns2yGERERERERERERESeB0pkPIf69++PtbU1FSpUoFChQsTGxpqV16xZk169etG2bVsKFSrE+PHj0/RhMplYu3YtderUITg4GE9PT9q1a0dMTAyurq5PHKOVlRWLFy9m3759VKxYkY8++ogvvvjCrI6TkxOff/45VapUoWrVqsTExBibbD+p/Pnz8/3337N27Vp8fHxYtGgRISEhT9zvPaNGjWLx4sX4+vry7bffsnDhQipUqACAo6Mjv/32G8WLFycwMBAvLy+Cg4O5cePGCz1DQ0RERERERERERCQ9ptR/bxQgIs+shIQEXFxc6PjFGmwdLL/Hxtze9SwdgoiIiIg8BffGofHTS+PsYG3pcHKW4GOWjkBERETkmacZGSIiIiIiIiIiIiIikmMpkSGZ4u3tjZOTU7qvhQsXZuu5Fy5cmOG5vb29s/XcIiIiIiIiIiIiIvJ02Vg6AHk2rV27ltu3b6dblhV7aDzIG2+8QbVq1dIty5UrV7aeW0RERERERERERESeLiUyJFNKlChhsXPnyZOHPHnyWOz8IiIiIiIiIiIiIvL0aLNvkeeIsclifDzOzs6WDkdEREREXhAah4qIiIhIdtIeGSIiIiIiIiIiIiIikmMpkSEiIiIiIiIiIiIiIjmWEhkiIiIiIiIiIiIiIpJjKZEhIiIiIiIiIiIiIiI5lhIZIiIiIiIiIiIiIiKSY9lYOgARyXq9Z2/B1iE3c3vXs3QoIiIiIvIiWVAZHKwtHYVlBR+zdAQiIiIizx3NyBARERERERERERERkRxLiQwREREREREREREREcmxlMgQEREREREREREREZEcS4kMERERERERERERERHJsZTIEBERERERERERERGRHEuJDBERERERERERERERybGUyJBsV69ePT788ENLh2GYPXs2xYoVw8rKiilTplg6HDMxMTGYTCYiIyMtHYqIiIiIiIiIiIhIjqBEhrxQEhIS6NOnD4MGDeLPP/+kZ8+elg7JYvr27YuHhwcmk4kjR44Yx4ODgylXrhz+/v7UqVNHSRURERERkSzk4eFB+fLl8ff3x9/fnyVLlgBQs2ZN41jFihUxmUwcOnQIgP/+9794eXnh5+fHK6+8wubNm43+ZsyYgY+PD/7+/vj4+DBt2jSLXJeIiIhIdrKxdAAiT1NsbCy3b9+mefPmuLu7Wzoci2rdujUDBw7k1VdfNTveqlUrZs+ejY2NDWvWrKFNmzYcP37cQlGKiIiIiDx/li9fTsWKFc2Obd++3ax81KhR+Pr6AlC7dm2GDx+Og4MDBw8epF69esTFxWFvb0/Hjh3p3bs3cPfBrYoVK1KvXj2jrYiIiMjzQDMyJEtdu3aNzp074+TkhLu7OxMnTjQr//7776lSpQp58uTBzc2Nd955hwsXLgCQmppKmTJlmDBhglmbI0eOYGVlRXR09EPPHxsbS8uWLXFycsLZ2Zk2bdrw119/ARAaGoqPjw8ApUqVwmQyERMTk2Ff8fHxWFtbs2/fPiO+/PnzU7VqVaPOokWLzBIif/75J23btiVfvnwUKFCAli1bpjnH/Pnz8fLywt7envLlyzNz5swMY0hJSaFHjx54enpy5syZh17/46hTpw5FixZNc/yNN97AxuZujrN69eqcOXOGlJSULD23iIiIiIhkbN68eXTr1s1437RpUxwcHADw8fEhOTmZS5cuAeDi4mLUu379Onfu3MFkMj3dgEVERESymRIZkqUGDBjAr7/+ysqVK/nll18IDw83EgEAt27d4tNPP+XgwYOsWrWK06dPExQUBIDJZCI4OJj58+eb9Tlv3jxq165N6dKlH3ju1NRUWrVqxT///ENERAQbN24kOjqatm3bAtC2bVs2bdoEwO7du4mLi6NYsWIZ9ufi4oK/vz/h4eEAxrTuGeYIRQAAc0BJREFUQ4cOkZCQAEB4eDh169YF7n5oqF+/Pk5OTvz2229s3boVJycnmjRpwq1btwCYM2cOQ4cOZfTo0URFRTFmzBiGDx/Ot99+m+b8t27dok2bNuzdu5etW7dSokSJNHWSkpJISEgwe2WlqVOn0qxZM6ys9E+FiIiIiPw/2T0Ofd516NABHx8funfvzsWLF83K/vzzT8LDw+nYsWO6befPn0/p0qXNHkpavnw53t7elChRggEDBhgPcImIiIg8L/TtpGSZxMRE5s6dy4QJE2jUqBE+Pj58++23JCcnG3WCg4Np2rQppUqVonr16kybNo1169aRmJgIQNeuXTl27Bi7d+8G4Pbt23z//fcEBwc/9Pyb/r/27jysqqr////rKIPKKCaCEziBICBOOYY4ZU45ZJqVijY5RZZD+SlzKjVzLk3vBrEyp9T0NjNNBc0pRSlNU28VscKcISdk2L8//Lm/ngDFZDji83Fd+8qz19prvfdenFiH91l7//CDfvnlF3311VeqU6eO6tevry+++EIxMTHatWuXihcvrlKlSkmSSpcuLS8vLxUtWvS2bYaHh5uJjOjoaLVo0UJBQUH68ccfzX3h4eGSpEWLFqlIkSL65JNPFBwcrICAAM2bN08JCQlmG+PGjdOUKVPUpUsXVapUSV26dNGrr76quXPnZrqW7dq106lTpxQdHS1PT88s45swYYLc3NzM7XaJmbv15ZdfasmSJZliAwAAAPJyHlrYbd68WT///LP27NmjUqVKqXfv3lblUVFRat++vR566KFMx27YsEFjxozRokWLrPZ37dpVv/76qw4dOqTPP/9chw4dytNzAAAAyG8kMpBrjh49quvXr6thw4bmPg8PD/n7+5uv9+7dq44dO8rHx0cuLi5mEiAhIUGS5O3trXbt2umzzz6TJK1evVrXrl3Tk08+ecf+Dx48qAoVKlh9iAoMDJS7u7sOHjz4r84pPDxcW7ZsUUZGhmJiYhQeHq7w8HDFxMTo1KlTOnz4sLkiIzY2Vv/73//k4uIiZ2dnOTs7y8PDQ9euXdPRo0d15swZnTx5Us8995xZ7uzsrHfeeSfTbbN69OihS5cuad26dVZLxf9pxIgRSkpKMreTJ0/+q/P8p8WLF2vMmDFav359tkkUAAAAPLjyah76IKhYsaIkyd7eXoMHD9aWLVvMMsMwNG/ePKvbSt0UExOjPn366L///a/VZ6xb+fr6qn79+lq9enXeBA8AAFBAeNg3co1hGLctv3z5sh599FE9+uij+vLLL1W6dGklJCSodevW5q2XJOn5559Xz549NW3aNM2bN0/du3dXiRIlctR/VveCzW5/ToSFhenvv//Wnj17tGXLFo0bN04VKlTQ+PHjFRoaKk9PTwUEBEi68TyLOnXqaMGCBZnaKV26tK5duybpxu2l6tevb1X+z5Uhbdu21ZdffqkdO3aoefPm2cbn6OgoR0fHf3Vu2VmyZIneeust/fDDD+aHLAAAAOBWeTEPfRBcvnxZqampcnd3l3TjmXu1atUyy2NiYnT9+nW1atXK6rjNmzerZ8+eWrlypWrWrGlVdvDgQfMzyZkzZ7RhwwY98cQTeXsiAAAA+YxEBnJN1apVZW9vrx07dph/AL9w4YK5auG3337T2bNnNXHiRHPVxO7duzO107ZtWzk5Oemjjz7Sd999p82bN+eo/8DAQCUkJOjkyZNm+wcOHFBSUpI5sb9bN5+T8eGHH8pisSgwMFBly5bV3r17tXr1anM1hiTVrl1bixcvlqenp1xdXbNsq1y5cjp27JieeeaZ2/bbv39/BQUF6fHHH9e3335r1U9uGThwoFauXKlTp06pZcuWcnZ21v/+9z8988wz8vLyUseOHc26GzZsMG/LBQAAAODf+euvv/TEE08oPT1dhmGocuXK+vzzz83yTz/9VH369Mn0jLrnnntOKSkp6tOnj7nviy++UHBwsD744APFxMTI3t5ehmHo1VdfzZQIAQAAuN+RyECucXZ21nPPPadhw4apVKlSKlOmjN58801zEl6xYkU5ODjogw8+UL9+/bR//36NGzcuUztFixZVRESERowYoapVq1rdqup2WrZsqZCQED3zzDOaPn260tLSNGDAADVt2lR169b91+cVHh6uGTNmqHPnzrJYLCpZsqQCAwO1ePFizZw506z3zDPP6P3331fHjh01duxYlS9fXgkJCVq+fLmGDRum8uXLa/To0YqMjJSrq6vatGmjlJQU7d69WxcuXNBrr71m1e/LL7+s9PR0tW/fXt99952aNGnyr88hK7NmzdKsWbMy7U9NTc3VfgAAAADcULlyZe3duzfb8i+++CLL/UeOHMn2mNmzZ99zXAAAALaOZ2QgV73//vsKCwvT448/rpYtW6pJkyaqU6eOpBu3V4qKitLSpUsVGBioiRMnavLkyVm289xzz+n69es5esj3TRaLRd98841KliypsLAwtWzZUpUrV9bixYvv6ZyaNWum9PR083kektS0aVOlp6dbrZQoUaKENm/erIoVK6pLly4KCAhQ3759dfXqVXOFxvPPP69PPvlEUVFRCg4OVtOmTRUVFaVKlSpl2ffgwYM1ZswYtW3bVtu2bbun8wAAAAAAAACA+5HFuNODDYACsHXrVoWHh+v3339XmTJlCjqc+0ZycrLc3Nz07Pur5VDcSZ8ODC/okAAAAPAAuDkPTfqwilyLF73zAYVZ30MFHQEAAEChw62lYFNSUlJ08uRJjRw5Ut26dSOJAQAAAAAAAAAPOG4tBZuycOFC+fv7KykpSZMmTbIqW7BggZydnbPcatSo8a/6q1GjRrZtLliwIDdOCQAAAAAAAABwD1iRAZsSERGhiIiILMsef/xx1a9fP8sye3v7f9XfmjVrsn24NatBAAAAAAAAAKDgkcjAfcPFxUUuLi652qaPj0+utgcAAAAAAAAAyF087BsoRMyHLCYlydXVtaDDAQAAwAOCeSgAAADyEs/IAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCz7Ao6AAC5b+B/tsihuFNBh5GlTweGF3QIAAAAyCtf1JaKF83/fvseyv8+AQAAkG9YkQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotERh4IDw/X4MGDCzoMFID4+HhZLBbFxcUVdCgAAAAAAAAAUCiQyMgDy5cv17hx4wo6DOSxiIgIderUqaDDKFQiIyPl6+sri8Wi/fv3m/t37dqlxo0bKyQkRKGhodq4caNZFhERofLlyys0NFShoaEaNmxYQYQOAAAAG3Xt2jV16tRJfn5+Cg0N1WOPPab4+HhJkmEYGj16tPz8/BQUFKTw8HDzuKNHj6pFixYKDQ1V9erVNWTIEGVkZEiSMjIy9PLLL6tKlSqqWrWqZs+eXQBnBgAA8OCwK+gACiMPD4+CDgGFzPXr1+Xg4FDQYeS5rl27avjw4WrSpIm5zzAMde7cWV988YWaNWum3377Ta1atdLhw4dVvHhxSdIbb7yhQYMGFVTYAAAAsHEvvvii2rRpI4vFog8//FAvvvii1q1bp5kzZ2rfvn3av3+/HBwclJiYaB4zdOhQdezYUZGRkbp27Zrq1aunFi1aqG3btvryyy914MABHT58WElJSapdu7aaN2+u6tWrF+BZAgAAFF6syMgDt95aavbs2apWrZqKFSumMmXKqGvXrjlqY+3atWrSpInc3d1VqlQptW/fXkePHjXLb97CaPny5WrWrJlKlCihmjVravv27VbtLFu2TDVq1JCjo6N8fX01ZcoUq3JfX1+NHz9effv2lYuLiypWrKj//Oc/Znnz5s0z/YH43LlzcnR0NL8V7+vrq3feeUe9evWSs7OzfHx8tHLlSp05c0YdO3aUs7OzgoODtXv37ruKzWKx6JtvvrHa5+7urqioKEk3/rg/aNAgeXt7q1ixYvL19dWECRNydH2nTp2q4OBgOTk5qUKFChowYIAuXbpklo8ePVqhoaFWx0yfPl2+vr5m+fz587Vy5UpZLBZZLBZFR0ebdY8dO3bP4/LOO+8oIiJCbm5ueuGFF3J0Xve7sLAwlS9f3mrfuXPndP78eTVr1kySVL16dbm7u+u7774riBABAABwnylWrJjatm0ri8UiSWrQoIGOHTsmSXr//ff13nvvmV8a8vb2tjo2KSlJknT16lWlpqaa5YsXL1a/fv1UtGhReXh4qFu3blq0aFF+nRIAAMADh0RGHtq9e7ciIyM1duxYHTp0SGvXrlVYWFiOjr18+bJee+017dq1Sxs2bFCRIkXUuXNncynzTW+++aaGDh2quLg4+fn5qUePHkpLS5MkxcbGqlu3bnrqqae0b98+jR49WiNHjjQTATdNmTJFdevW1d69ezVgwAD1799fv/32myTp+eef11dffaWUlBSz/oIFC1S2bFnzD8uSNG3aNDVu3Fh79+5Vu3bt1LNnT/Xq1UvPPvus9uzZo6pVq6pXr14yDOOuYrudmTNnatWqVVqyZIkOHTqkL7/80kw03EmRIkU0c+ZM7d+/X/Pnz9fGjRs1fPjwHPc9dOhQdevWTY899pgSExOVmJioRo0ameW5MS7vv/++goKCFBsbq5EjR2YZR0pKipKTk622wuahhx5SmTJltGzZMknSzp07dfjwYfN2ANKNxFRISIjat2/P80kAAADywf08D505c6Y6dOig5ORknTlzRitWrFCDBg3UoEEDLV682Kw3ffp0LV26VGXLllXZsmXVq1cv1apVS5KUkJAgHx8fs66vr68SEhLy/VwAAAAeFNxaKg8lJCTIyclJ7du3l4uLi3x8fMyJ75088cQTVq8//fRTeXp66sCBAwoKCjL3Dx06VO3atZMkjRkzRjVq1ND//vc/Va9eXVOnTlWLFi3MP4L7+fnpwIEDev/99xUREWG20bZtWw0YMECS9Prrr2vatGmKjo5W9erV9cQTT+jll1/WypUr1a1bN0nSvHnzFBERYX6j6WYbL730kiTp7bff1kcffaR69erpySefNNtt2LCh/vrrL3l5eeU4tjtd32rVqqlJkyayWCxWHyTu5NaHsVeqVEnjxo1T//79c3xvW2dnZxUvXlwpKSny8vLKVJ4b49K8eXMNHTr0tnFMmDBBY8aMyVHM97OVK1fq9ddf17vvvqvg4GA1adJE9vb2kqR3331X3t7eKlKkiFasWKE2bdroyJEjcnZ2LuCoAQAACq/7dR46fvx4HTlyRHPmzNHVq1d1/fp1Xb16VTt27FBCQoIaNmyoGjVqKCgoSHPnzlXPnj01bNgwnT59Ws2bN1eDBg3UvHlzSbL6PHTzC1sAAADIG6zIyEOtWrWSj4+PKleurJ49e2rBggW6cuVKjo49evSonn76aVWuXFmurq6qVKmSJGX6lk9ISIj575vLnE+fPi1JOnjwoBo3bmxVv3Hjxjpy5IjS09OzbMNiscjLy8tsw9HRUc8++6w+++wzSVJcXJx+/vnnTMmGW9soU6aMJCk4ODjTvruN7XYiIiIUFxcnf39/RUZGat26dTk6TpI2bdqkVq1aqVy5cnJxcVGvXr107tw5Xb58Ocdt3E5ujEvdunXv2M+IESOUlJRkbidPnsyN8G1OSEiIvvvuO+3Zs0fz58/Xn3/+qcDAQElSuXLlVKTIjf+Vde7cWa6urjp06FBBhgsAAFDo3Y/z0MmTJ2v58uX67rvvVKJECZUqVUrOzs569tlnJUkVK1ZU48aNzVvizpw5U71795YkeXp6qk2bNoqJiTHr3rpC+MSJE6pYsWL+nhAAAMADhERGHnJxcdGePXu0cOFCeXt76+2331bNmjV18eLFOx7boUMHnTt3Th9//LF27typnTt3SrrxXIhb3fxWuvT/vhF08/ZThmFYfUvo5r5/urWNm+3cegur559/XuvXr9fvv/+uzz77TC1atMi0+iGrOO41NovFkmlfamqq+e/atWvr+PHjGjdunK5evapu3brl6BkkJ06cUNu2bRUUFKRly5YpNjZWs2bNsmq/SJEit+37TnJjXJycnO7Yj6Ojo1xdXa22wujUqVPmvz/++GM5OTmZ34T7/fffzbIdO3bo3Llzqlq1ar7HCAAA8CC53+ahU6dO1cKFC7V+/Xq5u7ub+3v06KG1a9dKki5cuKCffvrJ/FJS5cqVzeeyXb58WRs3bjRXxz/55JOaO3eu0tPTdf78eS1evFjdu3fP35MCAAB4gHBrqTxmZ2enli1bqmXLlho1apTc3d21ceNGdenSJdtjzp07p4MHD2ru3Ll65JFHJEk//vjjXfcdGBiY6bht27bJz89PRYsWzXE7wcHBqlu3rj7++GN99dVX+uCDD+46ln8TW+nSpZWYmGiWHzlyJNOKFldXV3Xv3l3du3dX165d9dhjj+n8+fPy8PDItu/du3crLS1NU6ZMMb/Jv2TJEqs6pUuX1qlTp6ySDv989oKDg0OOV4/cKrfGpTAaOHCgVq5cqVOnTqlly5ZydnbW//73P82dO1cLFiyQYRgKCAjQihUrzHGJiIjQX3/9paJFi6p48eJaunSp3NzcCvhMAAAAYCt+//13DRkyRJUrVzaf8+fo6KidO3dq/Pjx6tOnj3mL2REjRqh27dqSpPnz52vQoEGaMmWKUlNT1alTJ/OLUz179tSuXbvk5+cnSRo2bJgCAgIK4OwAAAAeDCQy8tDq1at17NgxhYWFqWTJklqzZo0yMjLk7+9/2+NKliypUqVK6T//+Y+8vb2VkJCgN9544677HzJkiOrVq6dx48ape/fu2r59uz788MMcPwfiVs8//7wGDRqkEiVKqHPnznd9/L+JrXnz5vrwww/VoEEDZWRk6PXXX7da6TBt2jR5e3srNDRURYoU0dKlS+Xl5WX1DausVKlSRWlpafrggw/UoUMHbd26VXPmzLGqEx4erjNnzmjSpEnq2rWr1q5dq++++87qm2a+vr76/vvvdejQIZUqVSrHfzzPzXEpbGbNmmWujrnVqFGjNGrUqCyP+eGHH/I6LAAAANzHypcvn+0zLB566CH997//zbKsVq1a2rp1a5ZlRYsWzXLeCgAAgLzBraXykLu7u5YvX67mzZsrICBAc+bM0cKFC1WjRo3bHlekSBEtWrRIsbGxCgoK0quvvqr333//rvuvXbu2lixZokWLFikoKEhvv/22xo4dm+OHad+qR48esrOz09NPP61ixYrd9fH/JrYpU6aoQoUKCgsL09NPP62hQ4eqRIkSZrmzs7Pee+891a1bV/Xq1VN8fLzWrFljrrLITmhoqKZOnar33ntPQUFBWrBggSZMmGBVJyAgQLNnz9asWbNUs2ZN/fTTT5kevP3CCy/I399fdevWVenSpbP9kPNvzh0AAAAAAAAAcIPFyO6rKcAtTp48KV9fX+3atctcag3bk5ycLDc3Nz37/mo5FL/zMzYKwqcDwws6BAAAAOSym/PQpA+ryLV4Adwute+h/O8TAAAA+YZbS+G2UlNTlZiYqDfeeEMNGjQgiQEAAAAAAAAAyFfcWqoAJCQkyNnZOdstISGhoEM0bd26VT4+PoqNjc30HAlbtWDBgmyv7Z1u6wUAAAAAAAAAsC2syCgAZcuWVVxc3G3LbUV4eHi2D8azVY8//rjq16+fZdmtDwsHAAAAAAAAANg+EhkFwM7OTlWrVi3oMAotFxcXubi4FHQYAAAAAAAAAIBcwMO+gULEfMhiUpJcXV0LOhwAAAA8IJiHAgAAIC/xjAwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANsuuoAMAkPsG/meLHIo7FXQYkqRPB4YXdAgAAADIL1/UlooXvfvj+h7K/VgAAABQaLAiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hk4F8LDw/X4MGDC7wNWxIdHS2LxaKLFy8WdCj3hcjISPn6+spisWj//v3m/kaNGik0NFShoaEKCgqSxWLRL7/8Iknq2rWrWRYaGqoiRYpo1apVBXUKAAAAyAfZzRv79OmjkJAQhYaGql69etqwYYNZ9n//938KCAhQzZo19fDDD2vjxo1m2axZsxQcHKzQ0FAFBwdr5syZ+Xo+AAAAuDt2BR0A7l/Lly+Xvb19QYdRKPn6+mrw4MGFKsmTla5du2r48OFq0qSJ1f5t27aZ//766681ZswYhYSEmK9v2r17tx577DG1bt06fwIGAABAgchu3jht2jS5u7tLkuLi4tSyZUudOXNGFotFjzzyiEaOHKnixYvr559/Vnh4uBITE1WsWDE9++yzGjhwoCQpOTlZQUFBCg8PN+ecAAAAsC0kMvCveXh4FHQIuM+FhYXdsc5nn32m5557LtuyZ599Vo6OjrkdGgAAAGxIdvPGm0kMSbp48aIsFov5uk2bNua/g4ODlZ6errNnz6p8+fJyc3Mzy65cuaK0tDSrYwEAAGBbuLUU/rVbbws1e/ZsVatWTcWKFVOZMmXUtWvXf9Xm2rVr5ebmps8//1ySFBERoU6dOmny5Mny9vZWqVKlNHDgQKWmpprHXLhwQb169VLJkiVVokQJtWnTRkeOHJEkGYah0qVLa9myZWb90NBQeXp6mq+3b98ue3t7Xbp0SZJksVj0ySefqHPnzipRooSqVat217cu2rp1q2rWrKlixYqpfv362rdvn1X5smXLVKNGDTk6OsrX11dTpkwxy8LDw3XixAm9+uqrslgst/1AlZKSouTkZKutMPnjjz8UHR2tZ599NlPZtWvXtHDhwmyTHAAAAMg7tjQPfeONN1SlShV16dJFS5cuzXL+PG/ePFWpUkXly5c393399deqUaOGfHx8NGzYMAUHB+dn2AAAALgLJDJwz3bv3q3IyEiNHTtWhw4d0tq1a3P0Tft/WrRokbp166bPP/9cvXr1Mvdv2rRJR48e1aZNmzR//nxFRUUpKirKLI+IiNDu3bu1atUqbd++XYZhqG3btkpNTZXFYlFYWJiio6Ml3Uh6HDhwQKmpqTpw4ICkG8+1qFOnjpydnc02x4wZo27duumXX35R27Zt9cwzz+j8+fM5Ppdhw4Zp8uTJ2rVrlzw9PfX444+byZfY2Fh169ZNTz31lPbt26fRo0dr5MiR5jktX75c5cuX19ixY5WYmKjExMRs+5kwYYLc3NzMrUKFCjmO8X4QFRWl9u3b66GHHspUtmzZMlWrVo0PnAAAAAXAluahEydO1NGjR7VkyRINGzZM169ftyrfsGGDxowZo0WLFlnt79q1q3799VcdOnRIn3/+uQ4dOpSfYQMAAOAukMjAPUtISJCTk5Pat28vHx8f1apVS5GRkXfVxuzZs9WvXz+tXLlSHTt2tCorWbKkPvzwQ1WvXl3t27dXu3btzIf4HTlyRKtWrdInn3yiRx55RDVr1tSCBQv0xx9/6JtvvpF0Y4XDzUTG5s2bVbNmTTVv3tzcFx0drfDwcKs+IyIi1KNHD1WtWlXjx4/X5cuX9dNPP+X4fEaNGqVWrVopODhY8+fP119//aUVK1ZIkqZOnaoWLVpo5MiR8vPzU0REhAYNGqT3339f0o1bdhUtWlQuLi7y8vKSl5dXtv2MGDFCSUlJ5nby5Mkcx2jrDMPQvHnzsl1x8emnn7IaAwAAoIDY4jy0ZcuW+vvvv61WQ8fExKhPnz7673//K39//yyP8/X1Vf369bV69er8ChUAAAB3iUQG7lmrVq3k4+OjypUrq2fPnlqwYIGuXLmS4+OXLVumwYMHa926dWrWrFmm8ho1aqho0aLma29vb50+fVqSdPDgQdnZ2al+/fpmealSpeTv76+DBw9KupHI+PXXX3X27FnFxMQoPDxc4eHhiomJUVpamrZt26amTZta9XnrQ/6cnJzk4uJi9pkTDRs2NP/t4eFhFc/BgwfVuHFjq/qNGzfWkSNHlJ6enuM+JMnR0VGurq5WW2ERExOj69evq1WrVpnKjh8/rp9++kk9evQogMgAAABgC/PQtLQ085aykvTTTz/p9OnTqly5sqQbX2Lq2bOnVq5cqZo1a1ode3NuLklnzpzRhg0beNA3AACADSORgXvm4uKiPXv2aOHChfL29tbbb7+tmjVr6uLFizk6PjQ0VKVLl9a8efNkGEamcnt7e6vXFotFGRkZkpRl/Zv7b94bNygoSKVKlVJMTIyZyGjatKliYmK0a9cuXb16VU2aNMlxn//WzXhuje3WeB9EAwcOVPny5fX777+rZcuWqlq1qln26aefqk+fPipSJPP/pj777DM98cQThSpxAwAAgOxlNW9MT09XRESEgoKCVLNmTQ0ePFhff/21SpYsKUl67rnnlJKSoj59+ig0NFShoaHmao0PPvhANWrUUGhoqFq2bKlXX301yy/QAAAAwDbYFXQAKBzs7OzUsmVLtWzZUqNGjZK7u7s2btyoLl263PHYKlWqaMqUKQoPD1fRokX14Ycf5rjfwMBApaWlaefOnWrUqJEk6dy5czp8+LACAgIkyXxOxsqVK7V//3498sgjcnFxUWpqqubMmaPatWvLxcXl3514Nnbs2KGKFStKuvFcjsOHD6t69epmzD/++KNV/W3btsnPz89ceeLg4HDXqzPuR7NmzdKsWbOyLPviiy+yPW7cuHF5FRIAAABsUHbzxq1bt2Z7zK2rNf5p9uzZuRIXAAAA8gcrMnDPVq9erZkzZyouLk4nTpzQ559/royMjGzvQZsVPz8/bdq0ybzNVE5Vq1ZNHTt21AsvvKAff/xRP//8s5599lmVK1fO6lkb4eHh+uqrrxQSEiJXV1czubFgwYJMz8fIDWPHjtWGDRu0f/9+RURE6KGHHlKnTp0kSUOGDNGGDRs0btw4HT58WPPnz9eHH36ooUOHmsf7+vpq8+bN+uOPP3T27Nlcjw8AAAAAAAAA7hckMnDP3N3dtXz5cjVv3lwBAQGaM2eOFi5cqBo1atxVO/7+/tq4caMWLlyoIUOG5Pi4efPmqU6dOmrfvr0aNmwowzC0Zs0aq9tDNWvWTOnp6VZJi6ZNmyo9PT3T8zFyw8SJE/XKK6+oTp06SkxM1KpVq+Tg4CBJql27tpYsWaJFixYpKChIb7/9tsaOHauIiAjz+LFjxyo+Pl5VqlRR6dKlcz0+AAAAAAAAALhfWIwH9eb8QCGUnJwsNzc3Pfv+ajkUdyrocCRJnw4ML+gQAAAAkMduzkOTPqwi1+JF776BvodyPygAAAAUGqzIAAAAAAAAAAAANotEBvJMQkKCnJ2ds90SEhIKOsS71q9fv2zPp1+/fgUdHgAAAAAAAAAUOnYFHQAKr7JlyyouLu625febsWPHWj2U+1aurq75HA0AAAAAAAAAFH4kMpBn7OzsVLVq1YIOI1d5enrK09OzoMMAAAAAAAAAgAcGD/sGChHzIYtJSawQAQAAQL5hHgoAAIC8xDMyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsu4IOAAAAAABQSHxRWypeNPP+vofyPxYAAAAUGqzIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDhUJ4eLgGDx5c0GGYchJPVFSU3N3d8yUeAAAAwJb5+vqqevXqCg0NVWhoqBYvXixJatSokbkvKChIFotFv/zyiyTp6NGjatGihUJDQ1W9enUNGTJEGRkZBXkaAAAAyCN2BR0AcD+Ljo5Ws2bNdOHCBaukxPLly2Vvb2++9vX11eDBg20q2QIAAADYkq+//lpBQUFW+7Zt22ZVPmbMGIWEhEiShg4dqo4dOyoyMlLXrl1TvXr11KJFC7Vt2zZf4wYAAEDeI5EB5AEPD4+CDgEAAAAoVD777DM999xzVvuSkpIkSVevXlVqaqq8vb0LIjQAAADkMW4thUIjIyNDw4cPl4eHh7y8vDR69GizbOrUqQoODpaTk5MqVKigAQMG6NKlS2b5iRMn1KFDB5UsWVJOTk6qUaOG1qxZc9v+4uPj1axZM0lSyZIlZbFYFBERIcn61lLh4eE6ceKEXn31VVksFlkslmzb/O9//6s6deqoWLFiqly5ssaMGaO0tLRs66ekpCg5OdlqAwAAAPJaXsxDn3nmGQUHB+v555/XmTNnrMr++OMPRUdH69lnnzX3TZ8+XUuXLlXZsmVVtmxZ9erVS7Vq1brnOAAAAGB7SGSg0Jg/f76cnJy0c+dOTZo0SWPHjtX69eslSUWKFNHMmTO1f/9+zZ8/Xxs3btTw4cPNYwcOHKiUlBRt3rxZ+/bt03vvvSdnZ+fb9lehQgUtW7ZMknTo0CElJiZqxowZmeotX75c5cuX19ixY5WYmKjExMQs2/v+++/17LPPKjIyUgcOHNDcuXMVFRWld999N9sYJkyYIDc3N3OrUKHCHa8TAAAAcK9yex66efNm/fzzz9qzZ49KlSql3r17W5VHRUWpffv2euihh8x9c+fOVc+ePfXnn3/qxIkT+uqrr7Rx48Z7igMAAAC2yWIYhlHQQQD3Kjw8XOnp6dqyZYu57+GHH1bz5s01ceLETPWXLl2q/v376+zZs5KkkJAQPfHEExo1atRd9ZvdMzLCw8MVGhqq6dOnS8r6GRlRUVEaPHiwLl68KEkKCwtTmzZtNGLECLPOl19+qeHDh+vPP//Msv+UlBSlpKSYr5OTk1WhQgUlJSXJ1dX1rs4FAAAAyKls56EfVpFr8aKZD+h7KMdtJyYmys/PT3///bckyTAMVatWTbNmzVLr1q3Nes7Ozjp27Jg8PT0lScOGDVOJEiU0ZsyYf3lWAAAAsFU8IwOFxs2H/t3k7e2t06dPS5I2bdqk8ePH68CBA0pOTlZaWpquXbumy5cvy8nJSZGRkerfv7/WrVunli1b6oknnsjUXl6LjY3Vrl27rFZgpKen69q1a7py5YpKlCiR6RhHR0c5OjrmZ5gAAABArs5DL1++rNTUVPOLQQsXLrS6RVRMTIyuX7+uVq1aWR1XuXJlfffdd+rdu7cuX76sjRs36o033siVmAAAAGBbuLUUCg17e3ur1xaLRRkZGTpx4oTatm2roKAgLVu2TLGxsZo1a5YkKTU1VZL0/PPP69ixY+rZs6f27dununXr6oMPPsjX+DMyMjRmzBjFxcWZ2759+3TkyBEVK1YsX2MBAAAA8stff/2lZs2aKSQkRMHBwYqJidHnn39uln/66afq06ePihSx/vg6f/58/ec//1FISIjq1q2rRx99VF27ds3v8AEAAJAPWJGBQm/37t1KS0vTlClTzA8/S5YsyVSvQoUK6tevn/r166cRI0bo448/1ssvv3zbth0cHCTdWDlxp3p3qlO7dm0dOnRIVatWvW09AAAAoDCpXLmy9u7dm235F198keX+WrVqaevWrXkVFgAAAGwIKzJQ6FWpUkVpaWn64IMPdOzYMX3xxReaM2eOVZ3Bgwfr+++/1/Hjx7Vnzx5t3LhRAQEBd2zbx8dHFotFq1ev1pkzZ3Tp0qUs6/n6+mrz5s36448/zOdy/NPbb7+tzz//XKNHj9avv/6qgwcPavHixXrrrbfu/qQBAAAAAAAAoJAgkYFCLzQ0VFOnTtV7772noKAgLViwQBMmTLCqk56eroEDByogIECPPfaY/P39NXv27Du2Xa5cOY0ZM0ZvvPGGypQpo0GDBmVZb+zYsYqPj1eVKlVUunTpLOu0bt1aq1ev1vr161WvXj01aNBAU6dOlY+Pz92fNAAAAAAAAAAUEhbDMIyCDgJA7khOTpabm5uSkpLk6upa0OEAAADgAWHOQz+sItfiRTNX6Hso/4MCAABAocGKDAAAAAAAAAAAYLNIZAC30a9fPzk7O2e59evXr6DDAwAAAAAAAIBCz66gAwBs2dixYzV06NAsy7h1EwAAAAAAAADkPRIZwG14enrK09OzoMMAAAAAAAAAgAcWiQwAAAAAQO7ouUdi5TIAAAByGc/IAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiYxCKDw8XIMHDy7oMGxGdHS0LBaLLl68mC/9RUVFyd3d/bZ1Ro8erdDQUPN1RESEOnXqlKdxAQAAAAAAAMD9yK6gA0DuW758uezt7Qs6DNyFGTNmyDAM83V4eLhCQ0M1ffr0ggsKAAAAAAAAAGwAiYxCyMPDo6BDuO+lp6fLYrGoSJH8WbTk5uaWL/0AAAAAAAAAwP2GW0sVQrfeWmr27NmqVq2aihUrpjJlyqhr1645biMyMlLDhw+Xh4eHvLy8NHr0aKs6SUlJevHFF+Xp6SlXV1c1b95cP//8s1lWtGhRxcbGSpIMw5CHh4fq1atnHr9w4UJ5e3vfMZbr169r0KBB8vb2VrFixeTr66sJEyZIkuLj42WxWBQXF2fWv3jxoiwWi6Kjo63a2bp1q2rWrKlixYqpfv362rdvn1l283ZQq1evVmBgoBwdHXXixAldv35dw4cPV7ly5eTk5KT69etnajcqKkoVK1ZUiRIl1LlzZ507dy7TOUycOFFlypSRi4uLnnvuOV27ds2q/NZbS0VERCgmJkYzZsyQxWKRxWJRfHz8Ha8TAAAAAAAAABRGJDIKsd27dysyMlJjx47VoUOHtHbtWoWFheX4+Pnz58vJyUk7d+7UpEmTNHbsWK1fv17SjcREu3btdOrUKa1Zs0axsbGqXbu2WrRoofPnz8vNzU2hoaHmH/1/+eUX87/JycmSbjy7omnTpneMY+bMmVq1apWWLFmiQ4cO6csvv5Svr+/dXQxJw4YN0+TJk7Vr1y55enrq8ccfV2pqqll+5coVTZgwQZ988ol+/fVXeXp6qk+fPtq6dasWLVqkX375RU8++aQee+wxHTlyRJK0c+dO9e3bVwMGDFBcXJyaNWumd955x6rfJUuWaNSoUXr33Xe1e/dueXt7a/bs2dnGOWPGDDVs2FAvvPCCEhMTlZiYqAoVKmRZNyUlRcnJyVYbAAAAkNeYhwIAACA/kcgoxBISEuTk5KT27dvLx8dHtWrVUmRkZI6PDwkJ0ahRo1StWjX16tVLdevW1YYNGyRJmzZt0r59+7R06VLVrVtX1apV0+TJk+Xu7q6vv/5a0o1VHTcTGdHR0WrRooWCgoL0448/mvvCw8NzdB7VqlVTkyZN5OPjoyZNmqhHjx53dzEkjRo1Sq1atVJwcLDmz5+vv/76SytWrDDLU1NTNXv2bDVq1Ej+/v46deqUFi5cqKVLl+qRRx5RlSpVNHToUDVp0kTz5s2TdCPp0Lp1a73xxhvy8/NTZGSkWrdubdXv9OnT1bdvXz3//PPy9/fXO++8o8DAwGzjdHNzk4ODg0qUKCEvLy95eXmpaNGiWdadMGGC3NzczC27hAcAAACQm5iHAgAAID+RyCjEWrVqJR8fH1WuXFk9e/bUggULdOXKlRwfHxISYvXa29tbp0+fliTFxsbq0qVLKlWqlJydnc3t+PHjOnr0qKQbiYwtW7YoIyNDMTExCg8PV3h4uGJiYnTq1CkdPnw4RysyIiIiFBcXJ39/f0VGRmrdunV3cRX+n4YNG5r/9vDwkL+/vw4ePGjuc3BwsDrnPXv2yDAM+fn5WZ1jTEyMeY4HDx60avef/eS0zr81YsQIJSUlmdvJkydzpV0AAADgdpiHAgAAID/xsO9CzMXFRXv27FF0dLTWrVunt99+W6NHj9auXbvk7u5+x+Pt7e2tXlssFmVkZEiSMjIy5O3tnel5EZLMtsPCwvT3339rz5492rJli8aNG6cKFSpo/PjxCg0NlaenpwICAu4YR+3atXX8+HF99913+uGHH9StWze1bNlSX3/9tfkwbsMwzPq33i7qTiwWi/nv4sWLW73OyMgwn/PxzxURzs7OmfotCI6OjnJ0dCzQGAAAAPDgYR4KAACA/EQio5Czs7NTy5Yt1bJlS40aNUru7u7auHGjunTpck/t1q5dW6dOnZKdnV22z6u4+ZyMDz/8UBaLRYGBgSpbtqz27t2r1atX52g1xk2urq7q3r27unfvrq5du+qxxx7T+fPnVbp0aUlSYmKiatWqJUlWD/6+1Y4dO1SxYkVJ0oULF3T48GFVr1492z5r1aql9PR0nT59Wo888kiWdQIDA7Vjx45M/dwqICBAO3bsUK9evbKt808ODg5KT0+/bR0AAAAAAAAAeBCQyCjEVq9erWPHjiksLEwlS5bUmjVrlJGRIX9//3tuu2XLlmrYsKE6deqk9957T/7+/vrzzz+1Zs0aderUSXXr1pV04/ZSM2bMUOfOnWWxWFSyZEkFBgZq8eLFmjlzZo76mjZtmry9vRUaGqoiRYpo6dKl8vLykru7u4oUKaIGDRpo4sSJ8vX11dmzZ/XWW29l2c7YsWNVqlQplSlTRm+++aYeeughderUKdt+/fz89Mwzz6hXr16aMmWKatWqpbNnz2rjxo0KDg5W27ZtFRkZqUaNGmnSpEnq1KmT1q1bp7Vr11q188orr6h3796qW7eumjRpogULFujXX39V5cqVs+3b19dXO3fuVHx8vJydneXh4WGuPgEAAAAAAACABwl/GS3E3N3dtXz5cjVv3lwBAQGaM2eOFi5cqBo1atxz2xaLRWvWrFFYWJj69u0rPz8/PfXUU4qPj1eZMmXMes2aNVN6errVQ72bNm2q9PT0HK/IcHZ21nvvvae6deuqXr16io+P15o1a8w/7H/22WdKTU1V3bp19corr+idd97Jsp2JEyfqlVdeUZ06dZSYmKhVq1bJwcHhtn3PmzdPvXr10pAhQ+Tv76/HH39cO3fuNB9m2KBBA33yySf64IMPFBoaqnXr1mVKpHTv3l1vv/22Xn/9ddWpU0cnTpxQ//79b9vv0KFDVbRoUQUGBqp06dJKSEjI0bUCAAAAAAAAgMLGYhT0Tf4B5Jrk5GS5ubkpKSlJrq6uBR0OAAAAHhDMQwEAAJCXWJEBAAAAAAAAAABsFomMB1BCQoKcnZ2z3fL7Nkbjx4/PNpY2bdrkaywAAAAAAAAAANvCraUeQGlpaYqPj8+23NfXV3Z2+fcc+PPnz+v8+fNZlhUvXlzlypXLt1judyzpBwAAQEFgHgoAAIC8lH9/rYbNsLOzU9WqVQs6DJOHh4c8PDwKOgwAAAAAAAAAgA3i1lIAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDNxReHi4Bg8eXNBh3Beio6NlsVh08eLFgg4FAAAAAAAAAAoFu4IOALZv+fLlsre3L+gwbE54eLhCQ0M1ffr0gg4FAAAAAAAAAAotEhm4Iw8Pj4IO4YGXmppKMgkAAAAAAADAA4lbS+GObr211OzZs1WtWjUVK1ZMZcqUUdeuXXPcRmRkpIYPHy4PDw95eXlp9OjRVnWSkpL04osvytPTU66urmrevLl+/vlns6xo0aKKjY2VJBmGIQ8PD9WrV888fuHChfL29s5RPK+//rr8/PxUokQJVa5cWSNHjlRqaqpZHhERoU6dOlkdM3jwYIWHh5vlMTExmjFjhiwWiywWi+Lj4826sbGxqlu3rkqUKKFGjRrp0KFDVm199NFHqlKlihwcHOTv768vvvjCqtxisWjOnDnq2LGjnJyc9M477+TovAAAAAAAAACgsCGRgRzbvXu3IiMjNXbsWB06dEhr165VWFhYjo+fP3++nJyctHPnTk2aNEljx47V+vXrJd1ITLRr106nTp3SmjVrFBsbq9q1a6tFixY6f/683NzcFBoaqujoaEnSL7/8Yv43OTlZ0o3nUzRt2jRHsbi4uCgqKkoHDhzQjBkz9PHHH2vatGk5PpcZM2aoYcOGeuGFF5SYmKjExERVqFDBLH/zzTc1ZcoU7d69W3Z2durbt69ZtmLFCr3yyisaMmSI9u/fr5deekl9+vTRpk2brPoYNWqUOnbsqH379lkdf6uUlBQlJydbbQAAAEBeYx4KAACA/EQiAzmWkJAgJycntW/fXj4+PqpVq5YiIyNzfHxISIhGjRqlatWqqVevXqpbt642bNggSdq0aZP27dunpUuXqm7duqpWrZomT54sd3d3ff3115JurOq4mciIjo5WixYtFBQUpB9//NHcd3PFxJ289dZbatSokXx9fdWhQwcNGTJES5YsyfG5uLm5ycHBQSVKlJCXl5e8vLxUtGhRs/zdd99V06ZNFRgYqDfeeEPbtm3TtWvXJEmTJ09WRESEBgwYID8/P7322mvq0qWLJk+ebNXH008/rb59+6py5cry8fHJMo4JEybIzc3N3G5NpgAAAAB5hXkoAAAA8hOJDORYq1at5OPjo8qVK6tnz55asGCBrly5kuPjQ0JCrF57e3vr9OnTkm7ciunSpUsqVaqUnJ2dze348eM6evSopBuJjC1btigjI0MxMTEKDw9XeHi4YmJidOrUKR0+fDjHKzK+/vprNWnSRF5eXnJ2dtbIkSOVkJCQ43O5m3O9eburm+d68OBBNW7c2Kp+48aNdfDgQat9devWvWM/I0aMUFJSkrmdPHnyXkMHAAAA7oh5KAAAAPITD/tGjrm4uGjPnj2Kjo7WunXr9Pbbb2v06NHatWuX3N3d73j8Px9WbbFYlJGRIUnKyMiQt7e3ueLiVjfbDgsL099//609e/Zoy5YtGjdunCpUqKDx48crNDRUnp6eCggIuGMcO3bs0FNPPaUxY8aodevWcnNz06JFizRlyhSzTpEiRWQYhtVxtz5D427O1WKxmOf4z303GYaRaZ+Tk9Md+3F0dJSjo2OO4wIAAAByA/NQAAAA5CcSGbgrdnZ2atmypVq2bKlRo0bJ3d1dGzduVJcuXe6p3dq1a+vUqVOys7OTr69vlnVuPifjww8/lMViUWBgoMqWLau9e/dq9erVOV6NsXXrVvn4+OjNN9809504ccKqTunSpbV//36rfXFxcVYJCgcHB6Wnp+fwDP+fgIAA/fjjj+rVq5e5b9u2bTlKwgAAAAAAAADAg4ZbSyHHVq9erZkzZyouLk4nTpzQ559/royMDPn7+99z2y1btlTDhg3VqVMnff/994qPj9e2bdv01ltvaffu3Wa98PBwffnll2ratKksFotKliypwMBALV68OMfPx6hataoSEhK0aNEiHT16VDNnztSKFSus6jRv3ly7d+/W559/riNHjmjUqFGZEhu+vr7auXOn4uPjdfbsWasVF7czbNgwRUVFac6cOTpy5IimTp2q5cuXa+jQoTk6HgAAAAAAAAAeJCQykGPu7u5avny5mjdvroCAAM2ZM0cLFy5UjRo17rlti8WiNWvWKCwsTH379pWfn5+eeuopxcfHq0yZMma9Zs2aKT093Spp0bRpU6Wnp+d4RUbHjh316quvatCgQQoNDdW2bds0cuRIqzqtW7fWyJEjNXz4cNWrV09///231QoKSRo6dKiKFi2qwMBAlS5dOsfP2OjUqZNmzJih999/XzVq1NDcuXM1b968HCdiAAAAAAAAAOBBYjH++SAAAPet5ORkubm5KSkpSa6urgUdDgAAAB4QzEMBAACQl1iRAQAAAAAAAAAAbBaJDNyzhIQEOTs7Z7vl9JZLuWX8+PHZxtKmTZt8jQUAAAAAAAAAcG+4tRTuWVpamuLj47Mt9/X1lZ2dXb7Fc/78eZ0/fz7LsuLFi6tcuXL5Fkt+Y0k/AAAACgLzUAAAAOSl/PvrMgotOzs7Va1ataDDMHl4eMjDw6OgwwAAAAAAAAAA5AJuLQUAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBu5KdHS0LBaLLl68eNt6vr6+mj59eq70OXr0aIWGhuZKW3fyz7gtFou++eabfOkbAAAAAAAAAJAZiQzcVnh4uAYPHmy+btSokRITE+Xm5iZJioqKkru7e57GMHToUG3YsCFP+wAAAAAAAAAA2Ca7gg4A9xcHBwd5eXnla5/Ozs5ydnbO1z4BAAAAAAAAALaBFRnIVkREhGJiYjRjxgxZLBZZLBZFRUWZt5aKjo5Wnz59lJSUZJaPHj06y7aSkpL04osvytPTU66urmrevLl+/vnnHMXxz1tLRUdH6+GHH5aTk5Pc3d3VuHFjnThx4o7tHD16VB07dlSZMmXk7OysevXq6YcffshRDDf9/vvveuqpp+Th4SEnJyfVrVtXO3fuzHH7vr6+GjdunJ5++mk5OzurbNmy+uCDDzKdb8WKFeXo6KiyZcsqMjIy23hSUlKUnJxstQEAAAB5jXkoAAAA8hOJDGRrxowZatiwoV544QUlJiYqMTFRFSpUMMsbNWqk6dOny9XV1SwfOnRopnYMw1C7du106tQprVmzRrGxsapdu7ZatGih8+fP31VMaWlp6tSpk5o2bapffvlF27dv14svviiLxXLHYy9duqS2bdvqhx9+0N69e9W6dWt16NBBCQkJOer70qVLatq0qf7880+tWrVKP//8s4YPH66MjIy7av/9999XSEiI9uzZoxEjRujVV1/V+vXrJUlff/21pk2bprlz5+rIkSP65ptvFBwcnG1MEyZMkJubm7ndOj4AAABAXmEeCgAAgPzEraWQLTc3Nzk4OKhEiRLm7aR+++03s9zBwUFubm6yWCy3vd3Upk2btG/fPp0+fVqOjo6SpMmTJ+ubb77R119/rRdffDHHMSUnJyspKUnt27dXlSpVJEkBAQE5OrZmzZqqWbOm+fqdd97RihUrtGrVKg0aNOiOx3/11Vc6c+aMdu3aJQ8PD0lS1apV77r9xo0b64033pAk+fn5aevWrZo2bZpatWqlhIQEeXl5qWXLlrK3t1fFihX18MMPZxvTiBEj9Nprr5mvk5OT+RAJAACAPMc8FAAAAPmJFRnIc7Gxsbp06ZJKlSplPu/C2dlZx48f19GjR++qLQ8PD0VERJirHWbMmKHExMQcHXv58mUNHz5cgYGBcnd3l7Ozs3777bccr8iIi4tTrVq1zCTGv22/YcOGmV4fPHhQkvTkk0/q6tWrqly5sl544QWtWLFCaWlp2cbk6OgoV1dXqw0AAADIa8xDAQAAkJ9IZCDPZWRkyNvbW3FxcVbboUOHNGzYsLtub968edq+fbsaNWqkxYsXy8/PTzt27LjjccOGDdOyZcv07rvvasuWLYqLi1NwcLCuX7+eo36LFy+eZ+3fvDVWhQoVdOjQIc2aNUvFixfXgAEDFBYWptTU1BzFCAAAAAAAAACFDbeWwm05ODgoPT39X5dLUu3atXXq1CnZ2dnJ19c3V+KqVauWatWqpREjRqhhw4b66quv1KBBg9ses2XLFkVERKhz586SbjzTIj4+Psd9hoSE6JNPPtH58+ezXJWR0/b/mXTZsWOHqlevbr4uXry4Hn/8cT3++OMaOHCgqlevrn379ql27do5jhUAAAAAAAAACgtWZOC2fH19tXPnTsXHx+vs2bPmg61vLb906ZI2bNigs2fP6sqVK5naaNmypRo2bKhOnTrp+++/V3x8vLZt26a33npLu3fvvqt4jh8/rhEjRmj79u06ceKE1q1bp8OHD+foORlVq1bV8uXLFRcXp59//llPP/10pvO5nR49esjLy0udOnXS1q1bdezYMS1btkzbt2+/q/a3bt2qSZMm6fDhw5o1a5aWLl2qV155RZIUFRWlTz/9VPv379exY8f0xRdfqHjx4vLx8clxnAAAAAAAAABQmJDIwG0NHTpURYsWVWBgoEqXLp3peQ+NGjVSv3791L17d5UuXVqTJk3K1IbFYtGaNWsUFhamvn37ys/PT0899ZTi4+NVpkyZu4qnRIkS+u233/TEE0/Iz89PL774ogYNGqSXXnrpjsdOmzZNJUuWVKNGjdShQwe1bt36rlY5ODg4aN26dfL09FTbtm0VHBysiRMnqmjRonfV/pAhQxQbG6tatWpp3LhxmjJlilq3bi1Jcnd318cff6zGjRsrJCREGzZs0H//+1+VKlUqx3ECAAAAAAAAQGFiMQzDKOgggAeFr6+vBg8erMGDB+dJ+8nJyXJzc1NSUhIPXAQAAEC+YR4KAACAvMSKDAAAAAAAAAAAYLNIZKDA1ahRQ87OzlluCxYsyPd2AAAAAAAAAAC2w66gAwDWrFmj1NTULMvu5hkaudVOXoqPjy/oEAAAAAAAAADgvkIiAwXOx8fHptoBAAAAAAAAANgObi0FAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyCjkwsPDNXjw4IIOI9dFRUXJ3d29oMPIVnR0tCwWiy5evFjQoQAAAAAAAADAfY1EBnCPskoWNWrUSImJiXJzcyuYoAAAAAAAAACgkLAr6ACAwsjBwUFeXl4FHQYAAAAAAAAA3PdYkfEAyMjI0PDhw+Xh4SEvLy+NHj3aLJs6daqCg4Pl5OSkChUqaMCAAbp06ZJZfuLECXXo0EElS5aUk5OTatSooTVr1uSo3wMHDqht27ZydnZWmTJl1LNnT509e1bSjVsvOTg4aMuWLWb9KVOm6KGHHlJiYqIk6eLFi3rxxRdVpkwZFStWTEFBQVq9enWWfR09elQdO3ZUmTJl5OzsrHr16umHH36wquPr66t33nlHvXr1krOzs3x8fLRy5UqdOXNGHTt2lLOzs4KDg7V7927zmHPnzqlHjx4qX768SpQooeDgYC1cuNAsj4iIUExMjGbMmCGLxSKLxaL4+Pgsby21bNky1ahRQ46OjvL19dWUKVMyxTd+/Hj17dtXLi4uqlixov7zn//c9hqnpKQoOTnZagMAAADyGvNQAAAA5CcSGQ+A+fPny8nJSTt37tSkSZM0duxYrV+/XpJUpEgRzZw5U/v379f8+fO1ceNGDR8+3Dx24MCBSklJ0ebNm7Vv3z699957cnZ2vmOfiYmJatq0qUJDQ7V7926tXbtWf/31l7p16ybp/92OqWfPnkpKStLPP/+sN998Ux9//LG8vb2VkZGhNm3aaNu2bfryyy914MABTZw4UUWLFs2yv0uXLqlt27b64YcftHfvXrVu3VodOnRQQkKCVb1p06apcePG2rt3r9q1a6eePXuqV69eevbZZ7Vnzx5VrVpVvXr1kmEYkqRr166pTp06Wr16tfbv368XX3xRPXv21M6dOyVJM2bMUMOGDfXCCy8oMTFRiYmJqlChQqb4YmNj1a1bNz311FPat2+fRo8erZEjRyoqKsqq3pQpU1S3bl3t3btXAwYMUP/+/fXbb79le50nTJggNzc3c8uqbwAAACC3MQ8FAABAfrIYN/9ii0IpPDxc6enpVisfHn74YTVv3lwTJ07MVH/p0qXq37+/uXIiJCRETzzxhEaNGnVX/b799tvauXOnvv/+e3Pf77//rgoVKujQoUPy8/PT9evX1aBBA1WrVk2//vqrGjZsqI8//liStG7dOrVp00YHDx6Un59fpvajoqI0ePDg2z5Mu0aNGurfv78GDRok6caKh0ceeURffPGFJOnUqVPy9vbWyJEjNXbsWEnSjh071LBhQyUmJmZ7a6h27dopICBAkydPlnTjGoeGhmr69OlmnejoaDVr1kwXLlyQu7u7nnnmGZ05c0br1q0z6wwfPlzffvutfv311yzjMwxDXl5eGjNmjPr165dlLCkpKUpJSTFfJycnq0KFCkpKSpKrq2u21wYAAAC4F8xDAQAAkJ94RsYDICQkxOq1t7e3Tp8+LUnatGmTxo8frwMHDig5OVlpaWm6du2aLl++LCcnJ0VGRqp///5at26dWrZsqSeeeCJTe1mJjY3Vpk2bsly9cfToUfn5+cnBwUFffvmlQkJC5OPjY5UIiIuLU/ny5bNMYmTl8uXLGjNmjFavXq0///xTaWlpunr1aqYVGbfGXqZMGUlScHBwpn2nT5+Wl5eX0tPTNXHiRC1evFh//PGH+YHNyckpR3HddPDgQXXs2NFqX+PGjTV9+nSlp6ebK01ujc9iscjLy8scq6w4OjrK0dHxrmIBAAAA7hXzUAAAAOQnbi31ALC3t7d6bbFYlJGRoRMnTqht27YKCgrSsmXLFBsbq1mzZkmSUlNTJUnPP/+8jh07pp49e2rfvn2qW7euPvjggzv2mZGRoQ4dOiguLs5qO3LkiMLCwsx627ZtkySdP39e58+fN/cXL178rs5x2LBhWrZsmd59911t2bJFcXFxCg4O1vXr17O9FhaLJdt9GRkZkm7c6mnatGkaPny4Nm7cqLi4OLVu3TpTu3diGIbZ9q37/im7sQIAAAAAAACABxWJjAfY7t27lZaWpilTpqhBgwby8/PTn3/+malehQoV1K9fPy1fvlxDhgwxb/90O7Vr19avv/4qX19fVa1a1Wq7uZrh6NGjevXVV/Xxxx+rQYMG6tWrl/lH+5CQEP3+++86fPhwjs5ly5YtioiIUOfOnRUcHCwvLy/Fx8fn/GLcpt2OHTvq2WefVc2aNVW5cmUdOXLEqo6Dg4PS09Nv205gYKB+/PFHq33btm2Tn59fts/9AAAAAAAAAACQyHigValSRWlpafrggw907NgxffHFF5ozZ45VncGDB+v777/X8ePHtWfPHm3cuFEBAQF3bHvgwIE6f/68evTooZ9++knHjh3TunXr1LdvX6Wnpys9PV09e/bUo48+qj59+mjevHnav3+/pkyZIklq2rSpwsLC9MQTT2j9+vU6fvy4vvvuO61duzbL/qpWrarly5crLi5OP//8s55++ulcWclQtWpVrV+/Xtu2bdPBgwf10ksv6dSpU1Z1fH19tXPnTsXHx+vs2bNZ9jtkyBBt2LBB48aN0+HDhzV//nx9+OGHGjp06D3HCAAAAAAAAACFGYmMB1hoaKimTp2q9957T0FBQVqwYIEmTJhgVSc9PV0DBw5UQECAHnvsMfn7+2v27Nl3bLts2bLaunWr0tPT1bp1awUFBemVV16Rm5ubihQponfffVfx8fH6z3/+I0ny8vLSJ598orfeektxcXGSpGXLlqlevXrq0aOHAgMDNXz48GxXPkybNk0lS5ZUo0aN1KFDB7Vu3Vq1a9e+twskaeTIkapdu7Zat26t8PBweXl5qVOnTlZ1hg4dqqJFiyowMFClS5fO9FwO6cYKlSVLlmjRokUKCgrS22+/rbFjxyoiIuKeYwQAAAAAAACAwsxiZHWjfgD3peTkZLm5uSkpKUmurq4FHQ4AAAAeEMxDAQAAkJdYkQEAAAAAAAAAAGwWiQz8K/369ZOzs3OWW79+/Qo6PAAAAAAAAABAIcGtpfCvnD59WsnJyVmWubq6ytPTM58jgsSSfgAAABQM5qEAAADIS3YFHQDuT56eniQrAAAAAAAAAAB5jltLAQAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDJwz8LDwzV48OCCDsOmjB49WqGhoQUdBgAAAAAAAADc90hkAPfIYrHom2++sdo3dOhQbdiwoWACAgAAAAAAAIBCxK6gAwAKI2dnZzk7Oxd0GAAAAAAAAABw32NFBnJFRkaGhg8fLg8PD3l5eWn06NFm2dSpUxUcHCwnJydVqFBBAwYM0KVLl8zyEydOqEOHDipZsqScnJxUo0YNrVmzJkf9rlmzRn5+fipevLiaNWumqKgoWSwWXbx4UVLWt3iaPn26fH19rfbNmzdPAQEBKlasmKpXr67Zs2ebZdevX9egQYPk7e2tYsWKydfXVxMmTJAks53OnTvLYrGYr//Zb0ZGhsaOHavy5cvL0dFRoaGhWrt2rVkeHx8vi8Wi5cuXq1mzZipRooRq1qyp7du35+g6AAAAAAAAAEBhRSIDuWL+/PlycnLSzp07NWnSJI0dO1br16+XJBUpUkQzZ87U/v37NX/+fG3cuFHDhw83jx04cKBSUlK0efNm7du3T++9916OVjOcPHlSXbp0Udu2bRUXF6fnn39eb7zxxl3H/vHHH+vNN9/Uu+++q4MHD2r8+PEaOXKk5s+fL0maOXOmVq1apSVLlujQoUP68ssvzYTFrl27JN1IhCQmJpqv/2nGjBmaMmWKJk+erF9++UWtW7fW448/riNHjljVe/PNNzV06FDFxcXJz89PPXr0UFpaWraxp6SkKDk52WoDAAAA8hrzUAAAAOQnbi2FXBESEqJRo0ZJkqpVq6YPP/xQGzZsUKtWraweBF6pUiWNGzdO/fv3N1c9JCQk6IknnlBwcLAkqXLlyjnq86OPPlLlypU1bdo0WSwW+fv7m4mQuzFu3DhNmTJFXbp0MWM8cOCA5s6dq969eyshIUHVqlVTkyZNZLFY5OPjYx5bunRpSZK7u7u8vLyy7WPy5Ml6/fXX9dRTT0mS3nvvPW3atEnTp0/XrFmzzHpDhw5Vu3btJEljxoxRjRo19L///U/Vq1fPst0JEyZozJgxd3W+AAAAwL1iHgoAAID8xIoM5IqQkBCr197e3jp9+rQkadOmTWrVqpXKlSsnFxcX9erVS+fOndPly5clSZGRkXrnnXfUuHFjjRo1Sr/88kuO+jx48KAaNGggi8Vi7mvYsOFdxX3mzBmdPHlSzz33nPlcC2dnZ73zzjs6evSoJCkiIkJxcXHy9/dXZGSk1q1bd1d9JCcn688//1Tjxo2t9jdu3FgHDx602nfrdfT29pYk8zpmZcSIEUpKSjK3kydP3lVsAAAAwL/BPBQAAAD5iUQGcoW9vb3Va4vFooyMDJ04cUJt27ZVUFCQli1bptjYWHMFQmpqqiTp+eef17Fjx9SzZ0/t27dPdevW1QcffHDHPg3DuGOdIkWKZKp3s1/pxrMrpBu3l4qLizO3/fv3a8eOHZKk2rVr6/jx4xo3bpyuXr2qbt26qWvXrnfs+59uTbjcjP+f+269jjfLbsaYFUdHR7m6ulptAAAAQF5jHgoAAID8RCIDeWr37t1KS0vTlClT1KBBA/n5+enPP//MVK9ChQrq16+fli9friFDhujjjz++Y9uBgYFmsuGmf74uXbq0Tp06ZZXMiIuLM/9dpkwZlStXTseOHVPVqlWttkqVKpn1XF1d1b17d3388cdavHixli1bpvPnz0u6kXxIT0/PNk5XV1eVLVtWP/74o9X+bdu2KSAg4I7nCQAAAAAAAAAPMp6RgTxVpUoVpaWl6YMPPlCHDh20detWzZkzx6rO4MGD1aZNG/n5+enChQvauHFjjv7A369fP02ZMkWvvfaaXnrpJcXGxioqKsqqTnh4uM6cOaNJkyapa9euWrt2rb777jurb4yNHj1akZGRcnV1VZs2bZSSkqLdu3frwoULeu211zRt2jR5e3srNDRURYoU0dKlS+Xl5SV3d3dJkq+vrzZs2KDGjRvL0dFRJUuWzBTrsGHDNGrUKFWpUkWhoaGaN2+e4uLitGDBgru/qAAAAAAAAADwAGFFBvJUaGiopk6dqvfee09BQUFasGCBJkyYYFUnPT1dAwcOVEBAgB577DH5+/ubDwK/nYoVK2rZsmX673//q5o1a2rOnDkaP368VZ2AgADNnj1bs2bNUs2aNfXTTz9p6NChVnWef/55ffLJJ4qKilJwcLCaNm2qqKgoc0WGs7Oz3nvvPdWtW1f16tVTfHy81qxZoyJFbrx9pkyZovXr16tChQqqVatWlrFGRkZqyJAhGjJkiIKDg7V27VqtWrVK1apVy/G1BAAAAAAAAIAHkcXIyYMGgPtEdHS0mjVrpgsXLpgrJh4kycnJcnNzU1JSEvcpBgAAQL5hHgoAAIC8xIoMAAAAAAAAAABgs0hkwGb169dPzs7OWW79+vUr6PAAAAAAAAAAAPmAW0vBZp0+fVrJyclZlrm6usrT0zOfI7J9LOkHAABAQWAeCgAAgLxkV9ABANnx9PQkWQEAAAAAAAAADzhuLQUAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANsuuoAMAkHsMw5AkJScnF3AkAAAAsBUuLi6yWCx52gfzUAAAAPxTbs5DSWQAhci5c+ckSRUqVCjgSAAAAGArkpKS5Orqmqd9MA8FAADAP+XmPJREBlCIeHh4SJISEhLk5uZWwNFAuvGtxAoVKujkyZN5/gcE3BnjYXsYE9vDmNgWxsP23I9j4uLikud9MA8tPO7Hn3Fkj/EsPBjLwoXxLDwYy9vLzXkoiQygEClS5MZjb9zc3Pifp41xdXVlTGwI42F7GBPbw5jYFsbD9jAm1piHFj78jBcujGfhwVgWLoxn4cFY5j0e9g0AAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAhYijo6NGjRolR0fHgg4F/z/GxLYwHraHMbE9jIltYTxsD2OSNa5L4cFYFi6MZ+HBWBYujGfhwVjmH4thGEZBBwEAAAAAAAAAAJAVVmQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBlCIzJ49W5UqVVKxYsVUp04dbdmypaBDKpRGjx4ti8VitXl5eZnlhmFo9OjRKlu2rIoXL67w8HD9+uuvVm2kpKTo5Zdf1kMPPSQnJyc9/vjj+v333/P7VO5LmzdvVocOHVS2bFlZLBZ98803VuW5df0vXLignj17ys3NTW5uburZs6cuXryYx2d3f7rTmERERGR6zzRo0MCqDmOSeyZMmKB69erJxcVFnp6e6tSpkw4dOmRVh/dJ/snJePAeyV8fffSRQkJC5OrqKldXVzVs2FDfffedWc774+4xBy14tjQ/SkhIUIcOHeTk5KSHHnpIkZGRun79el6cdqFka7/HGc9/z5Z+3zCOuWvChAmyWCwaPHiwuY/xvH/k1990GMs8YAAoFBYtWmTY29sbH3/8sXHgwAHjlVdeMZycnIwTJ04UdGiFzqhRo4waNWoYiYmJ5nb69GmzfOLEiYaLi4uxbNkyY9++fUb37t0Nb29vIzk52azTr18/o1y5csb69euNPXv2GM2aNTNq1qxppKWlFcQp3VfWrFljvPnmm8ayZcsMScaKFSusynPr+j/22GNGUFCQsW3bNmPbtm1GUFCQ0b59+/w6zfvKncakd+/exmOPPWb1njl37pxVHcYk97Ru3dqYN2+esX//fiMuLs5o166dUbFiRePSpUtmHd4n+Scn48F7JH+tWrXK+Pbbb41Dhw4Zhw4dMv7v//7PsLe3N/bv328YBu+Pu8Uc1DbYyvwoLS3NCAoKMpo1a2bs2bPHWL9+vVG2bFlj0KBBeX4NCgtb+j3OeN4bW/l9wzjmrp9++snw9fU1QkJCjFdeecXcz3jeP/LrbzqMZe4jkQEUEg8//LDRr18/q33Vq1c33njjjQKKqPAaNWqUUbNmzSzLMjIyDC8vL2PixInmvmvXrhlubm7GnDlzDMMwjIsXLxr29vbGokWLzDp//PGHUaRIEWPt2rV5Gnth888P6rl1/Q8cOGBIMnbs2GHW2b59uyHJ+O233/L4rO5v2SUyOnbsmO0xjEneOn36tCHJiImJMQyD90lB++d4GAbvEVtQsmRJ45NPPuH98S8wB7U9BTk/WrNmjVGkSBHjjz/+MOssXLjQcHR0NJKSkvLkfAu7gvw9znjmvoL4fcM45p6///7bqFatmrF+/XqjadOmZiKD8by/5MffdBjLvMGtpYBC4Pr164qNjdWjjz5qtf/RRx/Vtm3bCiiqwu3IkSMqW7asKlWqpKeeekrHjh2TJB0/flynTp2yGgtHR0c1bdrUHIvY2FilpqZa1SlbtqyCgoIYr3uUW9d/+/btcnNzU/369c06DRo0kJubG2P0L0VHR8vT01N+fn564YUXdPr0abOMMclbSUlJkiQPDw9JvE8K2j/H4ybeIwUjPT1dixYt0uXLl9WwYUPeH3eJOej9IT9/rrdv366goCCVLVvWrNO6dWulpKQoNjY2T8+zsCrI3+OMZ+4pyN83jGPuGThwoNq1a6eWLVta7Wc87z95/TcdxjJv2BV0AADu3dmzZ5Wenq4yZcpY7S9TpoxOnTpVQFEVXvXr19fnn38uPz8//fXXX3rnnXfUqFEj/frrr+b1zmosTpw4IUk6deqUHBwcVLJkyUx1GK97k1vX/9SpU/L09MzUvqenJ2P0L7Rp00ZPPvmkfHx8dPz4cY0cOVLNmzdXbGysHB0dGZM8ZBiGXnvtNTVp0kRBQUGSeJ8UpKzGQ+I9UhD27dunhg0b6tq1a3J2dtaKFSsUGBhofrDk/ZEzzEHvD/n5//1Tp05l6qdkyZJycHDgZ+JfKOjf44znvbOF3zeMY+5YtGiR9uzZo127dmUq4315f8mPv+kwlnmDRAZQiFgsFqvXhmFk2od716ZNG/PfwcHBatiwoapUqaL58+ebD2f9N2PBeOWe3Lj+WdVnjP6d7t27m/8OCgpS3bp15ePjo2+//VZdunTJ9jjG5N4NGjRIv/zyi3788cdMZbxP8l9248F7JP/5+/srLi5OFy9e1LJly9S7d2/FxMSY5bw/7g5z0PtDfv1cP0g/+3nNFn6PM573xlZ+3zCO9+bkyZN65ZVXtG7dOhUrVizbeozn/SG//qbDWOY+bi0FFAIPPfSQihYtmilje/r06UzZXeQ+JycnBQcH68iRI/Ly8pKk246Fl5eXrl+/rgsXLmRbB/9Obl1/Ly8v/fXXX5naP3PmDGOUC7y9veXj46MjR45IYkzyyssvv6xVq1Zp06ZNKl++vLmf90nByG48ssJ7JO85ODioatWqqlu3riZMmKCaNWtqxowZvD/uEnPQ+0N+/lx7eXll6ufChQtKTU3lZ+Iu2cLvccbz3tnC7xvG8d7Fxsbq9OnTqlOnjuzs7GRnZ6eYmBjNnDlTdnZ25nVkPO9PefE3HcYyb5DIAAoBBwcH1alTR+vXr7fav379ejVq1KiAonpwpKSk6ODBg/L29lalSpXk5eVlNRbXr19XTEyMORZ16tSRvb29VZ3ExETt37+f8bpHuXX9GzZsqKSkJP30009mnZ07dyopKYkxygXnzp3TyZMn5e3tLYkxyW2GYWjQoEFavny5Nm7cqEqVKlmV8z7JX3caj6zwHsl/hmEoJSWF98ddYg56f8jPn+uGDRtq//79SkxMNOusW7dOjo6OqlOnTp6eZ2FhS7/HGc/cVxC/bxjHe9eiRQvt27dPcXFx5la3bl0988wziouLU+XKlRnP+1he/E2HscwjefIIcQD5btGiRYa9vb3x6aefGgcOHDAGDx5sODk5GfHx8QUdWqEzZMgQIzo62jh27JixY8cOo3379oaLi4t5rSdOnGi4ubkZy5cvN/bt22f06NHD8Pb2NpKTk802+vXrZ5QvX9744YcfjD179hjNmzc3atasaaSlpRXUad03/v77b2Pv3r3G3r17DUnG1KlTjb179xonTpwwDCP3rv9jjz1mhISEGNu3bze2b99uBAcHG+3bt8/3870f3G5M/v77b2PIkCHGtm3bjOPHjxubNm0yGjZsaJQrV44xySP9+/c33NzcjOjoaCMxMdHcrly5YtbhfZJ/7jQevEfy34gRI4zNmzcbx48fN3755Rfj//7v/4wiRYoY69atMwyD98fdYg5qG2xlfpSWlmYEBQUZLVq0MPbs2WP88MMPRvny5Y1Bgwbl38W4z9nS73HG897Yyu8bxjFvNG3a1HjllVfM14zn/SO//qbDWOY+EhlAITJr1izDx8fHcHBwMGrXrm3ExMQUdEiFUvfu3Q1vb2/D3t7eKFu2rNGlSxfj119/NcszMjKMUaNGGV5eXoajo6MRFhZm7Nu3z6qNq1evGoMGDTI8PDyM4sWLG+3btzcSEhLy+1TuS5s2bTIkZdp69+5tGEbuXf9z584ZzzzzjOHi4mK4uLgYzzzzjHHhwoV8Osv7y+3G5MqVK8ajjz5qlC5d2rC3tzcqVqxo9O7dO9P1ZkxyT1ZjIcmYN2+eWYf3Sf6503jwHsl/ffv2NedLpUuXNlq0aGH+UckweH/8G8xBC54tzY9OnDhhtGvXzihevLjh4eFhDBo0yLh27Vpenn6hYmu/xxnPf8+Wft8wjrnvn4kMxvP+kV9/02Esc5/FMAwjb9d8AAAAAAAAAAAA/Ds8IwMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAgBwYPXq0LBZLpq169eq53tf06dO1Zs2aXG/33woPD1f79u0LOoy7Mnr0aG3btq2gw7gnq1evVtmyZZWSkpKn/cTHx8tisejrr7/Ok+Oio6M1fvz4TPu//PJLBQQEKD09/a76BQDgQcM8lHlofmMeCsAWkcgAACCHihcvru3bt1ttixcvzvV+bO0D5P1ozJgx9/UHSMMw9Oabb+q1116To6Njnvbl7e2t7du3q3nz5nnSfnYfIHv06KFr165p/vz5edIvAACFCfPQ+wfz0JxjHgrgbtgVdAAAANwvihQpogYNGhR0GHft6tWrKl68eEGHkS8Ky7lu2rRJBw4cUERERJ735ejoWCA/10WLFlWvXr00Y8YM9e3bN9/7BwDgfsI81PYVlnNlHgrAVrEiAwCAXPLtt9+qfv36Kl68uEqXLq3+/fvr8uXLZvnly5c1aNAg+fv7q0SJEvL19VW/fv2UlJRk1vH19dWJEyc0a9Ys87YBUVFRkiSLxaLJkydb9Tl58mRZLBbzdXR0tCwWi7799lt17dpVrq6uevLJJyVJFy9e1IABA+Tt7S1HR0fVqVNH69atu+vzjIqKksVi0U8//aQWLVqoRIkS8vPz0/fff6+MjAyNHDlSXl5e8vT01IgRI5SRkWEeO3r0aDk7O2vXrl16+OGHVaxYMQUEBGj16tWZ+vnPf/6jgIAAOTo6qmLFinrrrbeUlpaWKY7t27erVatWcnJy0tChQ83rMWzYMPMaRkdHS5KmTJmievXqyc3NTZ6enmrfvr0OHz5s1W9ERISCgoIUHR2tWrVqycnJSQ8//LBiY2Ot6mVkZGjq1KlmjF5eXnryySetxvPgwYPq2LGj3Nzc5OTkpHbt2uno0aN3vMbz589X06ZN9dBDD5n7qlSporffftt8/c0338hisei1114z9/3www+yWCz6/fffzX13+rnMamn+9evXFRkZKQ8PD7m5uem5557T/PnzZbFYFB8fbxXrtWvXNGjQIJUsWVLe3t4aOnSoOU6jR4/WmDFjdPnyZXMswsPDzWOffPJJ/fLLL4qLi7vjNQEAANljHso8lHko81CgsCORAQDAXUhLS7PaDMOQJH399dd6/PHHFRwcrBUrVmjSpElavny5nnvuOfPYK1euKD09Xe+++66+++47vfPOO4qJiVHnzp3NOitWrJCXl5e6du1q3jagXbt2dx3nSy+9pKpVq2rFihUaMmSIrl+/rlatWmn16tV69913tWrVKgUGBqpdu3bat2/fv7oWERER6tSpk1asWKFy5cqpa9eueuWVV5SQkKD58+dr0KBBmjhxohYtWmR1XGpqqrp3767evXtr+fLlqlq1qjp37qz9+/ebdT744AO99NJLat68uVatWqV+/fpp0qRJeumllzLF8cwzz6hFixZavXq1evbsqe3bt0uSXn75ZfMa1q5dW5L0+++/a9CgQVq5cqU++eQTZWRkqFGjRjp//rxVm6dOnVJkZKSGDRumxYsX68qVK+rcubNSU1PNOi+//LKGDx+u9u3b67///a9mzZolFxcXXbp0SZJ07Ngxs+2oqCh99dVXOnPmjFq0aHHH+w1v2LBBjRs3ttoXFhammJgY8/XmzZtVrFixTPsqVaqk8uXLS8rZz2VW3njjDc2dO1evv/66lixZIkl66623sqz75ptvqkiRIlqyZIleeuklTZkyRZ988okk6fnnn9dzzz1ndTuM2bNnm8fWqFFD7u7uWr9+/W3jAQAAzENvxTyUeajEPBR44BgAAOCORo0aZUjKtH3xxRdGRkaG4ePjY/To0cPqmG+//dawWCzG/v37s2wzNTXV+PHHHw1JxqFDh8z9Pj4+xsCBAzPVl2S8//77Vvvef/9949Zf55s2bTIkGQMGDLCq99lnnxl2dnbGr7/+arX/4YcfNp588snbnnvTpk2Ndu3ama/nzZtnSDI++ugjc9++ffsMSUb9+vWtjq1Tp47RqVMn8/XN6/jpp5+a+9LS0gxfX1/z+qWlpRkPPfRQprjGjx9vWCwW4+jRo1ZxTJo0KVPMWV2rf0pLSzOuXLliODs7G3PnzjX39+7dO9O4rV+/3pBkbNmyxTAMwzh06JBhsViM8ePHZ9t+r169jEqVKhlXr141950+fdpwcnIyZs2ale1xf/75pyHJWLp0qdX+zz77zHB0dDTbq1OnjjFo0CCjSJEixsWLFw3DuDFWvXv3NgzDyPHP5fHjx636O3funFGsWDFj7NixVsc1bdrUkGQcP37c6rh/jlPjxo2NFi1amK9HjRplODk5ZXu+YWFhxhNPPJFtOQAADzrmocxDmYcyDwVgGKzIAAAgh4oXL65du3ZZbW3bttXhw4d14sQJdevWzepbck2bNpXFYtHu3bvNNr744gvVqlVLzs7Osre3V5MmTSQp07Lye9W2bVur1+vWrVNwcLD8/PysYmzRooV27dr1r/po2bKl+W8/P79M+27uP3nyZKZjb/32X9GiRfX4449rx44dkqTffvtNZ8+eVffu3a2O6dGjhwzD0NatW632//Ncb2fHjh1q1aqVSpUqJTs7O5UoUUKXLl3KdP3Lli2rGjVqmK8DAwMlyVwqv3HjRhmGcdtvlK1bt04dO3aUnZ2deb1LliypmjVr3vaaJyYmSpJKly5ttT8sLEwpKSnauXOn/v77b8XFxalfv34qVaqUfvzxR12/fl07d+5UWFiYJN3Vz+Wt9u3bp2vXrunxxx+32t+xY8cs6z/66KNWrwMDA61uKXAnDz30kE6dOpXj+gAAPIiYh1pjHso8VGIeCjxoeNg3AAA5VKRIEdWtWzfT/oMHD0qy/lB0q5sfoFasWKFevXrpxRdf1LvvvqtSpUopMTFRnTt31rVr13I1Vk9PT6vXZ8+e1d69e2Vvb5+pbtGiRf9VH+7u7ua/HRwcMu27uf+f52Zvb6+SJUtmivfmB6cLFy5Ikry8vKzq3Hz9z+X3/zzX7CQkJOjRRx9V3bp1NXfuXJUtW1YODg5q165dphizOg9JZr1z587Jzs7utn2fPXtW06dP1/Tp0zOV3e5BkDf7cHR0tNpfpUoVlS9fXps3b9bVq1dVsmRJBQYG6pFHHtHmzZvl5uama9euqWnTpmb/0p1/Lv8puw+w2Z1rTsb8dooVK6arV6/muD4AAA8i5qHWmIcyD5WYhwIPGhIZAADcIw8PD0nShx9+qPr162cqL1u2rCRp6dKlCg0N1dy5c82yW+8reyeOjo66fv261b5/fpi66dYHL96MMSQkRJ9++mmO+8srqampunDhgtWHyNOnT8vb21vS/7uef/31l9VxN78tdbP8pn+ea3bWrl2rS5cuafny5eaHnrS0tGyv4e2UKlVKaWlpOn36dLYfrDw8PNSuXTsNGDAgU5mLi0u2bd88v4sXL2Yqe+SRRxQTE6OrV6/qkUcekcViUVhYmBYuXCg3NzeVLVtWVapUsWrnTj+X/3RzHM6cOWNV5/Tp09nGfC8uXLigUqVK5UnbAAAUdsxD7w7zUOaht2IeCtxfSGQAAHCPqlevrvLly+vYsWMaOHBgtvWuXr1qfqPqpgULFmSql903icqXL29+6+6mH374IUcxtmzZUmvWrFHZsmWz/eCQn1asWKG+fftKktLT07Vq1So1aNBAkuTv76/SpUtryZIl6tKli3nM4sWLZbFYzNsg3I69vX2ma3j16lVZLBarbwMuWbJEaWlpdx1/8+bNZbFYNG/ePL3++utZ1mnZsqX279+vWrVq3dW3DStVqiQHBwcdP348U1lYWJiGDBmi5ORkPfPMM5Kkpk2baujQobKzszOX80s5/7n8p+DgYBUrVkwrV65UzZo1zf3ffPNNjtu4lYODw20fKnn8+PFMt4IAAAA5wzz07jEPzR7zUAC2jEQGAAD3yGKxaOrUqXr66ad1+fJltWvXTk5OTjpx4oS+/fZbjR8/Xn5+fmrVqpUGDhyosWPHqlGjRvruu++0YcOGTO0FBARo48aNWr9+vUqWLKlKlSqpVKlS6tq1q6ZPn66HH35Yfn5++vzzz3N8T9devXpp7ty5Cg8P19ChQ+Xn56eLFy9q7969un79uiZMmJDblyVbDg4Oeuedd3Tt2jVVqlRJs2fP1u+//64RI0ZIunGLgbffflsvv/yySpcurQ4dOmjPnj0aNWqU+vTpo0qVKt2xj4CAAK1cuVKPPPKInJyc5O/vr+bNm0uS+vTpo5deekkHDhzQ5MmTMy1Jzwk/Pz/169dPb731ls6fP68WLVroypUr+vbbbzV69GiVK1dOY8aMUb169dS6dWu9+OKLKlOmjE6dOqWYmBg98sgj6tGjR5ZtOzo6qk6dOoqNjc1UFhYWpitXrmjXrl3mNypDQkLk7OysrVu3avbs2WbdnP5c/pOHh4f69++vd999V8WKFVNoaKgWL16sY8eOSbpxa4u7ERAQoLS0NM2YMUONGjWSq6ur/P39JUnJyck6dOiQxowZc1dtAgCAG5iH3h3mocxDmYcC97GCfdY4AAD3h1GjRhlOTk63rbNu3TqjadOmhpOTk+Hk5GTUqFHDGDJkiHHx4kXDMAwjLS3NGDJkiFG6dGnDxcXF6Nq1q7Fjxw5DkrF06VKznf379xuPPPKI4eLiYkgy5s2bZxiGYVy6dMno06eP4eHhYZQuXdp48803jffee8+49df5pk2bDEnGrl27MsWXlJRkvPrqq0bFihUNe3t7w9vb22jbtq2xevXq255X06ZNjXbt2pmv582bZ0gyzpw5Y1VPkvH+++9b7evdu7dRo0aNTNdxx44dRp06dQwHBwfD39/fWLlyZaZ+58yZY/j7+xv29vZG+fLljTfffNNITU29YxyGYRhbtmwxateubRQvXtyQZGzatMkwDMOYP3++UblyZaNYsWJGgwYNjJ9++snw8fExBg4cmG3MhmEYZ86csRoLwzCM9PR0Y9KkSUa1atUMe3t7w8vLy+jevbuRlJRk1jl8+LDRrVs3o1SpUoajo6Ph6+tr9OrVy9i/f39Wl9o0ZcoUo1y5ckZGRkamstKlSxtubm5Genq6ua99+/aGpCzbvdPP5fHjxzP9DKakpBiDBg0y3N3dDVdXV6N3797GjBkzDEm3Pc4wDGPgwIGGj4+P+To1NdUYMGCAUaZMGcNisRhNmzY1yxYvXmw4OTkZycnJt70eAAA8yJiHMg9lHso8FIBhWAzDMPIraQIAAB5so0eP1uTJk3Xp0qWCDsWmnTlzRhUqVNC6deuslukXpGeffVZbt27N8lYD/1aXLl3k7u6uzz77LNfaBAAAyArz0JxhHgrAVnFrKQAAABtTunRp9e/fX1OmTCmQD5AxMTHaunWr6tSpo4yMDK1evVpfffWVpk6dmmt9HDt2TN99953279+fa20CAADg3jAPBWCrSGQAAADYoP/7v//TRx99pJSUFDk6OuZr387Ozlq9erUmTZqkK1euqFKlSpo6daoGDx6ca3388ccf+vjjj1WlSpVcaxMAAAD3jnkoAFvEraUAAAAAAAAAAIDNKlLQAQAAAAAAAAAAAGSHRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGb9fyQgwqaYFIIAAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1600x800 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved xgb_v2_4class_feature_importance.png\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABjIAAAMsCAYAAAD+vjuEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd1QU1/838PfSO9IVpdgQlapgARv2rigWUMGuscUa9ZvEEmsssUVjibH32I1IbBi7WLBiR9GISmwIolLu8wcP89uBpYqy6vt1zp6zO3PvzJ2ys3fnM/dehRBCgIiIiIiIiIiIiIiISA1pFHUBiIiIiIiIiIiIiIiIssNABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERF9drp37w6FQgGFQoF69eoVdXGIPjuxsbEwNjaGQqGAh4dHURcnzzK+9wqFAitXrizq4tBXauXKlbJzkaiw6yVDhgyRlrdnz54PLyAR0ReAgQwiIgB37tyBkZGRVFls3rx5ljRpaWmoW7eulMbU1BQxMTFZ0j179gyzZs1CkyZNYGtrC319fZiYmMDJyQn16tXDhAkTcObMGQghpDz37t2T/RnKeGlqasLY2BgVK1ZEz549cfbs2Y+6Hwqbo6OjtC0TJkzId35V+yTzy9HRsdDLnRcfum3qJvMf8vDw8KIu0if3pR3Tz0F4eLjK77WWlhZMTU3h7u6OQYMG4ebNm0VdVLWiztdG+vgK6wbq999/j4SEBADAjz/+KJunfEOON2nVhxACe/bsQdeuXVG+fHkYGxvDwMAA5cuXR/PmzbFs2TI8f/68qIv5yX0pv9+3b9/G4MGD4ePjg1KlSkFfXx96enooWbIkmjdvjjVr1iAtLU1l3pcvX+KHH36Ai4sLDA0NYWJigqpVq2LGjBl4+/ZtlvS3bt1CQEAASpYsCRMTE3h7e2PTpk0qlz1t2jQoFAp07NixULeXcjZ69Gjo6uoCAEaOHImUlJQiLhERUdHTKuoCEBGpg7Jly2L27Nno378/ACA0NBSLFy+WPgPAnDlz8M8//0ifFyxYAHt7e9lyli9fjqFDh0o3BjK8ffsWr1+/xq1bt3DkyBFMnDgR0dHRud5oSktLQ0JCAq5fv47r169j9erV2LZtG1q3bv2BW0xEpL5SU1MRHx+PS5cu4dKlS1ixYgXCw8Ph7e0tpencuTNcXFwAAHZ2dkVVVKLP0q1bt7Bq1SoAgIODA9q1a1fEJaLc3L9/H4GBgTh58mSWebdv38bt27cRGhqKq1evYu7cuZ++gPTBIiMj8euvv2aZ/ujRIzx69AihoaHYvXs3Nm/eLJsfHR0NPz8/3L9/Xzb9/PnzOH/+PDZu3Ij9+/fDwsICAPDw4UNUq1YNL1++hL6+PoyNjXH27Fl07twZ//33HwYOHCgt4+7du5g0aRJMTU0xb968j7DVlJ2SJUuiY8eOWLNmDW7cuIFVq1ahV69eRV0sIqIixUAGEdH/169fP+zatQt79+4FkP7kS6NGjVC2bFlcu3YNP/zwg5TW398fwcHBsvxz5szB8OHDpc8KhQJ+fn6oXr06TExM8Pz5c1y8eBFHjx5FUlJSjmVp1KgRGjdujLS0NFy7dg2rV6+GEAKpqakYN27cVxnI8PLyQqdOnbJMNzU1LYLSFJ3Xr1/D2Ni4qIvxxeD+VC+dOnWCl5cXUlJScObMGWzfvh0A8ObNG0yZMgU7duyQ0jZt2hRNmzYtopLmzac4v3htpIJYtGiR9GR3ly5d2OpCzT1+/Bh169aV3aguW7YsWrZsCRsbGzx//hwnTpzAiRMnPnpZ8nJdS0lJQXJyMvT19T96eb4kGhoaqFixIqpXrw5bW1sYGhoiOjoamzZtwuvXrwEAW7ZswenTp1G9enUA6Q89de7cWTo3zM3N0bdvX7x9+xZLlixBUlISLly4gP79+2PLli0AgBUrVuDly5cwMTFBVFQUSpQogU6dOmHLli2YM2eOLJDxzTffICkpCb/88gtKlCjxifcIdenSBWvWrAEALFy4kIEMIiJBRESSR48eCQsLCwFAABA+Pj4iKSlJVKlSRZpmY2Mjnj59KssXFRUltLS0pDSWlpbi5MmTKteRmJgoli5dKuLi4qRp0dHRUl4AYvz48bI8LVu2lObp6uqqXO6WLVtEs2bNhLW1tdDS0hJmZmaidu3aYuHCheLdu3cq81y/fl3069dPlCtXTujp6QkDAwNRoUIFMXjwYBEdHZ0lfVxcnBgxYoSoVKmSMDAwENra2sLGxkZ4e3uLgQMHStscEhIi2x5Vr7xQTh8SEpKnPCkpKWLlypWiQYMGwtLSUmhpaQkrKyvRunVrcejQoSzpnzx5IkaOHCn8/PyEvb29MDIyEtra2sLa2lo0atRIrFmzRqSlpUnp87NtytNWrFghW2/dunVVblvmc+HQoUNi4cKFwsXFRejq6oq6devKlrN9+3bRsmVLUbx4caGtrS3MzMxEw4YNxdatW/O0vzKsWLFCtt7Dhw9nO+/ly5di8ODBonjx4sLAwEDUq1dPnD59Wip/QECAKFasmDAyMhJNmjQRly9flq0r8zYePnxYrF69WlSpUkXo6ekJKysr0atXL/HkyROVZT1z5ozo2rWrcHBwEDo6OsLIyEi4ubmJsWPHZvluCiGEg4OD7Lt14MABUadOHWFsbCzt/7we082bN4ugoCBRuXJlYWVlJbS1tYWhoaGoVKmSGDRokMrvTeZjff36dREQECDMzMyEnp6eqFGjhmx/K4uLixPjx48X3t7ewtTUVOjo6IhSpUqJ5s2bi507d2ZJX1jnw6dy+PDhHL8nrq6u0rwKFSrI5ikft8zfi8zLDA0NFbVr1xYGBgbC1NRU+Pv7i3v37snyJCUlif/973+iSZMmonTp0sLExERoaWkJCwsLUbt2bbFgwQKRnJwsy5OX72uPHj2k+XXq1MmyD3bs2CHN19bWlv02ZKcg18bM34PTp0+Lpk2bCmNjY2FoaCgaNmwoLl68qDLvsmXLpG0qWbKkGDp0qIiPj8+yzA/ZlwVdV4bz58+L7t27i9KlSwtdXV1hZGQkvLy8xOzZs0VSUlKO+3DFihVi9erVwt3dXejp6YmyZcuKX375RQghRHJyspgyZYooXbq00NHREc7OzmLp0qUqy56UlCTmzZsnatWqJczMzIS2trawtbUVgYGB4vz581nSjx8/XiqDg4ODePHihRg6dKgoVaqU0NHREU5OTmLRokVS+sznm6qXqn2TWUpKijAzM5PynDt3LkuazNfFvDp8+LDo0KGDtA0mJiaiVq1a4vfffxepqalZ0k+ZMkW0bt1alCtXTpiZmQktLS1RrFgxUa1aNTFlyhSRkJCQJU9214wjR44IAwMDaV7r1q2l+k9B1iNE+jXV29tb+m3q0aOHePz4cba/4Rlu3bolBgwYICpUqCD09fWFvr6+cHFxEePGjRMvX77M8/7M0KlTJ9l2DxgwQOV36MqVK2LLli2yacnJyWLZsmXCz89PmJubCy0tLWFpaSkaNWok1q5dK6vjCJH1unzz5k0xadIkUb58eaGtrS1tb+Zr8J07d0THjh2FhYWFUCgUst+1R48eidGjRwtXV1dhZGQkdHV1Rfny5cWwYcNEbGysym1+//69WLp0qVSf09bWFlZWVsLHx0fMmDEjSxnyUt988eKFmDRpkvDy8hImJiZCR0dHODg4iN69e4tbt26pLMe9e/dE586dhZmZmTAwMBC1a9cW+/fvz1I3+pjWrVsnW9fGjRuleXv37pXN+/vvv6V5S5culc2LiooSQgjRu3dvAUBUr15dSrto0SLpdyjD2rVrBZD+fyjzeZIfK1asEHXr1hUWFhbSd8/JyUl07NhRLFy4UJa2MOpZp0+fFg0aNBCGhobC2tpaDBgwQLx+/VoIkf5/KaO+aWtrK4YPHy7evn0rW56qa/OQIUNEyZIlhY6OjqhUqZJYuHBhln2SU71EiIJ9D1JSUoSpqam0XFW/JUREXxMGMoiIMtm8ebOs0u/m5ib7vGvXrix5+vfvL0uT35uG2QUyUlNTxbVr14S9vb2sQq0sJSVFdOzYMcc/cdWqVcvyx3nTpk1CT08v2zzGxsYiLCxMSp+UlCQqVKiQ43pGjx4thCi6QEZiYqLw8/PLcb1TpkyR5YmIiMi1rD169JDSf+pAhq+vr+xzxh+j1NRUERQUlGM5+vbtm6f9LET+AhlVq1bNsi49PT2xa9cuWSAw42VhYSELMGTexvr166ssf7ly5cR///0nK+ecOXOEhoZGtttsY2OT5U+e8g3QGjVqCE1NzSznVl6PaYsWLXJMZ2JiIi5dupTtsXZzcxNGRkZZ8uno6IgrV67I8p06dUpYW1tnuy7l86awz4dPJbtARkpKijh58qQwMTHJcu5nyGsgw8fHR+X+KFu2rOwGd1xcXK7nQcOGDUVKSoqUJy/f1/Pnz8um3bhxQ1ZW5ePWrl27PO237M6DnCh/D6pVqyYLvme8zM3NxePHj2X5xowZo3JfeHt7CxsbG+mz8g30guzLgq5LCCEWLFiQ5XudOX/m30Dl+aquaQDEjz/+KPz9/VXOW758uWx5T548kQXeMr+0tLTEqlWrZHmUb5ZZWFgIZ2dnlXkzAieFFcg4c+aMlN7AwEDlDfGCBDJGjx6dY9latGgh3r9/L8tjaGiYYx5XV1fpBmQGVdeMEydOyK6tAQEBsnUVZD2LFy9WmbZ06dKicuXK2X4Ht27dKvT19bNdV9myZcX9+/fztE+FSL/5qVAopPweHh4qg0KqJCQkiDp16uS47S1btpTtq8zX5czXNVWBjPLly2f5vcqoRxw7dkyYm5tnu35ra2tx4cIFWbnj4uKy/V4C/1cXzs/v9/Xr12X16cwvQ0NDWb1XiPTvXPHixbOkVSgUolmzZvn+juTX27dvRVRUlGjdurVsXcoPiCj/BzExMZHdXH/27Jks388//yyEEOKnn36S0v/7778iLS1NdOjQQTo/M/JaW1sLbW3tLPWT/FC+zql62djYyNJ/aD2rcuXKQldXN0u+evXqidmzZ6tcZrdu3bIts5WVlXBxcVGZb+jQobJ8OdVLCvI9yNCoUSMp3cyZMwt2IIiIvhDsWoqIKJMOHTqgS5cuWLduHQDg0qVL0rxevXqhVatWWfIcOnRIem9mZgZ/f/8PKsPEiRMxceJElfNGjx4t+zxlyhRZX7m+vr5o0KABIiMjsWvXLgDAmTNn0K9fP2zcuBFAet/YwcHBePfuHQDAysoKISEhSElJwR9//IH4+Hi8fv0aHTp0wM2bN2FjY4PDhw/jxo0bAAA9PT306tULJUuWxOPHj3H79m0cOXJEKkNG3/VTp07FixcvAPxfd1kFdfXqVcyaNSvLdB8fH/j4+AAAhg4disOHDwMAdHV1ERQUhDJlyuDChQvYtm0bgPTBTb28vKSyaGhooHLlyvD29oaNjQ2KFSuGt2/f4sKFC9i9ezeEEFixYgX69++PatWqfZRty8nx48dRpkwZtGvXDnp6enjz5g0AYPr06Vi/fr20DR06dICLiwtu3bqFdevWITU1FUuXLkXVqlXRt2/fQi3ThQsX0Lt3bxgbG2PBggVISUnB27dv0bp1axgYGGDo0KF48eKF1P/6s2fPsHz5cowZM0bl8g4dOgQ/Pz/Url0bx48fx8GDBwGk9/k9evRo/P777wCAI0eOYPjw4RBCAABKly6Nzp074/nz51ixYgXev3+PJ0+ewN/fHzdu3JAGSFR26tQpGBsbo0uXLrC1tZX6hM7rMTUzM0PTpk1RoUIFmJmZQUdHB0+ePMG2bdvw4MEDxMfHY/To0VIXdZldunQJlpaW6N+/P548eSJ1F/D+/XvMnz8fS5YsAQDEx8ejdevWePr0qZS3UaNGqFGjBl6+fJllMPaiPB8KU48ePdCjR48s0zU0NDBq1KgCLfPEiRNwcXFBmzZtcPToUWmsozt37mD79u0IDAwEkN4dYLly5aQuPczMzJCcnIzr169jy5YtSElJwYEDB7B169ZsBzxV9X319PSEj4+P1OXL77//jhkzZgAA3r17h927d8u2P7/ycm3M7MyZM3BwcEBgYCCuXr0qleH58+f4448/MHbsWABAREQEfv75ZymftbU1QkJC8Pr1a/zxxx94//69yuUXZF8WdF3Hjx/HkCFDpOtCrVq10LBhQ7x8+RKrVq3CixcvEBERgW+++Ub6jmR27tw51KxZEw0bNsSmTZukweUnTZoEAGjevDmqVKmCxYsX47///gMAzJgxAz179pSW0bVrV1y+fBlAerdeXbp0QfHixXHkyBEcPHgQKSkp6N27N6pWrYrKlStnKcOzZ8/w8uVL9OzZExYWFli4cKF0vZ81axb69OkDc3NzzJw5E2fPnpUNyjtz5kzpfXbHPPM+y+Dq6gotrQ//S7h+/XrZ8WvRogVq1KiBf//9F6tWrUJSUhL++usvjB8/HlOnTpXS2dvbw8XFBfb29jAzM4MQQupKJzExEZcvX8aiRYvw3XffZbvuc+fOoVmzZtL4ZIGBgVizZg00NTULvJ6HDx9i6NChUn5DQ0P07t0bGhoaWL58OaKjo1WW5e7du+jSpYs0uLKbmxvatm2L9+/fY82aNfj3339x584dBAYGyo5DTg4fPiyd3wAQEhICDQ2NPOUdPHiwbHy3Zs2awdvbG//884/0O7Jnzx78+OOPmD59usplHD9+HG5ubmjRogXS0tJUdlt369YtKBQKdOjQAa6urrh37x4MDQ3x6tUr+Pv7SwOQlylTBh07doS2tjY2b96MGzdu4OnTp2jXrh2ioqKk3+1u3brh3Llz0vIrV66MZs2aQUtLC2fPnsWdO3cA5L2+mZqaCn9/f8TExAAAbGxs0KVLF5iammLPnj2IiIhAYmIiOnbsiFu3bsHKygoAMGjQIDx+/FhaTqtWreDp6YnQ0FCEhobm6RgUxIQJE7L9HzBy5EhpfChA/j+ldOnSsm7izM3NYWpqilevXsnS9ujRA7/88gtevnyJcuXKwcTEBE+ePAEADBs2DAAwatQoPH36FD/88IPKa1Ze/fbbb9L7Bg0awM/PD4mJiXjw4AGOHTuWpbvdD61nXb16FQ4ODujSpQtOnz4t1SnDw8MRHh4OV1dXtG3bFrt370ZkZCQAYN26dZg+fTpsbW2zLC8uLg7x8fHo378/ihUrhrVr1+Lhw4cAgLlz56Jdu3aoXbt2jvugoN+DDJ6enti/fz+A9O/jyJEjc1wfEdEXrSijKERE6urFixeiRIkSsidlSpUqJeLj41WmV+7KoFq1arJ52T1B2b59+1zTZH7169dP9qRVSkqK7OmeWrVqyZ7S69mzp+zpsQcPHgghhPj222+l6RoaGuLatWtSnn/++Ue2zsmTJwshhNi2bZs0rUmTJln2wdu3b8XDhw9l03LrCiQ3edknGct99uyZ7Inc9evXy5bVuXNnaV6jRo2yrOv+/fvizz//FL/++quYNWuWmDlzpihZsqSU56effsr3timXs6AtMsqXLy9evXoly5uamipr+TB16lTZfOWnmsuXL5/DHv4/+WmRkXFOCCHfrwDEhg0bpHne3t7SdOUnzTNvY+PGjaXzOi0tTTRu3Fiap6urKxITE4UQQrRp00aabmxsLOuCZ/Xq1bJlrl27VpqnfKy0tLSyPMmnKl1O5+v79+/FP//8I5YvXy7mzJkjZs6cKes+SFdXV/Z0q/Kx1tDQkHXf07ZtW2lelSpVpOnz5s2Tbc/06dOzlOPu3btCiI9zPnwqmZ/8ze6VeZuEyHuLDAcHB6nbmPfv38ueGh4+fHiW5T558kTs3LlTLFq0SLoWKD+N2bNnTyltXr6vQgixfv16KY21tbV0fmzfvl2aXrx48Wy7W8osP9fGDMrnt5GRkawbC09PT5Xf1b59+8rOXeWncjNfF1R9Z/KzLwu6LuUWE02aNJH9Ru7bt0+ap/wbmHkfVqpUSTomynkAiKZNm0p5Fi5cKJuXUSe4ePGibPqJEyekPGlpaaJmzZrSvD59+kjzMj+p/Ouvv0rz5s6dq3JdqvZHfo0cOVLK26pVK5Vp8tsiQ/kcytz6S7llg5GRUZbuLl++fCn27t0rFi9eLGbPni1mzpwpa0VQv359WXrlcg0bNkxWDwoJCcm2tUJ+1jN16lTZekJDQ6V5ma9byr/hw4YNk6a7urrKtvX69euyfMePH891vwohxIwZM7ItS07+++8/Wb0oMDBQmpeWliYaNGggzTM0NJS618m8fbVr11bZRWnmc0S5G7QMyr9l1tbWspZRL168kLUMXrdunRAi6/epVatWWa6Nd+7ckX3O7fd7586d0nwdHR1Z14Lv3r2TtdTIaLmbuSVM165dpTzv37+XtcopyPcwJ6paMWhpaYkZM2Zk6c5IubV07dq1syyrVKlSsmtkhps3b4r27duLEiVKSF3xZdThjhw5IhQKhShfvrxISkoSL1++FAsXLhQDBw4UI0eOFHv37s3ztii3rFTVfVLmYynEh9WztLS0pO6nEhISZN8BKysr6Vp69epV2f5VbnGfef9nnJtCpP/ua2trS/OUW3NkVy8pyPdA2axZs6T53t7eedjrRERfLrbIICJS4eHDh9JTMxni4uIQExOT61NJhTFgpvJg33fv3sXq1auRlJSEJUuW4P379/jjjz8AADdu3JCVMygoSPaUXkhIiJRWCIGTJ0+iQ4cOssEgvby8ULFiRelz7dq1Ubp0aelpw4y03t7e0NXVxbt37xAWFobKlSvDzc0NTk5O8PT0RIMGDVCyZMkP3vaCOn36NFJTU6XPQUFBCAoKUplWefufPXuGkJAQ/PXXXzkuP+Ppq09twIABMDExkU27ceMGnj17Jn3+3//+h//9738q89+6dQv//fcfLC0tC61MXbp0kd47OjpK77W1tREQECB9dnJyQkREBABIT0qq0rVrV+l7o1Ao0KVLF/z9998A0p9Yv3LlCqpVqyY7bs2aNZNtU1BQEHr16oXk5GQA6cdYuZwZWrRoAVdX1/xsrsy6deswdOhQ6alsVd69e4f//vtP5aCYNWvWhJubm/S5QoUK0nvlfaT8pK6xsbHKp+9Kly4NoPDPh/j4eCxdujTb+XnVqVMn2NnZ5TuPl5cXUlNTceXKFWzcuBEpKSn43//+h+TkZIwbNy7f5ejatSsMDQ0BpJ+jpUuXllq6KO/zpKQkDBgwAKtXr5YGQVYlp2uBqu8rAAQEBGDEiBGIjY3F06dPsWvXLrRv314aeBVIfwK5MJ6Mz4s2bdqgePHi0mcnJydcuHABgHyfKD8RnbklQdeuXdGnTx+kpKRkWX5B9mVB16X8XQkLC8v2SXUhBE6dOiW7RmXo0KEDtLW1AcivaUD6E98ZnJycZPNevHgBY2PjLE/W59QqIrvBmDU1NWWDuCpfG5TXVRhevnwpvVd1vubXmzdvpCebAWDp0qXZXkMSEhJw6dIleHl5IS0tDWPGjMG8efOybXED5PydmzNnjvS+T58+WLJkSZZ6WEHWo3w+WllZoWnTptLnevXqwdHREffu3cuyDOVz4fLlyypbBmY4ceKE1FpL1XmR0apKKLXGyI/M9aJu3bpJ7xUKBYKDg6Wn1RMTE3Hp0iV4e3tnWc7w4cOho6OT47oyBpjOTHl/PH36FMWKFct2GSdOnEBQUFCW79OPP/6Y5dpYpkyZHMuTUznev3+f5XueuRxA+jmgvO+V6xTa2tro2LEjxo8fn69y5FXjxo1hZGSE169f49q1a9i1axfev3+P7777DsePH8eWLVuka5ZyGVWdK8rTlL8b5cuXx59//pkl/fv379GvXz8IIbBkyRLExsaiTp06su/HrFmz0LVrV6lVaU5q164t1bFdXFxQvXp1lC9fHpUrV4afnx/KlSsnS/+h9SxfX1/p+BoaGsLKykpqVdOiRQvpOqrqeq6KtrY2OnXqJH12dHRErVq1pBbgZ8+ezWnzARTse6BM+TqtfP0mIvoaMZBBRJRJcnIyunXrJnW7lOHdu3cIDg7GqVOnpD8PGUqWLIlbt24BSL9RKISQ/ixkdAUBQNb0PSc+Pj6yG5c1atSQuhxZsWIF+vXrh+rVq2dZlrW1teyzjY2N7HNGeuV8mfNk5MsIZGSkLVWqFFauXInBgwfjv//+w7Vr13Dt2jUpj5GREX7//XdZZb8whYSEYOXKldnOzxx4ykliYiKSkpKgr6+PXr165RrEAJDlfMivzH8u87q8zH+0gPxtK5AehCvMQIZywEr5Jo21tbXsZoPy+5xuZhbGeaupqQkLCwvpz2p23zNV+zOvzp8/j+Dg4By3JUN2x9fBwUH2WXn/KS9X+Rjb2dnJukjJrLDPh+fPnxe4GydlXl5e+Q5kNG3aFN27d5c+ly1bVupeY9KkSVKXdvmR130+duzYHK8xGXL67mZ3fmlra6Nv377Stvz+++9o0aKFrFsp5e3Oj9yujarkdZ8o3zBRDnwA6d9vS0tLWbcrGQqyLwu6rvyc/3FxcSqnZ3dNyzwv883UjH1VGGWwsbGBnp5etuXIy3Unr5RvosXHx3/w8l68eJGvm+0Z+2D+/PmybrGyk9ffy8zd6mQoyHpyOh8zpqkKZBTkXPj7779VdiM0fvx4+Pj4oFSpUrLp169flwVWslPQOmJmefndLFu2rMrfqYLsj8x5cgo65FVBypH5hnFu+68wZe4a8OjRo6hTpw4AYOfOnVi0aBG+/fZbAICFhYWU7vXr11mWpfwdNzc3z3Xd06ZNw/Xr19G9e3f4+fmhffv2ePjwIdzd3REWFobIyEg0a9YMa9euRadOndCyZcscl/fbb7+hY8eOOHXqFJ49e5alS6iOHTtiw4YN0NDQKJR6VuY6gvK1NC/X88wsLCyynNvKxz4v/+s+9DdC+RjmFAQhIvoaMJBBRJTJ+PHjZU8WDhgwAIsWLQKQfiPzp59+kvrNztCgQQMpkPH8+XPs2rULbdq0AZD+FE1GUOLXX3/NU4U3s2rVqsk+nzx5EtWrV4eZmZlsunJ/+gCk/m4zZKRXzpc5T+Z8ymk7d+6M9u3b48yZM7h8+TJu3bqFw4cP48KFC0hISECvXr3QsmVL6ennTynzvhg1apTKIE0GLS0tJCYmYs+ePdK0zp07Y+bMmbC1tYWGhgaqVasmtSgoCIVCId3cUe4DOKOlTV4YGBhkmZZ5W3v37p3l6V1lOe2HgsgcyMtQ0KfJcztvM/60mZmZSX/wMudJTU2VtUrIvI8yqNqfebVlyxbpj66hoSH+/PNP1K1bF/r6+ti7dy9atGiR6zIy77vsWnAp32x48OABUlNTsw1mFPX58DEpX/tSUlIQERGR70BGXve58pgDfn5+WLp0KUqXLg1NTU107NhR1noiOzmdX/369cPUqVORnJyMv//+G0uXLpVuOlWvXh2VKlXKy+YUirzuE+UbJpm/cykpKdk+MVuQfVnQdSlfF/z8/NC8eXOV6YD0FlGqZHdNA/J2Xcv8HZw6dWq2y8zuHMnrMSkMyv3AZxdYyY/MN9batWuX7b4G/q+1ifJ54uLigvXr18PZ2Rna2tr47rvv8hR8cHZ2xvXr1wGkt0YrVqwYvvnmG1magqwnp/MRgMqgGiA/F9zd3dG1a9dsy66q9YMq9erVk9UnVq9ejSFDhuQ6TkZB64iZ5eV3M7s0ysu0t7fH4MGDs11GxnmR+Wb7vXv3pDErCkq5HEZGRjm2pMgIXGU+r3Pbfx9T7dq1YWZmJv2HCA8PlwIZbm5uOHnyJAAgOjpa9jBVXFycLLih3CJUlRs3bmDatGmwsrKSxl7KaLUTEhICGxsbNGnSBK6urrh06RIOHjyYayDDzs4OJ0+exO3bt3HmzBncunULly5dwq5du5CSkoLNmzejWbNm6N69+0epZykrSD312bNnWepgysc+L4GFgnwPlCmfe0XZ+p2ISB0wkEFEpOTkyZPSIKxAejcFCxcuREJCAlavXg0g/Umlli1bonr16lK6QYMGYdmyZVIT/v79+8Pe3h6enp6FUq7MN9Mz1lOhQgWYm5tLT/qsX78e/fr1k/7cZgy2DKTfFKlRowaA9Ce9MpZ59uxZREVFSd1LHT16VDaIZcYTYc+fP8fr16/h4OAAX19f+Pr6Akh/EinjT2diYiKuX7+OqlWrApD/mcgYtPRjqV69OjQ1NaV9o6+vr7I7nmvXruH58+fQ1tZGXFycrNuFDh06SE8+RkVF4eLFi9muLy/bVqxYMelP5+nTpzFgwAAAwMqVK1XeGMkrZ2dnWFhYSDfu3717p3JbY2JiEBUVJXtaTx2tXbtW6l5KCIF169ZJ83R0dKSuoHx8fLBz504AwL59+2RdJK1fv17qViojbX7ldkyVAyVlypSRPRG7cePGfK8vJ76+vti8eTOA9Ccs58yZk+UY379/Hw4ODoV+Pjg6Oha4K5PClt2172NQPr4tW7aUurt4+vSp1IXEhyhRogTat2+PjRs3Ii0tDaNHj5bmFWSQ70/B29tb6mLn7NmzuH37trRf1q5dq7KrJ6Bg+7Kg61K+Ljx+/BjffPNNlmB6fHw8QkND4eHhkZfNzrfM15vixYurPKZnzpzJsauhvMp8o+7Nmzf5CtIqBxkuX76cY6A0LwwNDeHu7i79Zr548QLDhg3Lssy4uDgcP35c6hZI+Tzx8/OTrvVJSUnYtWtXntb93XffITw8XKqjDRw4ECYmJrJugAqyHm9vb2zduhVA+k3L8PBw1KtXDwBw5MgRla0xAHn9KjY2Fl27ds3SouPt27fYsmUL6tatCyB9YOcJEyZku422trYICAiQAoAXLlzA0KFDMWfOnCz7+OrVq4iKikJAQACqVasmqxetWbMGzZo1A5DeSlS5WyBDQ8Ncb3IXhI+Pj1TuJ0+eoEWLFrLuTIH0QOWePXtQq1YtAJDqlxmmTJmCP//8U3YTOuP3L0Nuv9/K39GEhARUqVIF9evXl6URQuDQoUPS+VmlShVZAGndunXS735ycrL0G63KypUrZdeAvP6mbtu2DS1atMhynTh58qTsQSjlQGerVq2wZMkSAOnXur///htNmjQBgCxlbNWqVY7r79evH969e4dffvlFqitkPIij3L1YxvvMA3WrcvHiRbi6uqJcuXKybqTatGkjff/OnTuH7t27f9J6Vl4lJydj06ZNUndP9+7dw7Fjx6T5Xl5euS6jIN8DZefPn5feZ/5+EBF9bRjIICL6/xITExEcHCz94StdujR++eUXAMCCBQsQHh6OmJgYpKamIjg4GBcuXJBuHFSuXBmTJk2S+qV//PgxvL290bRpU1StWhW6urq4f/9+np/eOnHiBGbNmgUhhDRGhrKMP2SampoYMmSI9Af42LFjqFOnDho2bIjIyEjp5g6Q3kd7RjcvAwYMwG+//Yb3798jLS0NdevWRUhICFJSUqQxNYD0vvl79+4NALh58yZq1qwJb29vuLu7w9bWFlpaWti3b5+sbMpPJpUsWRK3b98GkP6nTk9PDyYmJihbtiz8/f3ztC/yysLCAt27d8fy5csBAD/99BNOnTqFGjVqQFtbGzExMTh+/DiuXbuG8ePHo1atWrC2tkaxYsWk7gO+/fZbqXXJypUrc+xLOy/b5uXlhf379wNIf4Ly8ePH0NbWRmho6Adtq4aGBoYOHYoff/wRQPrNiVu3bqF+/fowNDTEo0ePcOrUKamJfsYfWnX1999/o0GDBqhTpw6OHTsmPf0HpPdJnfE9Gzp0qHROx8fHo1q1aujcuTNevHghO2/t7OzQvn37fJcjt2Oq/JTc5cuX0alTJ7i4uCA8PByHDh0q0LZnp3v37pgyZYoU8Bo1ahT279+PGjVqICEhAUePHkWlSpWwcuXKL+p8yAhQpaam4tq1a1i/fr00T1NTUxZALmwVKlTAlStXAACTJ0/GkydPoFAosGbNmhz76s6PwYMHSzdj3r59CyA96Ko8DkN+Xb16VXpyVtX6PuTGea9evbBkyRIIIZCamoq6deuiW7duiI+Pl661qhRkXxZ0XSNGjMCuXbsghEBUVBRcXFzQrl07WFpa4vnz54iMjMTRo0dRvHjxj9b1oYeHBxo0aCBdu/r06YPdu3dLgZPo6GgcOXIE0dHRWLFiBdzd3T9ofZmfyA0KCoKPjw80NDTQrVu3XLu88fLygqmpKV69eoXExERcvnw51yBPdjfrRowYgcDAQIwcOVIag+Hw4cNwd3dHy5YtYWpqiqdPn+Ls2bM4efIkatWqhbZt2wJIP08yWrMuW7YMCoUCJiYm2LJlC27cuJGHPZF+Q3f58uWIi4tDaGgohBDo3r07jI2N0bp16wKvp2vXrpgwYYL0PW3bti169uwJADmej4MHD8bixYvx7t07PH36FO7u7ujYsSNsbW0RHx+Py5cv48iRI0hISJCNWZGbuXPn4tSpU3jw4AGA9HppaGgoWrVqBWtrazx79kwaa+Pbb79FQEAALC0t0a1bN6mbtw0bNuDly5eoVq0ajhw5gvDwcGn5AwYMKJQgW2bdu3fH5MmT8ezZM7x79w41atRAx44dUbp0aSQlJeHatWsIDw/H8+fPER0dDTMzM7i5uaFJkyYICwsDkN6VUpUqVdCsWTNoa2vj4sWLuHbtGu7cuSOtJ7ff75YtW6JChQrS8W7RogXat28PZ2dnpKSk4ObNmwgPD0dsbCwOHz6M0qVLw9bWFs2aNZO6Qlq7di3i4+Ph4eGB0NBQXL16tdD3V8+ePaGpqYlmzZrByckJCoUC169fx/bt22XplFtBNGvWDFWrVpUCwUFBQejXrx+SkpKwePFiKZ2/v3+OLf/++OMPHDlyBI0aNZK1JKpcuTIuXLiAHTt2oH///oiOjpaClrmNGwikj3316tUr+Pn5oWTJkjA3N8edO3dkXUxl/Hf4lPWs/OjZsyeOHj2KYsWKYe3atbIHZ/r06ZNr/oJ8DzKkpqbKHupo0KBB4W4cEdHn5pMNK05EpOb69esnAAgAQkNDQ/zzzz+y+YcPHxYKhUJKM2jQoCzLmD9/vtDT05PS5PTq27evlC86OjpPeQCIHj16yNaZnJws2rVrl2OeqlWriufPn8vybdiwQejq6mabx9DQUOzdu1dKf/LkyVzL1q5dO9k65s2bpzJdixYt8nRMlPOEhITkmj4hIUH4+fnlWs7x48dLeaZPn64yjYuLi6hatWq268/Ltu3bt092zmS8HBwcRIUKFVQuO/O5cPjwYZXbmpKSIgIDA3Pd1rzsNyGEWLFiRbbrzTxP2fjx42XbpSwkJESaV7du3Wy3sUWLFirLXqZMGREXFydb5qxZs4SGhka222tlZSXOnj0ry+Pg4KDy2GeW2zF99uyZsLW1zXY/K3+Ojo6Wllu3bt1sj0dO++/UqVPC2to6T8e2sM+HT+Xw4cO5ljnjNXHiRFne7M4vIeTXjhUrVsjmZXc8NmzYoHK9JUqUEI0aNcrTuZzd91VZlSpVZHmCgoLyuddEnvfZixcvpDw5fQ9y2pdjxoxRuewqVaoIGxsblcenIPuyoOsSIv23V1NTM8d9kfn7ld05ktMxzXy+Kn/PHz9+LFxdXXM9Jsrryun7n9O63r59K0qUKKFy+RERESIvBg8eLOX54YcfsszPfE3L7jVnzhwpz6hRo3JNr3zMjx49KrS0tLKkMTIyktVr8nLsEhISRPXq1aXpurq64uDBgx+0nt9++y3bc6lixYrS58z1sj///FPo6+vnui/y6+7du6JatWq5Lvfbb7+V8sTHxwtfX98c0zdr1ky8e/dOypPTuacsp+uGsqNHjwpzc/Ncy628nri4OFkdLLfvc17qZFFRUcLe3j7Xcih/5+/evZvt77Dyb0nm45lTvSknpqamuZavW7duIi0tTZbv1q1bws7OLts87u7uWepTyp4+fSrMzc2Fvr6+uH37tmze5s2bpeVYWlpK/x1Kliwp+43JjnJ9V9XL3NxcOvYfo56V02+fqmuJEPJrs42NTbbn4uDBg2XLy+k7UZDvgRBChIaGSvM8PT1z3d9ERF+6nDvWJCL6Suzbt09qlg0Aw4cPR+3atWVp6tWrh2HDhkmfFy5ciAMHDsjSDB48GNHR0fjpp59Qp04dWFtbQ1tbG/r6+rCzs0PDhg0xbtw4REREyNaXE21tbdja2qJFixbYuHFjlicBtbS08Oeff2Ljxo1o0qQJLC0toaWlhWLFisHX1xfz58/H8ePHs/R93LlzZ1y4cAF9+vRB2bJloaenBz09PTg5OWHgwIG4dOmS1AUBkP6U1OzZs9GuXTs4OTnB1NQUmpqaMDMzg6+vL+bNm5el2ffAgQMxYcIElClTpsDjJ+SHoaEhDhw4gNWrV6Nx48awsrKCtrY2LC0t4e7uju7du2P79u2yLl1Gjx6NhQsXwsnJCdra2ihevDj69OmDI0eOwMjIKNt15WXbmjRpgi1btsDd3R06OjqwtrZGnz59cObMGZWDh+aHpqYm1q9fj507d6JNmzawtbWFtrY2zMzM4OLigk6dOmHdunWYN2/eB63nUxg5ciQ2bNiAqlWrQk9PD5aWlujZsydOnDiRZVDqESNG4MSJEwgKCoKdnR10dHRgYGAAV1dXjB49GpcvX5a6Nsuv3I6pubk5jh07hnbt2sHExAT6+vrw9vbGtm3bCjxQc06qV6+OK1euYNy4cahatSpMTEykc7RJkyayVk1f0vmQQVdXFw4ODggICMC+ffswbty4j7q+zp07Y/PmzXB3d4e2tjYsLCzQqVMnnDp1SjamwIcaNGiQ7HPGU97qatq0aVi6dCkqV64MHR0dlChRAoMGDcLBgwdlfa8rt8Yr6L4syLqA9N/es2fPolevXihXrhz09PRgaGiI8uXLo2nTppg3bx7++eefQtsnqtjY2ODMmTNYsGAB6tatC3Nzc2hpaaF48eKoWrUqvvnmG4SFhcm6PCooXV1d7N27F40aNYKJiUmBljFw4ECpG8p169YVSndyM2bMwJEjR9C5c2fY29tDV1cXJiYmcHZ2Rps2bbBs2TJZVze1atVCWFgYfHx8oKurC1NTUzRv3hwnTpyQun/KK0NDQ/z111/SE93v3r1DmzZtcPr06QKvp3///ti2bRu8vLygq6srtXA4efKkbGDgzOdj+/btcfnyZQwZMgSVKlWCoaEh9PT0UKZMGfj5+UmDKedX6dKlcfLkSezYsQNBQUEoW7YsDA0Noa+vj7Jly6Jp06ZYsmSJ7FppbGyM8PBwLFmyBHXr1oWZmRm0tLRgYWGBBg0aYNWqVdizZ4+s26DCVqtWLVy9ehVjx46Fp6cnjI2NoaOjA3t7e/j6+uLHH3/EuXPnZIN6W1pa4sSJE1iyZAnq168PCwsLaGlpwdzcHNWrV5e66syQlzqZs7MzLl26hKlTp6J69eowNTWFtrY2SpYsierVq2PEiBGyQbWB9H1+6tQpdOzYEcWKFYO+vj5q1qyJ3bt35/i7r9x9aOZx7nIyc+ZMdO7cGRUqVICZmRk0NTVhaGgIZ2dnBAcHY//+/Vi9enWWMXTKlSuHixcvYuzYsahYsSL09fVhaGgIT09PTJs2DSdPnsxSn1I2bNgwPH/+HOPGjUPZsmVl8zp06IDNmzfD09MT8fHx0NPTQ7t27aQWCrmZNm0a+vfvj6pVq6J48eLQ1taGgYEBnJ2dMWDAANmx/9T1rLzQ09PD4cOHMWzYMJQsWRI6OjpwdnbGggUL8lWnKsj3AICsu9WBAwcW1mYREX22FKIwaq1EREREeXTv3j2ULl1a+nz48GGp73GiL93Jkyel7gHt7e1x7969jzqw84dKSkqCvr5+lul79uyR9bd+/PjxAo1NU1TrovQg2ooVKwAAf/75Z4G65PuSZXc+RkZGwsvLS+qKdN26dVL/+UQA0Lx5c4SGhkJDQwNnzpwp8AMWVDQmTJiAiRMnAgAcHByyHRPnY3v48CHKli2L9+/fS102fooHw4iI1BmvgkREREREH9Hbt29x6tQpvHjxApMmTZKmDxgwQK2DGADwv//9D5GRkWjVqhVKly6NlJQURERE4LfffpPSeHl5yQaQ/hzWRemDKG/ZsgUJCQmYPHky2rVrp/bn46e0dOlSrFmzBgEBAShbtiw0NTVx+fJl/Prrr1IQo1SpUoU+5hd93lJTU3H8+HEAQN++fRnEoAKbMWOGNF7frFmzGMQgIgIDGUREREREH9Xjx4/h5+cnm1auXLks3UypIyEEwsPDZQMDKytXrhy2bNlSKDfAP+W6CChRooSsyy6SE0Lg3Llz0iDKmdnY2GDnzp0qW23Q1+vChQuIj4+HpaUlpk6dWtTFoc/Y/PnzMX/+/KIuBhGRWmEgg4iIiIjoE7GyskLDhg3x888/w9DQsKiLk6u2bdviyZMnOH36NOLi4vD27VsUK1YMLi4u8Pf3R+/evWFgYPDZrYsoN/Xq1UP37t1x4sQJPHnyBAkJCdKYHy1atMA333wDc3Pzoi4mqRkvL69CGXOGiIiIsuIYGUREREREREREREREpLY0iroARERERERERERERERE2WEgg4iIiIiIiIiIiIiI1BYDGUREREREREREREREpLYYyCAiIiIiIiIiIiIiIrXFQAYREREREREREREREaktBjKIiIiIiIiIiIiIiEhtMZBBRERERERERERERERqi4EMIiIiIiIiIiIiIiJSWwxkEBERERERERERERGR2mIgg4iIiIiIiIiIiIiI1BYDGUREREREREREREREpLYYyCAiIiIiIiIiIiIiIrXFQAYREREREREREREREaktBjKIiIiIiIiIiIiIiEhtMZBBRERERERERERERERqi4EMIiIiIiIiIiIiIiJSWwxkEBERERERERERERGR2mIgg4iIiIiIiIiIiIiI1BYDGUREREREREREREREpLYYyCAiIiIiIiIiIiIiIrXFQAYREREREREREREREaktBjKIiIiIiIiIiIiIiEhtMZBBRERERERERERERERqi4EMIiIiIiIiIiIiIiJSWwxkEBERERERERERERGR2mIgg4iIiIiIiIiIiIiI1BYDGUREREREREREREREpLYYyCAiIiIiIiIiIiIiIrXFQAYREREREREREREREaktBjKIiIiIiIiIiIiIiEhtMZBBRERERERERERERERqi4EMIiIiIiIiIiIiIiJSWwxkEBERERERERERERGR2mIgg4iIiIiIiIiIiIiI1BYDGUREREREREREREREpLYYyCAiIiIiIiIiIiIiIrXFQAYREREREREREREREaktBjKIiIjU3N69e+Hj4wMzMzMoFAooFArMnTsX4eHh0mdHR8eiLma+/f7771L59+/fX9TFoTyoV6+edMxWrlz5ydarfK4cOnTok62XiIiIVPtS66ddu3aFQqGAsbExnj9/XtTF+eKsXLlSOj/q1av3ydb74sULmJiYQKFQIDg4+JOtl4gKFwMZRERE/19aWhp27tyJjh07wtHREQYGBjA1NUXlypUREhKCPXv2QAjxSct04cIFtG7dGidPnsTLly8/6bpVadKkifTnQ6FQoFWrVgVaTmJiIsaNGwcA8Pb2RqNGjbKkUcfj8aWbMGGC9FKH8y1DcHAwSpUqBQAYOXIkjzsREX011LE+pA71U0dHR1mdVKFQQEtLCxYWFqhRowamTp2KxMTEfC3z3LlzWL9+PQDgm2++gbm5ucp006ZNk63X0tIS79+//+Btoo/HzMwM/fv3BwCsXbsWFy5cKOISEVFBKAT/CRIREeHJkyfo2LEj/vnnnxzTvXjxAsWKFfs0hQIwfvx4/PTTTwDSb/hPmzYNurq6KFOmDAwNDXH58mUAgJ6eHry8vD5qWf7991/Y29sjLS1NmqalpYWHDx/CxsYmX8uaM2cOhg8fDgBYtWpVliej1PV4fOkUCoX0Pjo6OsuTlJcvX8arV68AAE5OTrC2tv5kZZs0aZIU/NqxYwfatGnzydZNRERUFNS1PqQO9VNHR0fcv38/xzQ1a9bE0aNHoampmadltmnTBrt27YJCoUB0dDQcHBxUpnN2dsaNGzdk0/7880+0b98+b4X/ij19+hQ3b94EAJiamsLV1fWTrTsmJgaOjo4QQqBt27bYvn37J1s3ERUOraIuABERUVFLSkpCkyZNcPHiRQCAhoYGunfvjpYtW8LU1BQPHjxAaGgotm3b9snL9uDBA+l9s2bN0KBBA9n8WrVqfbKyrF69WhbEAICUlBSsXbsWI0aMyPNyhBBYvHgxAEBfXx/+/v6y+ep8PIpCcnIyhBDQ0dEp6qJ80j+bmQUGBkqBjMWLFzOQQUREXzR1rg+pU/0UAHr06IGePXvi/fv3WLduHf744w8AwMmTJ3H8+HHUqVMn12U8ePAAf/31FwDAx8cn2yDGyZMnswQxgPQuk9QxkJGWloZ3795BX1+/qIsCALC2tv6kD8Ios7e3h4+PD44fP449e/bg33//RcmSJYukLERUQIKIiOgrN23aNAFAem3YsEFluhs3boh3795Jn9PS0sSaNWtE/fr1hbm5udDW1hZWVlaiefPmYvfu3VnyOzg4SOvYv3+/mDFjhihfvrzQ0dERjo6OYubMmVLaw4cPy8qU+RUdHS1L4+DgIFtXUlKSGDt2rChVqpTQ1dUVbm5uYtWqVWLFihVSnrp16+ZrP1WoUEHK26NHD+m9i4tLvpZz9uxZKW+TJk2yzFfH45Fh/fr1om7dusLc3FxoamoKMzMzUbFiRREUFCT27t0rS5uSkiIWL14satWqJYoVKya0tbWFvb296N27t7h7964sbXR0tGybY2NjRUhIiLCyshIKhUJMnz5dmle2bNks5frmm2+k+cOHDxdCCBERESG6du0qXF1dhZWVldDW1haGhoaicuXKYsSIESIuLk7KHxISkuP5tmLFCiGEEHXr1s0yrXPnztK0SZMmycr17t07UaxYMWn+xYsXpXnXrl0TvXr1EqVLlxa6urrC2NhY+Pj4iBUrVoi0tDRVh1w4OTkJAEJDQ0M8e/ZMZRoiIqIvgTrWh9Spfqpc7vHjx0vTX79+naf9ltmsWbOkPNOmTcs2Xd++faV03bp1E5qamgKA0NLSEo8fP1aZZ/fu3cLLy0vo6uqK4sWLi0GDBomXL19m2XfK/vjjD1G5cmWho6Mj7O3txQ8//CCuX78uy6NMefrFixfFkCFDhK2trdDQ0BDbt2+X0oWFhYnWrVsLGxsboa2tLSwtLUWrVq3EP//8k6XcZ86cEf7+/qJEiRJCW1tbGBkZCUdHR9GqVSsxf/58Wdq81pFVHet9+/blu54rhBCJiYni559/Ft7e3sLY2Fjo6OiIcuXKiWHDhomnT5+qPBZTp06VljV37lyVaYhIfTGQQUREXz3lG/QNGjTIU57U1FQREBCQ45+5YcOGyfIo/+EqX768yjzr1q0TQnzYH8W0tDTRtGlTlfmqVq1aoEDGiRMnpHyWlpbi9evXshvUZ8+ezfOylP8ojhs3Lst8dTweQgixcuXKHJffr18/Ke2bN2+En59ftmmLFSsmTp8+LaXPHMjIXJ5z584Je3t76fOpU6ekvMnJycLS0lKad+XKFSGEEL/99luO5S1durR48eKFEOLDAhkHDhyQpjk7O8v28fbt26V53t7esul6enrZrq9Lly4qgxndunWT0ij/KSciIvrSqGN9SJ3qp6oCGe/fvxfLli2TLfvq1at5Wl7Lli2lPIcOHVKZJikpSVb/jYyMlG3TrFmzsuRZt26dUCgUOW5zxr7LoHyzPac8ynKqR2bUmUaPHp3tsdPQ0BC//fabtLzr168LXV3dbNNXqFBBSpufOrKqQEZqamq+67lxcXHCxcUl23WWLFkyy4NDQghx8OBBKU2bNm1UnwxEpLY42DcREX3VEhMTZc3DVQ06rcqiRYvw559/AkgfJ2L8+PEIDQ3Ft99+K6WZM2cO9uzZozL/3bt3MX78eOzZs0fW3H3+/PkAAE9PTxw9ehTNmjWT5vXo0QNHjx7F0aNHUaJEiWzLtn79euzbt0/6/O2332Lv3r0YOXIkzp8/n6fty2zlypXS+06dOsHIyAgBAQEq5+cmo99kIH2cBWXqejwAYMuWLdL78ePH4+DBg9ixYwfmz5+PNm3awNjYWJo/YcIEHD58GABQunRprFixAmFhYejXrx8A4OXLlwgMDERycrLK8sTExOCnn35CWFgYli5dCmtra/To0UOav27dOul9WFgY/vvvPwBAjRo1ULlyZQCAm5sbZs2ahW3btmH//v0IDw/H9u3b0aRJEwDpY2D8/vvvAIDvv/8eR48elZVhy5Yt0vnWvHlzleUEgPr166N06dIAgOvXr8vOMeVy9urVCwAQFxeHbt264e3btwCA/v37Y9++fVi9ejXs7e2lfCtWrMiyrgoVKkjvL126lG2ZiIiIPmfqWh9St/pphokTJ0KhUEBHRwd9+vQBAGhra2P69OmoVKlSnpaRU/00w/bt26XBzStXrgx3d3d07dpVmp+5PpyQkICBAwdKg7F7eXlh27ZtWLlyJR49eqRyHffv35e60gSAJk2aYNeuXfj1119x69atPG3LnTt3MGLECISGhmLNmjUoW7YsQkND8fPPPwNI79p1xowZ2L9/P2bNmgVdXV2kpaVh8ODB0vgVu3fvxrt37wAAAQEB2LdvH0JDQ/H777+jZ8+esi6Z8lNHVkVDQyPf9dyBAwfiypUrAAAPDw9s3LgRoaGhaNeuHYD0sf1CQkKyrIt1SaLPXFFHUoiIiIrSw4cPZU/vLFu2LE/5qlSpIuX55ptvZPOaN28uzWvfvr00XfnJsYEDB0rTT548KU03NzeXLUv5SXnlZvNCiGyfeGvVqpU0vWnTprI8/v7++X7iLfPTZydPnhRCCBEeHi5Ns7CwkHVrkBPl/RMaGiqbp87HIygoSJq+adOmbJusp6WlCSsrKyntL7/8Io4ePSq9SpQoIc3bt2+fECJri4zMzfWFEOLevXtCQ0NDABDW1tYiOTlZCCFEYGCgyv2VnJwsFixYIGrVqiU181deBwDRrl072TqU52Xu4kAI1S0yhBDip59+kqZnNPl/9eqV1OrCwMBAvHr1SgghxIIFC6S0Li4usn3z/fffS/Nq1KiRZf2LFi2S5g8YMEDl/iciIvrcqXN9SAj1qJ8ql1vVy8jISHz//fciNTU1T8szMDCQ8iYlJalM07hxYylNRvdTiYmJwsjISJqu3Ep569at0nQtLS3x4MEDad7OnTtV1rtmz54tq18nJiZKeebNmyfLo0x5unL3Sxnat28vze/WrZus/qV8bowZM0YIIcTSpUulaaNGjRL37t3Ldl/mtY4shOoWGULkr5774sULWb12/fr10rYcPnxYaGtrS/OuX78uW/+bN2+keQYGBtmWk4jUE1tkEBHRV61YsWKyz8+ePctTvqioKOl95gENlZ9gU06nrH79+tJ7S0tL6f3z58/ztP6cKD+tVbt2bdm8unXr5nt5yk+flSlTBjVq1ACQvp0ZAyE+e/YMu3fvztPyxP9/Ki3ze0C9j0e/fv2gqakJIL1VirW1NczMzFC7dm1MnjwZL168AJDe4iAuLk7KN3z4cNSuXVt6xcbGSvOuXr2qsjyqBot0cHCQBtN8+vQpDhw4gISEBOzcuRMAYGhoiE6dOknpe/bsicGDB+PYsWN4/vw5UlNTsywzo8wfqkePHtDQSK9Wbty4EWlpadi6davU6iIgIAAmJiYAgGvXrkn5rly5Its3U6ZMkeap2jfK54tCoSiUshMREakbda4PFVRh10+VZbQKCQ8Px8KFC2FmZoaEhARMmTIFkyZNyvfyMtdPgfQn/A8cOAAgvQ4SGBgIADAwMIC/v7+UTrlVhvI2ly5dGqVKlZI+Z7fNynmqVKkCAwODXPNkpqoeqVz/WrNmjaz+tXfvXmleRv2rbdu2sLW1BQDMnDkTjo6OMDQ0hIeHB7799ltZi6G81pFzkp967s2bN2X12qCgIGlb/Pz8ZC2eM9cnWZck+rwxkEFERF81Q0NDWRPjjD8oH0LVn5/MzM3NpfdaWlofvM7sZK6g56VsmSn/Ibt79y4UCgUUCgU0NDRw//59lelyYm1tLb3P/MdYnY9HnTp1cOHCBSkwUbx4cbx8+RLHjh3Djz/+iCZNmqgMFuTk9evXKqdn1zVDRvdMQHqz+x07duDNmzcA0v84ZjTd//fff7FmzRop7ZAhQxAWFoajR4/iu+++k6anpaXlq7zZKVWqFBo3bgwAePToEQ4fPizrFqB37975XqaqfaN8vlhZWRWgpEREROpPnetDhaEw6qfK7O3tUatWLdStWxcDBgzAqFGjpHnLly/P0zKU6xWqAjerV6+W6k1CCDg6Okp1YuU614YNG/D+/fss+Qty07yg+ymnLr5yk1H/srKywvnz5zFlyhQ0bdoUpUuXxvv373Hx4kXMnz8fNWrUwIMHDwAUXh05r/XcgmxPBtYliT5vDGQQEdFXr3v37tL7AwcOyPp5VXbz5k3pj0nFihWl6cePH5elO3bsmPTe2dm5EEuaN8r9+p44cUI2759//snXspSfPsvNvn378OTJk1zTubq6Su+Vn+bKoK7HQwgBV1dXzJ49G//88w9iY2Px6NEjODo6AgAiIiJw69YtWFlZyZ5iDAsLgxAiyys+Ph7jx49Xua7s/uz6+/vDwsICALBjxw4sW7ZMmqf85y/jjyWQflNi3rx5aNy4MWrVqpXjMVJeb36DHMrBilmzZkljhJQvX1725KXysfLx8VG5bzL2T2bK54vyeURERPSlUdf6UEEVZv00N8o3/JVbyeYkt/rpqlWr8rQc5VbKytscHR2Nx48fS5+PHDmiMr9ynvPnz0utW4G87ydV9Ujlc2Ps2LEq617JyclS6wwhBGxsbPC///0PoaGhuHv3LuLj46XWJy9fvsRff/0lpc1LHTk3ea3nOjk5SS1AgPTjlV1dMvM4GaxLEn3ePl6InYiI6DPx7bffYuPGjbh48SIAIDAwEH///TdatmwJExMTPHjwAKGhodi6dSuePn0KHR0d9OjRQxqYcNmyZShevDi8vb3x999/S5V6ALKB6z6VTp06YdeuXQCAv/76C6NGjUKDBg1w6NAh7NixI1/LUn76rHz58hgyZEiWNHPmzMHdu3eRkpKCtWvXYsSIETkus169etL7M2fOZJmvrsdj6NChuH37Nho3bgw7OzuYmZnh1q1bsj/Ib9++hUKhQI8ePTBz5kwAQHBwMMaMGQMXFxckJiYiJiYGhw4dwr59+5CUlJSvMujo6KBr166YN28eEhISpD+0zs7O8PHxkdKVKVNGev/8+XP89NNPqFGjBsLCwrB69epsl29hYSENqLh48WK0bNkSGhoaqFatGnR0dHIsW+vWrWFlZYW4uDjZYJ7KfzyB9PPzf//7HxISEnDixAkEBAQgKCgIpqam+PfffxEVFYVt27YhMDAQEyZMkOXNOF8UCoWsiwwiIqIvjbrWhwqqMOunmcXExODYsWNITU1FVFQUZs+eLc1TvoGfk3r16kmDoJ85c0bWzdbJkyelG+CampqYPXu27EY6AOzZswdhYWEA0lspt2/fHo0bN4aZmRlevHiB5ORktGvXDqNHj8bLly8xduxYleVo3749vvvuO6SkpOC///5Dhw4d0L9/f9y7dw8//vhj3ndKJr169cK2bdsApHcVlZqairp160JDQwMPHjzA2bNnsW3bNmzZsgX16tXD5s2bMXv2bLRu3RrlypWDjY0Nnj17JuuWLCPIktc6cm7yWs8tVqwY2rVrJwX3mjdvjlGjRqFcuXJ4+fIl7t+/j7CwMNy9ezdLAEX5v8eHdmlGREXgo47AQURE9JmIjY0VderUyXHQQADixYsXQgghUlJSZIPmqXoNHTpUtg7lQQkPHz4sTc880LOyggymmJaWJpo2baqyTJ6envkaTLFChQpS+p9++kllGuUBml1cXHJdZlpamnBychIAhL6+voiPj8+SRh2PR79+/XJcfpUqVaRBEN+8eSPq1auXa/lzW6cqly5dyrKcmTNnZkmnPPCi8svPzy/bc0B5QEXlV8bglNkN9p1h+PDhsnxaWloiNjY2S7pt27ZJA4Fn98p8vt+6dUua16hRoxz3ERER0ZdAHetDQhR9/TRzubN7aWtri9DQ0DwtLyYmRhpA2tfXVzavb9++0jLr16+vMv/+/ftl9Z/Hjx8LIYRYu3atUCgUOW4z8H+DfQshxNSpU3PdT5mPSXbLUvbdd9/lus8yzoENGzbkmM7ExETcv39fCJG/OnJ2g31nyGs99+nTp8LFxSXH9Sqffxl8fX0FAKGpqSliYmJU7iciUl/sWoqIiAhA8eLFcfjwYWzfvh0BAQGwt7eHnp4ejIyMUKFCBQQFBWHnzp0wNTUFkP401pYtW7B69Wr4+fnBzMwMWlpasLS0RLNmzbBr1y7MmTOnSLZFoVBg+/btGDNmDEqWLAkdHR1UrlwZf/zxB4KDg6V0hoaGOS7n1KlTsubXAQEBKtMpDyh45coVnDt3Ltfy9evXDwCQlJSE7du3Z0mjjscjKCgIffr0gZubGywtLaGlpQUDAwO4uLhg9OjROHjwoDTgtb6+Pg4cOIClS5eiXr16MDc3h5aWFmxsbFC1alUMGzZM6nopv1xdXeHt7S191tbWlh3XDMuWLcPIkSPh4OAAPT09eHh4YNOmTSrTZpg3bx46deoEc3PzAvXlnLn1RfPmzVG8ePEs6fz9/XHhwgX07dsX5cqVg56eHgwNDVGuXDm0bNkSixcvxoABA2R5NmzYIL3/5ptv8l02IiKiz4061ocKqrDqp7nR1dVFmTJl0K1bN5w6dQpNmzbNUz47Ozs0b94cQHrXVxnjwL19+xabN2+W0mVXH65Xr57ULVJGK2UA6NKlC3bu3AkvLy/o6urC2toa/fv3x9atW2X5lbd77NixWL58OSpVqgQdHR2UKlUKY8eOxaJFi6Q0yoOA59XPP/+Mv//+G/7+/ihRogS0tbVhZmaGSpUqITg4GH/++Sdq1KgBAKhevTpGjhwJHx8flChRAjo6OtDR0YGjoyNCQkJw+vRp2NvbA8hfHTk3ea3nWllZ4cyZM5g1axZq1KgBU1NTaGtrw9bWFjVq1MD333+fZR/HxMRI3Zq1aNECdnZ2+d6HRFS0FEJ84KhKREREpHaEECpvRPv7+0vN94cPHy5rev8pJSYmonz58oiNjYW3t7fKLqaIMrx//x5ly5bFw4cP4eHhgXPnzuX5DzERERGpB3Wvn547dw7e3t4QQmDUqFGYMWPGBy8zu23euXMn2rZtCyC9a8+4uDgpXXZ55s2bh6FDhwIAqlSpkuvDQyT33XffYebMmVAoFIiIiEDVqlWLukhElE8cI4OIiOgLNGjQIFhbW6Nhw4ZwcHBAXFwc1qxZI/1JVCgU6NatW5GVz9DQEJMmTULv3r0RERGBv//+G40bNy6y8pB6W7NmDR4+fAggfSBxBjGIiIg+P+peP61atSq6dOmCtWvX4rfffsOYMWNgbm7+Qcvcv38/fv/9d3Tr1g0VK1aEEAKnTp3C6NGjpTTBwcGywMUff/yBU6dOISAgAE5OTnj79i0OHTqEcePGSWkyD2JNOXv58iUWL14MIL2VDIMYRJ8ntsggIiL6AnXu3BmbNm1SOU9DQwOzZ8+WnugiIiIiIvrYvsb66b59+9CsWbNs59euXRuhoaGyrqUWL16cYzeaHTp0wIYNG7IMOE5E9KVjiwwiIqIvULt27fDy5UtcuXIF//33HxQKBUqWLIlatWph4MCBsr5niYiIiIg+tq+xfurk5ITg4GCcPn0asbGxePPmDczMzODu7o7OnTuje/fuWQIS1apVQ8eOHXH27Fk8efIE79+/h6WlJapWrYrg4GB06NChiLaGiKhosUUGERERERERERERERGpLXYwTEREREREREREREREaouBDKIviBAC8fHxYEMrIiIiIvqYWO8kIiIiok+JgQyiL8jr169hamqK169fF3VRiIiIiOgLxnonEREREX1KDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG1pFXUBiKjwDVx6FDr6hkVdDCIiIiJSYfnAekVdhMKzpgqgr1nUpSAiIiIiVXreKOoSFBq2yCAiIiIiIiIiIiIiIrXFQAYREREREREREREREaktBjKIiIiIiIiIiIiIiEhtMZBBRERERERERERERERqi4EMIiIiIiIiIiIiIiJSWwxkEBERERERERERERGR2mIgQ405Ojpi7ty5n2x9CoUCO3bsyHb+vXv3oFAoEBkZCQAIDw+HQqHAy5cvP0n5iIiIiIi+BmFhYahatSo8PT3h4uKCVatWAQB69uyJChUqwMPDA3Xq1JHq5QDw5s0bBAYGoly5cnBycsK2bduKqPRERERE9DkYMmQIHB0doVAocOXKFWl6TnXO7t27o1SpUvDw8ICHhwdGjRolzZs/fz5cXFzg5uYGDw8PbNq0SZoXEREBHx8fGBgYICAgoEDlZSCDCszHxwexsbEwNTUFAKxcuRLFihUr2kJloo5lygsGiYiIiIi+TkIIBAUFYcWKFbhw4QL27NmDfv364fXr12jbti2uXr2KyMhIfPfdd+jYsaOUb9asWdDV1cXt27cRFhaGAQMG4MWLF0W4JURERESkzgICAnDs2DE4ODjIpudU5wSAMWPGIDIyEpGRkZg5c6Y0vXLlyjh+/DguXbqE3bt3Y9CgQbh//z4AoESJEpg7dy7mzJlT4PIykPGFSU5O/mTr0tHRQfHixaFQKD7ZOomIiIiIvgYZD7TEx8fDwsICurq6aN26NbS0tAAANWrUwP3795GWlgYA2LRpEwYOHAgAKF26NOrUqYOdO3cWSdmJiIiISP3VqVMHpUqVyjI9pzpnTho0aCA98G5nZwcbGxs8ePAAAFCqVClUq1YNurq6BS4vAxkf2Z9//glXV1fo6+vDwsICDRs2RGJiIurVq4ehQ4fK0rZt2xbdu3eXTXv9+jWCgoJgZGQEW1tbLFiwQDZfoVBg8eLFaNOmDQwNDTF58mQAwO7du1G1alXo6emhTJkymDhxIlJSUqR8t27dQp06daCnp4dKlSph//79Wcp+5swZeHp6Qk9PD15eXrhw4YJsvnKrgfDwcPTo0QOvXr2CQqGAQqHAhAkTct0/jo6OmDRpUo7bGBMTgzZt2sDIyAgmJibo2LEjnjx5Is2/ePEi/Pz8YGxsDBMTE1StWhVnz54tcJnevXuH7777DnZ2dtDV1UX58uWxfPlyaf6RI0ekL16JEiUwZswY2b5V1SWYh4eHbN0KhQK///47/P39YWBggPLly2PXrl0A0rvw8vPzAwCYmZlBoVBkOS+UyxofHy97EREREdHnS6FQYPPmzWjXrh0cHBxQq1YtrFq1Cjo6OrJ08+bNQ/PmzaGhkf6XLiYmRvY0naOjI2JiYgqtXKx3EhEREX19Mtc5AeCXX36Bm5sbWrZsKet2StmBAwfw4sULVK1atdDKwkDGRxQbG4vAwED07NkTUVFRCA8PR7t27SCEyPMyZs6cCTc3N5w/fx5jx47FsGHDsgQdxo8fjzZt2uDy5cvo2bMnwsLC0LVrVwwZMgTXrl3DkiVLsHLlSkyZMgUAkJaWhnbt2kFTUxOnTp3C4sWLMXr0aNkyExMT0bJlS1SoUAHnzp3DhAkTMHLkyGzL6ePjg7lz58LExASxsbGIjY3NMX1et1EIgbZt2+L58+c4cuQI9u/fjzt37qBTp05S/i5duqBUqVKIiIjAuXPnMGbMGGhraxe4TMHBwdi4cSPmz5+PqKgoLF68GEZGRgCAf//9F82bN4e3tzcuXryI3377DcuXL5cCSPkxceJEdOzYEZcuXULz5s3RpUsXPH/+HHZ2dti6dSsA4MaNG4iNjcW8efNULmPatGkwNTWVXnZ2dvkuBxERERGpj5SUFEybNg07d+7E/fv3cfDgQYSEhOD58+dSmrVr12Lz5s1YsmSJLK9yS+n8/OfIC9Y7iYiIiL4uquqcU6ZMwe3bt3Hp0iX06tULzZo1Q0JCgizf5cuX0aNHD2zatAn6+vqFVh6tQlsSZREbG4uUlBTpaSoAcHV1zdcyfH19MWbMGACAk5MTjh8/jjlz5qBRo0ZSmqCgIPTs2VP63K1bN4wZMwYhISEAgDJlymDSpEn47rvvMH78eBw4cABRUVG4d++e1Hxo6tSpaNasmbSMdevWITU1FX/88QcMDAxQuXJlPHz4EN98843Kcuro6MDU1BQKhQLFixcvtG08cOAALl26hOjoaOnP0po1a1C5cmVERETA29sbMTExGDVqFJydnQEA5cuXl5ad3zLdvHkTmzdvxv79+9GwYUNp/2VYtGgR7Ozs8Ouvv0KhUMDZ2RmPHj3C6NGjMW7cOFl0Mjfdu3dHYGAggPT9v2DBApw5cwZNmzaFubk5AMDa2jrHMT7Gjh2L4cOHS5/j4+P5p5KIiIjoMxYZGYlHjx7B19cXAODt7Q1bW1upFfKmTZswceJEHDx4ENbW1lI+e3t73Lt3D1ZWVgCA+/fvo3nz5oVWLtY7iYiIiL4e2dU5S5YsKb339/fHmDFjcOPGDanlxbVr19CyZUv88ccfqFWrVqGWiS0yPiJ3d3c0aNAArq6u6NChA5YtW5bvAfdq1qyZ5XNUVJRsmpeXl+zzuXPn8NNPP8HIyEh69enTB7GxsXjz5g2ioqJgb28v6wMt83qioqLg7u4OAwODbNMUlpy2MSoqCnZ2drI/SZUqVUKxYsWkNMOHD0fv3r3RsGFDTJ8+HXfu3ClwWSIjI6GpqYm6deuqnB8VFYWaNWvKnnbz9fVFQkICHj58mK91ubm5Se8NDQ1hbGyMp0+f5msZurq6MDExkb2IiIiI6PNlZ2eHhw8f4saNGwCA27dv486dO3BycsLmzZvxww8/4MCBA7C3t5fl69ChAxYuXAgAiI6OxpEjR9C6detCKxfrnURERERfh5zqnMr3P0+dOoVnz56hXLlyANLvmzZv3hxLly6VPYRfWBjI+Ig0NTWxf/9+hIaGolKlSliwYAEqVKiA6OhoaGhoZGnundeBujMPrm1oaCj7nJaWhokTJ0qjx0dGRuLy5cu4desW9PT0VDYzz7zMwm6Knl8Z5RFCqBxMXHn6hAkTcPXqVbRo0QKHDh1CpUqVsH379gKtN7fmTqrKk7GvMqbn9dhqa2vLPisUijwNnENEREREXy4bGxssWbIEAQEBcHd3R7t27bBo0SKULFkSXbp0wdu3b9GmTRt4eHjAw8MDz549AwCMGjUKSUlJKFeuHJo0aYKFCxdKrXyJiIiIiDIbOHAgSpUqhYcPH6Jhw4ZSQCKnOmf37t3h6uoKDw8PDBs2DFu2bJEG+B4yZAhevXqF0aNHS/nCwsIAAHfu3EGpUqUwfPhw7N27F6VKlcKiRYvyVV52LfWRKRQK+Pr6wtfXF+PGjYODgwO2b98OKysrxMbGSulSU1Nx5coVaZDnDKdOncryOaMLpexUqVIFN27ckE6+zCpVqoSYmBg8evQItra2AICTJ09mSbNmzRokJSVJN/czlyUzHR0dpKam5phGlZy2MaOsDx48kFplXLt2Da9evULFihWlPE5OTnBycsKwYcMQGBiIFStWwN/fP99lcnV1RVpaGo4cOSJ1LaWsUqVK2Lp1qyygceLECRgbG0tNqzIf2/j4eERHR+e5DACkwRwLsj+JiIiI6PMWGBgodUGqLKcHnwwNDbFp06aPWSwiIiIi+oIsXLhQatGrLKc654EDB7Kdl3lcZ2Vly5bNd282mbFFxkd0+vRpTJ06FWfPnkVMTAy2bduGuLg4VKxYEfXr18dff/2Fv/76C9evX8eAAQPw8uXLLMs4fvw4ZsyYgZs3b2LhwoXYsmULvv322xzXO27cOKxevVpqqRAVFYVNmzbhhx9+AAA0bNgQFSpUQHBwMC5evIijR4/i+++/ly0jKCgIGhoa6NWrF65du4a9e/di1qxZOa7X0dERCQkJOHjwIP777z+8efMmT/spp21s2LAh3Nzc0KVLF5w/fx5nzpxBcHAw6tatCy8vLyQlJWHQoEEIDw/H/fv3cfz4cUREREhBjvyWydHRESEhIejZsyd27NiB6OhohIeHY/PmzQCAAQMG4MGDBxg8eDCuX7+OnTt3Yvz48Rg+fLg0Pkb9+vWxZs0aHD16FFeuXEFISAg0NTXztC8yODg4QKFQYM+ePYiLi8syaA4RERERERERERHR14KBjI/IxMQE//zzD5o3bw4nJyf88MMPmD17Npo1a4aePXsiJCREuilfunTpLK0xAGDEiBE4d+4cPD09MWnSJMyePRtNmjTJcb1NmjTBnj17sH//fnh7e6NGjRr45ZdfpAHHNTQ0sH37drx79w7VqlVD7969MWXKFNkyjIyMsHv3bly7dg2enp74/vvv8fPPP+e4Xh8fH/Tv3x+dOnWClZUVZsyYkaf9lNM2KhQK7NixA2ZmZqhTpw4aNmyIMmXKSE+baWpq4tmzZwgODoaTkxM6duyIZs2aYeLEiQUu02+//YaAgAAMGDAAzs7O6NOnDxITEwGkD2izd+9enDlzBu7u7ujfvz969eolBYmA9IEQ69Spg5YtW6J58+Zo27YtypYtm6d9kaFkyZKYOHEixowZAxsbGwwaNChf+YmIiIiIiIiIiIi+FApR1IMh0FfN0dERQ4cOxdChQ4u6KF+E+Ph4mJqaouvMPdDRN8w9AxERERF9cssH1ivqInywjHrnq1/LwkQ/f62PiYiIiOgT6XmjqEtQaNgig4iIiIiIiIiIiIiI1BYDGfTRHD16FEZGRtm+WCYiIiIiIiIiIiIiyo1WUReAvlxeXl6IjIzMMc29e/c+SVky5KVMRERERERERERERKQ+GMigj0ZfXx/lypUr6mLIqGOZiIiIiIiIiIiIiCh7HOyb6AsiDbr46hVMTEyKujhERERE9IVivZOIiIiIPiWOkUFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESktrSKugBEVPgGLj0KHX3Doi4GERFRtpYPrFfURSCiwrCmCqCvWdSlICIiKhw9bxR1CYgoG2yRQUREREREREREREREaouBDCIiIiIiIiIiIiIiUlsMZBARERERERERERERkdpiIIOIiIiIiIiIiIiIiNQWAxlERERERERERERERKS2GMggIiIiIiIiIiIiIiK1xUDGV8TR0RFz584t6mIQEREREREREREREeUZAxlfoJUrV6JYsWJFXQwiIiKiAnN0dISzszM8PDzg4eGBTZs2AQCEEJgwYQKcnJzg4uKCevXqyfItWrQIFStWhIuLC9zc3PD27dsiKD0RERERfYnCwsJQtWpVeHp6wsXFBatWrQIAnD17FjVr1oSnpycqVqyIGTNmyPJlV0edMGECrK2tpTpvly5dPvk2EX0utIq6APR5e//+PXR0dIq6GJ89IQRSU1OhpcWvJBERUYY///wTLi4usmnz58/H5cuXceXKFejo6CA2Nlaat3PnTqxbtw6nTp2Cqakpnj59Cm1t7U9dbCIiIiL6AgkhEBQUhMOHD8PNzQ337t2Ds7Mz2rVrhz59+mDixIlo3bo1nj9/DmdnZ7Rs2RKVKlXKtY4aHByMWbNmFeGWEX0e2CJDDe3btw+1atVCsWLFYGFhgZYtW+LOnTsAgPDwcCgUCrx8+VJKHxkZCYVCgXv37iE8PBw9evTAq1evoFAooFAoMGHCBCntmzdv0LNnTxgbG8Pe3h5Lly6Vrfvy5cuoX78+9PX1YWFhgb59+yIhIUGa3717d7Rt2xbTpk2Dra0tnJycct0eR0dHTJ48GcHBwTAyMoKDgwN27tyJuLg4tGnTBkZGRnB1dcXZs2dl+U6cOIE6depAX18fdnZ2GDJkCBITE6X5a9euhZeXF4yNjVG8eHEEBQXh6dOn0vyMfXXw4EF4eXnBwMAAPj4+uHHjRp6Ow8WLF+Hn5wdjY2OYmJigatWqsjIeP34cdevWhYGBAczMzNCkSRO8ePECAPDu3TsMGTIE1tbW0NPTQ61atRAREZGlbGFhYfDy8oKuri6OHj0KIQRmzJiBMmXKQF9fH+7u7vjzzz/zVF4iIqKvwcyZM/Hzzz9LD1KUKFFCNm/ixIkwNTUFAFhbW0NTU7NIyklEREREX6aMe3Lx8fGwsLCArq6ubHpiYiJ0dHRgbm4OgHVUosLCQIYaSkxMxPDhwxEREYGDBw9CQ0MD/v7+SEtLyzWvj48P5s6dCxMTE8TGxiI2NhYjR46U5s+ePRteXl64cOECBgwYgG+++QbXr18HkB7kaNq0KczMzBAREYEtW7bgwIEDGDRokGwdBw8eRFRUFPbv3489e/bkaZvmzJkDX19fXLhwAS1atEC3bt0QHByMrl274vz58yhXrhyCg4MhhACQHlBp0qQJ2rVrh0uXLmHTpk04duyYrCzv37/HpEmTcPHiRezYsQPR0dHo3r17lnV///33mD17Ns6ePQstLS307NkzT2Xu0qULSpUqhYiICJw7dw5jxoyRIuaRkZFo0KABKleujJMnT+LYsWNo1aoVUlNTAQDfffcdtm7dilWrVknb16RJEzx//ly2ju+++w7Tpk1DVFQU3Nzc8MMPP2DFihX47bffcPXqVQwbNgxdu3bFkSNHVJbx3bt3iI+Pl72IiIi+FF26dIGrqyt69+6NuLg4xMfHIy4uDtu3b0eNGjVQo0YNqcspALh27RrOnj0LX19feHl5Yf78+UVYeqIvC+udRET0tVMoFNi8eTPatWsHBwcH1KpVC6tWrYKOjg5WrFiBH3/8Efb29nBycsK0adNQvHhxALnXUTds2AB3d3fUr18fhw8fLopNI/osKETGnWNSW3FxcbC2tsbly5fx33//wc/PDy9evJDGwYiMjISnpyeio6Ph6OiIlStXYujQobJWG0B6y4jatWtjzZo1ANKbxBUvXhwTJ05E//79sWzZMowePRoPHjyAoaEhAGDv3r1o1aoVHj16BBsbG3Tv3h379u1DTExMnruUyrzex48fo0SJEvjxxx/x008/AQBOnTqFmjVrIjY2FsWLF0dwcDD09fWxZMkSaTnHjh1D3bp1kZiYCD09vSzriYiIQLVq1fD69WsYGRkhPDwcfn5+OHDgABo0aCBtT4sWLZCUlKRyGcpMTEywYMEChISEZJkXFBSEmJgYHDt2LMu8xMREmJmZYeXKlQgKCgIAJCcnw9HREUOHDsWoUaOksu3YsQNt2rSR8llaWuLQoUOoWbOmtLzevXvjzZs3WL9+fZZ1TZgwARMnTswyvevMPdDRN8xx+4iIiIrS8oH1cpwfExMDe3t7JCcn44cffsDly5exZs0aWFpaYuLEiRg3bhxiYmJQs2ZNhIWFwcXFBSYmJujUqRMWL16MV69eoW7duvj555/RvHnzT7NRRF+w7Oqdr34tCxN9PlVKRERfiJ7Z9+KRkpKCpk2bYuLEifD19UVERATatm2Ly5cvY/DgwWjTpg06duyIu3fvol69eti/fz8qVKiQYx318ePHsLCwgLa2No4fPw5/f39ERETAwcHhE2400eeBLTLU0J07dxAUFIQyZcrAxMQEpUuXBpD+h/5Dubm5Se8VCgWKFy8udccUFRUFd3d3KYgBAL6+vkhLS5N1x+Tq6prvcTGU12tjYyMtJ/O0jLKcO3cOK1euhJGRkfRq0qQJ0tLSEB0dDQC4cOEC2rRpAwcHBxgbG0uDfWbeT8rrzuh+QrkLquwMHz4cvXv3RsOGDTF9+nSpey/g/1pkqHLnzh0kJyfD19dXmqatrY1q1aohKipKltbLy0t6f+3aNbx9+xaNGjWSbffq1atl61Y2duxYvHr1Sno9ePAg1+0iIiL6HNjb2wNI/w0dOnQojh49CgsLCxgZGaFr165SGl9fX6nrR3t7ewQGBkJTUxPm5uZo1qwZzpw5U2TbQPQlYb2TiIi+dpGRkXj06JF0v8fb2xu2trY4ePAgtm/fjo4dOwIAypQpg+rVq+PEiRMAcq6jFi9eXOr9w9fXF56enlm6XieidAxkqKFWrVrh2bNnWLZsGU6fPo3Tp08DSO9KSUMj/ZApN6RJTk7O87IzD3ipUCikLquEEFAoFCrzKU9XDnQUZL0Zy1I1LaMsaWlp6NevHyIjI6XXxYsXcevWLZQtWxaJiYlo3LgxjIyMsHbtWkRERGD79u0A0vdTbuvOSzddEyZMwNWrV9GiRQscOnQIlSpVktahr6+fbb6MY5N5X6rav8r7MqNMf/31l2y7r127lu04Gbq6ujAxMZG9iIiIPneJiYmylqUbNmyAp6cnACAwMBD79u0DALx48QJnzpyRHloICgqS5r19+xZHjhyBu7v7py080ReK9U4iIvra2dnZ4eHDh9LDvrdv38adO3fg4+MDPT09qVvw//77D6dOnYKLiwuAnOuoDx8+lJZ/69YtREZGyh78JaL/o1XUBSC5Z8+eISoqCkuWLEHt2rUBQNZ9kZWVFQAgNjYWZmZmANIjwsp0dHSksRryo1KlSli1ahUSExOlG+zHjx+HhoZGngb1LkxVqlTB1atXUa5cOZXzM7rZmj59Ouzs7ADgo0SsnZyc4OTkhGHDhiEwMBArVqyAv78/3NzccPDgQZXN68uVKwcdHR0cO3ZM1rXU2bNnMXTo0GzXValSJejq6iImJgZ169Yt9G0hIiL6XDx58gTt27dHamoqhBAoU6YMVq9eDQCYOnUqevTogUWLFgFIf0q8SpUqAIBhw4ahX79+qFSpEhQKBTp06AB/f/8i2w4iIiIi+nLY2NhgyZIlCAgIgIaGBoQQWLRoEUqWLInNmzdj+PDhSElJQXJyMkaOHAlvb28AOddRv//+e5w7dw5aWlrQ1NTEwoULP/k9OKLPBQMZasbMzAwWFhZYunQpSpQogZiYGIwZM0aaX65cOdjZ2WHChAmYPHkybt26hdmzZ8uW4ejoiISEBBw8eBDu7u4wMDCAgYFBruvu0qULxo8fj5CQEEyYMAFxcXEYPHgwunXrJnX99KmMHj0aNWrUwMCBA9GnTx8YGhpKA4wvWLAA9vb20NHRwYIFC9C/f39cuXIFkyZNKrT1JyUlYdSoUQgICEDp0qXx8OFDREREoH379gDSb5q4urpiwIAB6N+/P3R0dHD48GF06NABlpaW+OabbzBq1CiYm5vD3t4eM2bMwJs3b9CrV69s12lsbIyRI0di2LBhSEtLQ61atRAfH48TJ07AyMhI5VgdREREX6IyZcrgwoULKudZWlpi9+7dKufp6+tLAQ8iIiIiosIWGBiIwMDALNMbNmyIc+fOqcyTUx111apVhVo+oi8Zu5ZSMxoaGti4cSPOnTsHFxcXDBs2DDNnzpTma2trY8OGDbh+/Trc3d3x888/Y/LkybJl+Pj4oH///ujUqROsrKwwY8aMPK3bwMAAYWFheP78Oby9vREQEIAGDRrg119/LdRtzAs3NzccOXIEt27dQu3ateHp6Ykff/xRGuPCysoKK1euxJYtW1CpUiVMnz4ds2bNKrT1a2pq4tmzZwgODoaTkxM6duyIZs2aSS0wnJyc8Pfff+PixYuoVq0aatasiZ07d0JLKz02OH36dLRv3x7dunVDlSpVcPv2bYSFhUmtaLIzadIkjBs3DtOmTUPFihXRpEkT7N69WxonhYiIiIiIiIiIiOhroxDKgy0Q0WctPj4epqam6DpzD3T08z+WCRER0aeyfGC9oi4CEX2AjHrnq1/LwkRfs6iLQ0REVDh63ijqEhBRNtgig4iIiIiIiIiIiIiI1BYDGfRBjh49CiMjo2xf6qxy5crZlnvdunVFXTwiIiIiIiIiIiIiAgf7pg/k5eWFyMjIoi5GgezduxfJyckq533qwc2JiIiIiIiIiIiISDUGMuiD6Ovro1y5ckVdjAJxcHAo6iIQERERERERERERUS442DfRF0QadPHVK5iYmBR1cYiIiIjoC8V6JxERERF9Shwjg4iIiIiIiIiIiIiI1BYDGUREREREREREREREpLYYyCAiIiIiIiIiIiIiIrXFQAYREREREREREREREaktBjKIiIiIiIiIiIiIiEhtaRV1AYio8A1cehQ6+oZFXQwi+kIsH1ivqItARETqak0VQF+zqEtBRERUcD1vFHUJiCgP2CKDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQAMDR0RFz584t6mIQEdFnqHHjxnBzc4OHhwdq166NyMhIAIAQAhMmTICTkxNcXFxQr149Kc+dO3fQoEEDeHh4wNnZGSNGjEBaWlrRbAAREREREVE2wsLCULVqVXh6esLFxQWrVq0CAPj4+MDDwwMeHh5wcXGBQqHApUuXAAC3bt1Co0aN4O7ujsqVK2PTpk3S8iZMmABra2spb5cuXYpku4g+NwxkfGVWrlyJYsWKFXUxPpnPdXvDw8OhUCjw8uXLoi4KEVGuNm/ejEuXLiEyMhIjRoxAz549AQDz58/H5cuXceXKFVy5cgUbNmyQ8owcORJt2rRBZGQkIiMj8ffff2Pfvn1FtQlERERERERZCCEQFBSEFStW4MKFC9izZw/69euH169f48SJE9L/mQkTJsDFxQVubm4AgO7du6NLly64ePEiDh06hFGjRuHff/+VlhscHCzlXbduXVFtHtFnhYEM+mjev39f1EUgIqJPQDlg/OrVK2hopFcvZs6ciZ9//hk6OjoAgBIlSsjyvXr1CgCQlJSE5OTkLPOJiIiIiIjUQcaDpvHx8bCwsICurq5s/h9//IFevXpJny9evIjmzZsDAGxsbODu7i5rlUFE+cdAxmdm3759qFWrFooVKwYLCwu0bNkSd+7cAaD6Kf7IyEgoFArcu3cP4eHh6NGjB169egWFQgGFQoEJEyZIad+8eYOePXvC2NgY9vb2WLp0qWzdly9fRv369aGvrw8LCwv07dsXCQkJ0vzu3bujbdu2mDZtGmxtbeHk5JTr9jg6OmLSpEkICgqCkZERbG1tsWDBAlmamJgYtGnTBkZGRjAxMUHHjh3x5MkTaf7Fixfh5+cHY2NjmJiYoGrVqjh79myu25udd+/e4bvvvoOdnR10dXVRvnx5LF++XJp/5MgRVKtWDbq6uihRogTGjBmDlJQU2TZl7qbLw8NDtm6FQoHff/8d/v7+MDAwQPny5bFr1y4AwL179+Dn5wcAMDMzg0KhQPfu3bMta3x8vOxFRFQUgoODYWdnhx9++AGrVq1CfHw84uLisH37dtSoUQM1atSQVdznzp2LLVu2wNbWFra2tggODoanp2cRbgEREeWE9U4iIvoaKRQKbN68Ge3atYODgwNq1aqFVatWSQ9rAcC///6L8PBwdO3aVZrm7e2NtWvXAkjvVvfEiRO4d++eNH/Dhg1wd3dH/fr1cfjw4U+2PUSfMwYyPjOJiYkYPnw4IiIicPDgQWhoaMDf3z9P/Yr7+Phg7ty5MDExQWxsLGJjYzFy5Ehp/uzZs+Hl5YULFy5gwIAB+Oabb3D9+nUA6UGOpk2bwszMDBEREdiyZQsOHDiAQYMGydZx8OBBREVFYf/+/dizZ0+etmnmzJlwc3PD+fPnMXbsWAwbNgz79+8HkN6Er23btnj+/DmOHDmC/fv3486dO+jUqZOUv0uXLihVqhQiIiJw7tw5jBkzBtra2rlub3aCg4OxceNGzJ8/H1FRUVi8eDGMjIwApP84NW/eHN7e3rh48SJ+++03LF++HJMnT87TtiqbOHEiOnbsiEuXLqF58+bo0qULnj9/Djs7O2zduhUAcOPGDcTGxmLevHkqlzFt2jSYmppKLzs7u3yXg4ioMKxevRoPHjzA5MmTMWrUKCQnJ+P9+/dISkrCqVOnsHnzZgwfPhxXrlwBACxZsgTdunXDo0ePcP/+faxfvx6HDh0q4q0gIqLssN5JRERfo5SUFEybNg07d+7E/fv3cfDgQYSEhOD58+dSmpUrV6Jly5awtLSUTTt58iQ8PDwwatQoNGzYENra2gCA/v374969e7h48SImTZqETp064f79+59824g+N1pFXQDKn/bt28s+L1++HNbW1rh27VqueXV0dGBqagqFQoHixYtnmd+8eXMMGDAAADB69GjMmTMH4eHhcHZ2xrp165CUlITVq1fD0NAQAPDrr7+iVatW+Pnnn2FjYwMAMDQ0xO+//y6LTOfG19cXY8aMAQA4OTnh+PHjmDNnDho1aoQDBw7g0qVLiI6Olv4srVmzBpUrV0ZERAS8vb0RExODUaNGwdnZGQBQvnx5adk5ba8qN2/exObNm7F//340bNgQAFCmTBlp/qJFi2BnZ4dff/0VCoUCzs7OePToEUaPHo1x48ZJ3ankRffu3REYGAgAmDp1KhYsWIAzZ86gadOmMDc3BwBYW1vnOMbH2LFjMXz4cOlzfHw8/1QSUZEKCQlB//79AQBGRkbSU0n29vbw9fXF2bNn4eLigvnz5+Pu3bsA0q91zZo1w5EjR1C/fv0iKzsREWWP9U4iIvoaRUZG4tGjR/D19QWQ3tLC1tZW6h1ECIEVK1Zg4cKFsnwODg7YsmWL9Llp06Zo3LgxAMjuUfn6+sLT0xNnz56Fg4PDJ9gios8XW2R8Zu7cuYOgoCCUKVMGJiYmKF26NID07pc+VMaARACkm/9Pnz4FAERFRcHd3V0KYgDpF9u0tDTcuHFDmubq6pqvIAYA1KxZM8vnqKgoab12dnayP0mVKlVCsWLFpDTDhw9H79690bBhQ0yfPl3qaqsgIiMjoampibp166qcHxUVhZo1a0KhUEjTfH19kZCQgIcPH+ZrXcr729DQEMbGxtL+zitdXV2YmJjIXkREn1J8fDwePXokfd6+fTssLCxgbm6OwMBAaQDvFy9e4MyZM9K1r0yZMggNDQWQ3trw0KFDcHFx+fQbQEREecJ6JxERfY3s7Ozw8OFD6d7X7du3cefOHak79SNHjuD9+/do1KiRLN+TJ08ghAAAhIWF4dq1awgKCgIA2f2jW7duITIyEq6urp9ic4g+a2yR8Zlp1aoV7OzssGzZMtja2iItLQ0uLi54//691P1RxoUSAJKTk/O87IwmbhkUCoXUZZUQQnbzPnO6DMqBjg+Rsczs1qs8fcKECQgKCsJff/2F0NBQjB8/Hhs3boS/v3++16uvr5/jfFXlydjfGdM1NDRkxwBQfRxy2t9ERJ+LV69eoX379khKSoKGhgasrKywZ88eKBQKTJ06FT169MCiRYsApD/NW6VKFQDAqlWrMGjQIMyePRvJyclo27YtAgICinJTiIiIiIiIZGxsbLBkyRIEBARI93sWLVqEkiVLAkjvKaVHjx5ZeujYvXs3pk+fDi0tLZQoUQJ79+6V7jl9//33OHfuHLS0tKCpqYmFCxfmaZxZoq8dAxmfkWfPniEqKgpLlixB7dq1AQDHjh2T5ltZWQEAYmNjYWZmBiC9hYEyHR0dpKam5nvdlSpVwqpVq5CYmCgFK44fPw4NDY0PvtieOnUqy+eMbqIqVaqEmJgYPHjwQGqVce3aNbx69QoVK1aU8jg5OcHJyQnDhg1DYGAgVqxYAX9//3xvr6urK9LS0nDkyBGpaylllSpVwtatW2UBjRMnTsDY2Fj6EbOyskJsbKyUJz4+HtHR0XkuAwCpVUtBjhUR0adkZ2eHM2fOqJxnaWmJ3bt3q5zn6emJ48ePf8yiERERERERfbDAwECpa/DM1qxZo3J679690bt3b5XzVq1aVWhlI/qasGupz4iZmRksLCywdOlS3L59G4cOHZL1U1uuXDnY2dlhwoQJuHnzJv766y/Mnj1btgxHR0ckJCTg4MGD+O+///DmzZs8rbtLly7Q09NDSEgIrly5gsOHD2Pw4MHo1q2bND5GQR0/fhwzZszAzZs3sXDhQmzZsgXffvstAKBhw4Zwc3NDly5dcP78eZw5cwbBwcGoW7cuvLy8kJSUhEGDBiE8PBz379/H8ePHERERIQU58ru9jo6OCAkJQc+ePbFjxw5ER0cjPDwcmzdvBgAMGDAADx48wODBg3H9+nXs3LkT48ePx/Dhw6Xoe/369bFmzRocPXoUV65cQUhICDQ1NfO1TxwcHKBQKLBnzx7ExcUhISEhv7uViIiIiIiIiIiI6IvAQMZnRENDAxs3bsS5c+fg4uKCYcOGYebMmdJ8bW1tbNiwAdevX4e7uzt+/vlnTJ48WbYMHx8f9O/fH506dYKVlRVmzJiRp3UbGBggLCwMz58/h7e3NwICAtCgQQP8+uuvH7xdI0aMwLlz5+Dp6YlJkyZh9uzZaNKkCYD07pZ27NgBMzMz1KlTBw0bNkSZMmWwadMmAICmpiaePXuG4OBgODk5oWPHjmjWrBkmTpxY4O397bffEBAQgAEDBsDZ2Rl9+vRBYmIiAKBkyZLYu3cvzpw5A3d3d/Tv3x+9evXCDz/8IOUfO3Ys6tSpg5YtW6J58+Zo27YtypYtm699UrJkSUycOBFjxoyBjY0NBg0alK/8RERERERERERERF8KhcjcmT/RJ+To6IihQ4di6NChRV2UL0J8fDxMTU3RdeYe6OgXznglRETLB9Yr6iIQEZGayah3vvq1LEz089f6mIiISK30vFHUJSCiPGCLDCIiIiIiIiIiIiIiUlsMZNBHc/ToURgZGWX7YpmIiIiIiIiIiIiIKDdaRV0A+nJ5eXkhMjIyxzT37t37JGXJkJcyEREREREREREREZH6YCCDPhp9fX2UK1euqIsho45lIiIiIiIiIiIiIqLscbBvoi+INOjiq1cwMTEp6uIQERER0ReK9U4iIiIi+pQ4RgYREREREREREREREaktBjKIiIiIiIiIiIiIiEhtMZBBRERERERERERERERqi4EMIiIiIiIiIiIiIiJSWwxkEBERERERERERERGR2tIq6gIQUeEbuPQodPQNi7oYREVm+cB6RV0EIiKir8OaKoC+ZlGXgojoy9LzRlGXgIhI7bBFBhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjU1mcdyHB0dMTcuXM/2foUCgV27NiR7fx79+5BoVAgMjISABAeHg6FQoGXL19+kvJ9qMz7M7ftJSL6HL19+xZt27aFk5MTPDw80LRpU9y7dw8AUK9ePZQpUwYeHh7w8PDAnDlzZHkXLVqEihUrwsXFBW5ubnj79m0RbAEREREREX3N3r17h0GDBqF8+fKoXLkyunbtCgCIiIiAr68v3Nzc4OHhgUOHDkl5vv/+e7i6ukr/dTZt2iRb5tatW+Hq6orKlSujUqVK0n8kIiJ1oVXUBfiS+fj4IDY2FqampgCAlStXYujQoZ9NYCM2NhZmZmZFXYwv1ud2PhB9Sfr27YtmzZpBoVDg119/Rd++ffH3338DAObPn4+WLVtmybNz506sW7cOp06dgqmpKZ4+fQptbe1PXXQiIiIiIvrKjRkzBhoaGrh58yYUCgViY2MhhIC/vz/WrFkDPz8/XL9+HY0aNcLNmzehr6+PUaNGYcqUKQCAR48ewdnZGY0bN4aZmRkuXLiAH374AQcPHoStrS3i4+OhpcVbhkSkXj7rFhkFkZyc/MnWpaOjg+LFi0OhUHyydRam4sWLQ1dXt6iLQURUqPT09NC8eXPp2lyjRg3cvXs313wzZ87ExIkTpeC0tbU1NDU1P2pZiYiIiIiIlCUmJmLFihWYOnWq9J+mRIkSePbsGZ4/fw4/Pz8AgLOzM4oVK4bQ0FAAQLFixaRlvH79GgqFAmlpaQCA2bNnY8SIEbC1tQUAmJiYwMDA4BNuFRFR7oo8kPHnn3/C1dUV+vr6sLCwQMOGDZGYmIh69eph6NChsrRt27ZF9+7dZdNev36NoKAgGBkZwdbWFgsWLJDNVygUWLx4Mdq0aQNDQ0NMnjwZALB7925UrVoVenp6KFOmDCZOnIiUlBQp361bt1CnTh3o6emhUqVK2L9/f5aynzlzBp6entDT04OXlxcuXLggm6/ctVR4eDh69OiBV69eQaFQQKFQYMKECbnuH0dHR0yePBnBwcEwMjKCg4MDdu7cibi4OLRp0wZGRkZwdXXF2bNnZflOnDiBOnXqQF9fH3Z2dhgyZAgSExOl+U+fPkWrVq2gr6+P0qVLY926dVnWnblrqdGjR8PJyQkGBgYoU6YMfvzxR1lgaMKECfDw8MCaNWvg6OgIU1NTdO7cGa9fv851OwEgLS0NP//8M8qVKwddXV3Y29tLTwsAwOXLl1G/fn3pXOnbty8SEhKk+d27d0fbtm0xdepU2NjYoFixYtJxHTVqFMzNzVGqVCn88ccfUp6M7sA2b96M2rVrQ19fH97e3rh58yYiIiLg5eUFIyMjNG3aFHFxcbLyrlixAhUrVoSenh6cnZ2xaNGiLMvdtm0b/Pz8YGBgAHd3d5w8eRIAcjwfFi1ahPLly0NPTw82NjYICAjIdp+9e/cO8fHxshcR5c/8+fPRqlUr6fOoUaPg6uqKTp06yQIc165dw9mzZ+Hr6wsvLy/Mnz+/KIpLRERUJFjvJCJSD3fu3IGFhQUmT54MLy8v1K5dGwcPHoSlpSVsbGywdetWAMDp06dx8+ZNWRdR8+fPR4UKFVClShUsXboUFhYWANL/68TExKBu3brw9PTEjz/+iNTU1KLYPCKibBVpICM2NhaBgYHo2bMnoqKiEB4ejnbt2kEIkedlzJw5E25ubjh//jzGjh2LYcOGZQk6jB8/Hm3atMHly5fRs2dPhIWFoWvXrhgyZAiuXbuGJUuWYOXKldJN87S0NLRr1w6ampo4deoUFi9ejNGjR8uWmZiYiJYtW6LC/2PvzsNzuvb//7/uJBIhA2JIVCRSQhKRSKkaShA1HjTmOWI4WqqtGj/mUtRQtGhVEVXHWLTVoKbEVDQxV46aIhwxa2Kekt8ffvbX3cQUkTt4Pq5rXyd7rb3Xfq/tPufs+37vtVbJkoqNjdWwYcPUu3fvh8ZZqVIlTZo0SU5OTkpMTFRiYuIjj3/QxIkTVblyZe3atUv169dXu3bt1L59e7Vt21Y7d+5U8eLF1b59e+O+7du3T7Vr11ZoaKj27t2rhQsXavPmzerRo4fRZlhYmOLj47V+/XotWbJE06ZN09mzZx8Zh6OjoyIiInTgwAFNnjxZM2bMSDN//JEjR7R8+XKtWLFCK1asUHR0tMaMGfNE/RwwYIA+//xzDR48WAcOHNB//vMfFSpUSJJ07do11alTR3nz5tUff/yhxYsXa+3atWZ9kqT169fr1KlT2rhxo7744gsNGzZMDRo0UN68ebV9+3Z169ZN3bp104kTJ8zOGzp0qAYNGqSdO3fKxsZGrVq1Ut++fTV58mRt2rRJR44c0ZAhQ4zjZ8yYoYEDB+qzzz5TXFycRo0apcGDB2vOnDlm7Q4cOFC9e/fW7t275e3trVatWunOnTsP/TzExMSoZ8+e+vTTT3Xw4EGtWrVKVatWfeg9Gz16tJydnY3N3d39ie41gHtGjRqlQ4cOGf/7P3fuXMXFxWnv3r16++23zaaYunPnjo4cOaKNGzfqt99+04wZMxQZGWmp0AEAyFI8dwJA9nD79m0dPXpUvr6+iomJ0ZQpU9SyZUudO3dOP/30k7777jsFBQVp2rRpqlKlitl0uD179tTBgwe1detWjRw5UhcuXDDajI2N1apVq7Rlyxb9/vvvmj59uqW6CADpsuiEd4mJibpz545CQ0Pl4eEhSfL393+qNipXrqz+/ftLkry9vbVlyxZNnDhRtWrVMo5p3bq1wsPDjf127dqpf//+6tChgyTJy8tLI0aMUN++fTV06FCtXbtWcXFxio+PV5EiRSTd+7Grbt26Rhvz5s3T3bt3NWvWLOXKlUt+fn46efKk3nvvvXTjtLW1lbOzs0wmk1xdXZ+qj/Xq1dO///1vSdKQIUP09ddfq3z58mrWrJmkeyMlKlasqDNnzsjV1VXjxo1T69atjREtJUqU0Jdffqlq1arp66+/VkJCglauXKlt27apQoUKkqSZM2fKx8fnkXEMGjTI+NvT01OffPKJFi5cqL59+xrlKSkpioiIkKOjo6R793rdunVmIyvSc/nyZU2ePFlTpkwx/l1ef/11ValSRdK9+339+nV9//33yp07tyRpypQp+te//qXPP//cSHjky5dPX375paysrFSyZEmNHTtW165d0//93/9JupcsGTNmjLZs2aKWLVsa1+/du7dq164tSfrwww/VqlUrrVu3TpUrV5YkderUSREREcbxI0aM0IQJExQaGipJKlasmJEUux///Xbr168vSRo+fLj8/Px0+PBhlSpVKt3PQ0JCgnLnzq0GDRrI0dFRHh4eKlu27EPv24ABA9SrVy9jPzk5mS+VwBMaP368li5dqrVr1xrDpu//98dkMqlHjx7q3bu3Lly4IBcXFxUtWlStWrWStbW18uXLp7p162rHjh2qV6+eJbsBAECW4LkTALIHDw8PWVlZqU2bNpKkgIAAFStWTH/++aeCg4ONqaQkycfHR76+vmnaCAgI0GuvvaaoqCg1adJEHh4eCg0Nlb29vSQpNDRUO3bs0Pvvv581nQKAJ2DRERkBAQGqWbOm/P391axZM82YMUOXLl16qjYqVqyYZj8uLs6srFy5cmb7sbGx+vTTT+Xg4GBsXbp0UWJioq5du6a4uDgVLVrUSGKkd524uDgFBASYzRn4z2MyS5kyZYy/7/9g/2DC537Z/REVsbGxioiIMOtf7dq1lZKSomPHjikuLk42NjZm9+X+3ImPsmTJElWpUkWurq5ycHDQ4MGDlZCQYHaMp6enkcSQ7s3T+LiRHtK9+3nz5k3VrFnzofUBAQFGEkO6l8RKSUnRwYMHjTI/Pz9ZWf2/j3WhQoXM7pW1tbVcXFzSxPQk9/j+OefOndOJEyfUqVMns3s8cuRIHTly5KHturm5SdIj70etWrXk4eEhLy8vtWvXTvPmzdO1a9ceerydnZ2cnJzMNgCP98UXX2j+/Plas2aN8b99d+7c0ZkzZ4xjfvzxRxUqVMgYbt26dWutWrVKknTjxg1FR0crICAgy2MHAMASeO4EgOwhf/78qlmzplavXi1JOn78uI4dO6aSJUvq9OnTxnEzZsxQ7ty5VaNGDUky+63syJEj2rVrl5HkaN26tX777TelpKTo7t27WrNmDd91AGQ7Fh2RYW1trTVr1mjr1q367bff9NVXX2ngwIHavn27rKys0kwx9aQLdf9zce0Hf/yW7o0aGD58uPE2/YNy5syZ7tRW/2zzaaa/elYPDgO8H0d6ZfcXaUpJSdG///1v9ezZM01bRYsWNX74f5pFyLdt26aWLVtq+PDhql27tpydnbVgwQJNmDDhobHev8b9uB7lftb/YVJTUx8a74Pl6V3/SWJ6knv84P2V7j0U3B/Rct8/F/591L9TehwdHbVz505FRUXpt99+05AhQzRs2DD98ccfj000AXgyJ0+e1CeffCIvLy9jITw7OzutX79e9evX182bN2VlZaX8+fPr559/Ns77+OOP9e9//1u+vr4ymUxq1qyZ3n33XUt1AwAAAMAr6ptvvlF4eLj69esna2trffvtt3Jzc9Pw4cM1b948paamysfHR8uWLTN+i+jfv78OHz6sHDlyyMbGRlOmTDFm5mjZsqViYmLk5+cna2trVa1aNc1U3gBgaRZNZEj3ftytXLmyKleurCFDhsjDw0PLli1TgQIFlJiYaBx39+5d7d+/3/jR6b5t27al2S9VqtQjrxkUFKSDBw+qePHi6db7+voqISFBp06dUuHChSXJWKT5wWPmzp2r69evGz/C/zOWf7K1tc2SxZKCgoL0559/PrR/Pj4+unPnjmJiYvTmm29Kkg4ePKi///77oW1u2bJFHh4eGjhwoFF2/PjxTIu5RIkSsre317p169S5c+c09b6+vpozZ46uXr1qJKa2bNkiKysreXt7Z1ocT6JQoUJ67bXXdPToUWMoZ0Y87PNgY2OjkJAQhYSEaOjQocqTJ4/Wr1+fbuINwNMrUqTIQ5PRMTExDz3P3t5e33///fMKCwAAAACeiJeXl6KiotKUDx06VEOHDk33nJ9++umh7VlZWemLL77QF198kVkhAkCms2giY/v27Vq3bp3eeecdFSxYUNu3b9e5c+fk4+Oj3Llzq1evXvr111/1+uuva+LEien+0L5lyxaNHTtWjRs31po1a7R48WL9+uuvj7zukCFD1KBBA7m7u6tZs2aysrLS3r17tW/fPo0cOVIhISEqWbKk2rdvrwkTJig5OdnsB3zp3rC7gQMHqlOnTho0aJDi4+M1fvz4R17X09NTV65c0bp164xpqR6cmiqz9OvXT2+99Za6d++uLl26KHfu3IqLi9OaNWv01VdfqWTJkqpTp466dOmib7/9VjY2Nvroo48eOSqiePHiSkhI0IIFC1S+fHn9+uuvWrZsWabFnDNnTvXr1099+/aVra2tKleurHPnzunPP/9Up06d1KZNGw0dOlQdOnTQsGHDdO7cOX3wwQdq166dMRVUVho2bJh69uwpJycn1a1bVzdv3lRMTIwuXbpkNnfwo6T3eVi/fr2OHj2qqlWrKm/evIqMjFRKSopKliz5nHsEAAAAAAAAANmTRdfIcHJy0saNG1WvXj15e3tr0KBBmjBhgurWravw8HB16NBB7du3V7Vq1VSsWLE0ozEk6ZNPPlFsbKzKli1rLMB8f9Hmh6ldu7ZWrFihNWvWqHz58nrrrbf0xRdfGAuOW1lZadmyZbp586befPNNde7cOc1i1Q4ODvrll1904MABlS1bVgMHDtTnn3/+yOtWqlRJ3bp1U4sWLVSgQAGNHTv2Ke/YkylTpoyio6N16NAhvf322ypbtqwGDx5srNEgSbNnz5a7u7uqVaum0NBQde3aVQULFnxom40aNdLHH3+sHj16KDAwUFu3btXgwYMzNe7Bgwfrk08+0ZAhQ+Tj46MWLVoY60nkypVLq1ev1sWLF1W+fHk1bdpUNWvW1JQpUzI1hifVuXNnfffdd4qIiJC/v7+qVaumiIgIFStW7InbSO/zkCdPHi1dulQ1atSQj4+PvvnmG82fP19+fn7PsTcAAAAAAAAAkH2ZUrNysQcAz1VycrKcnZ3VdtwK2drnfvwJwEtqZvdgS4cAAMBL7f5zZ9KU1+Vkb/34EwAATy78oKUjAIBsx6IjMgAAAAAAAAAAAB6FRIYFbdq0SQ4ODg/dXiYJCQmP7GtCQoKlQwQAAAAAAAAAZEMWXez7VVeuXDnt3r3b0mFkicKFCz+yr4ULF866YAAAAAAAAAAALwwSGRZkb2+v4sWLWzqMLGFjY/PK9BUAAAAAAAAAkHlY7Bt4iRiLLiYlycnJydLhAAAA4CXFcycAAACyEmtkAAAAAAAAAACAbItEBgAAAAAAAAAAyLZIZAAAAAAAAAAAgGyLRAYAAAAAAAAAAMi2SGQAAAAAAAAAAIBsy8bSAQDIfN2/3SRb+9yWDiPbmNk92NIhAAAAvJzmBkn21paOAgCyRvhBS0cAAK8sRmQAAAAAAAAAAIBsi0QGAAAAAAAAAADItkhkAAAAAAAAAACAbItEBgAAAAAAAAAAyLZIZAAAAAAAAAAAgGyLRAYAAAAAAAAAAMi2SGTglRAVFSWTyaS///77kcd5enpq0qRJmXLNYcOGKTAwMFPawvO1atUqlStXTmXKlNFbb72lPXv2SJJGjRqlkiVLysrKSitWrLBwlAAAAACA7OzmzZvq0aOHSpQoIT8/P7Vt29asfs6cOTKZTGbfL2fNmiV/f3/Z2NhoypQpZsdfuHBBjRs3VpkyZeTj46MOHTro+vXrWdIXAMhuSGTgpRQcHKyPPvrI2K9UqZISExPl7OwsSYqIiFCePHksExyylUuXLqlt27aaO3eu9u7dq88//1xt2rSRJNWsWVORkZGqWrWqhaMEAAAAAGR3/fv3l5WVlf766y/9+eefGjdunFF38uRJTZ8+XW+99ZbZOW+88YYWLVqk1q1bp2lv5MiR8vLy0t69e7V//36dOXNGs2fPfu79AIDsyMbSAQBZwdbWVq6urpYOA9nQkSNHVLBgQfn4+EiSqlWrpuPHj2vnzp2qUKGChaMDAAAAALwIrl69qtmzZ+vkyZMymUySJDc3N6O+a9eumjhxovr162d2XkBAgCTJyir9d40vX76slJQU3bp1S9euXVORIkWeUw8AIHtjRAZeOmFhYYqOjtbkyZNlMplkMpkUERFhTC0VFRWljh07KikpyagfNmxYum0lJSWpa9euKliwoJycnFSjRg1j2qGMmD17tnx8fJQzZ06VKlVK06ZNM+ri4+NlMpm0dOlSVa9eXbly5VJAQIB+//33h7Z38+ZNJScnm214OiVKlNC5c+e0bds2SdKyZct05coVxcfHWzYwAACAbITnTgB4tCNHjsjFxUUjR45UuXLl9Pbbb2vdunWSpK+//lp+fn5P/bLc4MGDdfjwYbm6uhov4DVs2PB5hA8A2R6JDLx0Jk+erIoVK6pLly5KTExUYmKi3N3djfpKlSpp0qRJcnJyMup79+6dpp3U1FTVr19fp0+fVmRkpGJjYxUUFKSaNWvq4sWLTx3XjBkzNHDgQH322WeKi4vTqFGjNHjwYM2ZM8fsuIEDB6p3797avXu3vL291apVK925cyfdNkePHi1nZ2dje7CfeDLOzs768ccf1b9/f73xxhuKioqSr6+vcuTIYenQAAAAsg2eOwHg0W7fvq2jR4/K19dXMTExmjJlilq2bKk//vhDM2bM0KeffvrUbS5evFhlypRRYmKiTp06pb/++ksRERGZHzwAvABIZOCl4+zsLFtbW+XKlUuurq5ydXWVtbW1UW9raytnZ2eZTCaj3sHBIU07GzZs0L59+7R48WKVK1dOJUqU0Pjx45UnTx4tWbLkqeMaMWKEJkyYoNDQUBUrVkyhoaH6+OOPNX36dLPjevfurfr168vb21vDhw/X8ePHdfjw4XTbHDBggJKSkoztxIkTTx0XpKpVqyoqKkqxsbEaO3asTp06ZUw1BQAAAJ47AeBxPDw8ZGVlZay5GBAQoGLFiunQoUPGd0xPT09t27ZNnTp10owZMx7b5ldffaU2bdrI2tpajo6Oatq0qTZs2PC8uwIA2RJrZAAPERsbqytXrsjFxcWs/Pr16zpy5MhTtXXu3DmdOHFCnTp1UpcuXYzyO3fuGAuQ31emTBnj7/vzaZ49e1alSpVK066dnZ3s7OyeKhaklZiYaNzrESNGqEaNGipevLiFowIAAMg+eO4EgEfLnz+/atasqdWrV6tevXo6fvy4jh07purVq+v06dPGccHBwerdu7caNGjw2Da9vLy0cuVKvfnmm7p9+7ZWrVqlqlWrPs9uAEC2RSIDeIiUlBS5ubkpKioqTV2ePHmeui3p3vRS/5wT88HRIpLMpjS6v0DY/fPxfAwePFibN2/WnTt3VLFiRc2cOVPSvSkUpk6dqnPnziksLEw5c+bUrl27VKBAAQtHDAAAAADIbr755huFh4erX79+sra21rfffmu24Hd6fvjhB/Xv31+XLl3STz/9pDFjxuiXX35R2bJlNXnyZHXr1k2lS5dWSkqKKleurJ49e2ZRbwAgeyGRgZeSra2t7t69m+F6SQoKCtLp06dlY2MjT0/PZ4qnUKFCeu2113T06FFjmCmyj++++y7d8gEDBmjAgAFZHA0AAAAA4EXk5eWV7suQD/pnfdu2bdW2bdt0jy1WrJhWr16dSdEBwIuNRAZeSp6entq+fbvi4+Pl4OCQZkSDp6enrly5onXr1ikgIEC5cuVSrly5zI4JCQlRxYoV1bhxY33++ecqWbKkTp06pcjISDVu3FjlypV7qpiGDRumnj17ysnJSXXr1tXNmzcVExOjS5cuqVevXs/cZwAAAAAAAAB4GbHYN15KvXv3lrW1tXx9fVWgQAElJCSY1VeqVEndunVTixYtVKBAAY0dOzZNGyaTSZGRkapatarCw8Pl7e2tli1bKj4+XoUKFXrqmDp37qzvvvtOERER8vf3V7Vq1RQREaFixYpluJ8AAAAAAAAA8LIzpaamplo6CACZIzk5Wc7Ozmo7boVs7XNbOpxsY2b3YEuHAAAA8FK5/9yZNOV1OdlbP/4EAHgZhB+0dAQA8MpiRAYAAAAAAAAAAMi2SGQAGeTn5ycHB4d0t3nz5lk6PAAAAAAAAAB4KbDYN5BBkZGRun37drp1GVlDAwAAAAAAAACQFokMIIM8PDwsHQIAAAAAAAAAvPRY7Bt4iRiLLiYlycnJydLhAAAA4CXFcycAAACyEmtkAAAAAAAAAACAbItEBgAAAAAAAAAAyLZIZAAAAAAAAAAAgGyLRAYAAAAAAAAAAMi2SGQAAAAAAAAAAIBsy8bSAQDIfN2/3SRb+9yWDgNAFprZPdjSIQAAXkVzgyR7a0tHAeBVFH7Q0hEAALIQIzIAAAAAAAAAAEC2RSIDAAAAAAAAAABkWyQyAAAAAAAAAABAtkUiAwAAAAAAAAAAZFskMgAAAAAAAAAAQLZFIgMAAAAAAAAAAGRbJDIykaenpyZNmpRl1zOZTFq+fPlD6+Pj42UymbR7925JUlRUlEwmk/7+++8sie9Z/fN+Pq6/AAAAAAAAAICXD4mMV0ilSpWUmJgoZ2dnSVJERITy5Mlj2aCeQmJiourWrWvpMADghfTOO++oTJkyCgwM1Ntvv20kuTt27GiUly9fXuvWrTPOadq0qQIDA43NyspKP//8s4V6AAAAADw5T09PlSpVyniWXbhwoSQpJiZGFStWVNmyZeXj46OxY8ca5/zf//2ffHx8FBAQoDfffFPr16836qZOnSp/f38FBgbK399fX375ZZb3CQBeZTaWDuBVd/v2beXIkSNLrmVraytXV9csudbz8CLH/jhZ+TkA8GpatGiRkbxevny5wsPDtXPnTk2cONEo3717t0JCQnTu3DmZTCYtWbLEOD8mJkZ16tRR7dq1LRA9AAAA8PSWLFmi0qVLm5V16dJFw4cPV8OGDXXx4kWVKlVKDRo0kK+vr95++20NHjxY9vb22rNnj4KDg5WYmKicOXOqbdu26t69uyQpOTlZpUuXVnBwsMqUKWOJrgHAK4cRGf+wZMkS+fv7y97eXi4uLgoJCdHVq1cVHBysjz76yOzYxo0bKywszKzs8uXLat26tRwcHFS4cGF99dVXZvUmk0nffPONGjVqpNy5c2vkyJGSpF9++UVvvPGGcubMKS8vLw0fPlx37twxzjt06JCqVq2qnDlzytfXV2vWrEkT+44dO1S2bFnlzJlT5cqV065du8zqH5xaKioqSh07dlRSUpJMJpNMJpOGDRv22Pvj6empkSNHqn379nJwcJCHh4d++uknnTt3To0aNZKDg4P8/f0VExNjdt7WrVtVtWpV2dvby93dXT179tTVq1eN+rNnz+pf//qX7O3tVaxYMc2bNy/Ntf85tVS/fv3k7e2tXLlyycvLS4MHD9bt27eN+mHDhikwMFBz586Vp6ennJ2d1bJlS12+fPmx/ZQe/lm4b9asWfLz85OdnZ3c3NzUo0cPoy4hIcG4H05OTmrevLnOnDmTJrZZs2bJy8tLdnZ2Sk1NVVJSkrp27aqCBQvKyclJNWrU0J49e54oXgB4lAdH4CUlJcnKyipN+d9//y2TyZTu+bNmzVLbtm1lZ2f3PMMEAAAAnrv7U25fvXpVtra2ypcvnySpbt26sre3lyT5+/vr7t27On/+vCQZs1tI0rVr13Tnzp2HPjsDADIfiYwHJCYmqlWrVgoPD1dcXJyioqIUGhqq1NTUJ25j3LhxKlOmjHbu3KkBAwbo448/TpN0GDp0qBo1aqR9+/YpPDxcq1evVtu2bdWzZ08dOHBA06dPV0REhD777DNJUkpKikJDQ2Vtba1t27bpm2++Ub9+/czavHr1qho0aKCSJUsqNjZWw4YNU+/evR8aZ6VKlTRp0iQ5OTkpMTFRiYmJjzz+QRMnTlTlypW1a9cu1a9fX+3atVP79u3Vtm1b7dy5U8WLF1f79u2N+7Zv3z7Vrl1boaGh2rt3rxYuXKjNmzeb/fAfFham+Ph4rV+/XkuWLNG0adN09uzZR8bh6OioiIgIHThwQJMnT9aMGTM0ceJEs2OOHDmi5cuXa8WKFVqxYoWio6M1ZsyYx/bxcZ+Fr7/+Wt27d1fXrl21b98+/fzzzypevLgkKTU1VY0bN9bFixcVHR2tNWvW6MiRI2rRooXZNQ4fPqxFixbpxx9/NKZ4qV+/vk6fPq3IyEjFxsYqKChINWvW1MWLF9ON8+bNm0pOTjbbAOBh2rdvL3d3dw0aNEhz5swxyvv376/XX39doaGhWrx4cZovZDdu3ND8+fPVqVOnrA4ZAJBN8NwJ4EXUpk0b+fv7q3Pnzjp37pwkafbs2Ro8eLCKFi0qb29vjR49Ot0ZIGbPnq3XX39dRYoUMcqWLFkiPz8/eXh4qE+fPvL398+yvgDAq46ppR6QmJioO3fuKDQ0VB4eHpL01P+nVLlyZfXv31+S5O3trS1btmjixImqVauWcUzr1q0VHh5u7Ldr1079+/dXhw4dJEleXl4aMWKE+vbtq6FDh2rt2rWKi4tTfHy88X+go0aNMlsvYt68ebp7965mzZqlXLlyyc/PTydPntR7772Xbpy2trZydnaWyWR66imb6tWrp3//+9+SpCFDhujrr79W+fLl1axZM0n3RkpUrFhRZ86ckaurq8aNG6fWrVsbI1pKlCihL7/8UtWqVdPXX3+thIQErVy5Utu2bVOFChUkSTNnzpSPj88j4xg0aJDxt6enpz755BMtXLhQffv2NcpTUlIUEREhR0dHSffu9bp164wk0cM87rMwcuRIffLJJ/rwww+NsvLly0uS1q5dq7179+rYsWNyd3eXJM2dO1d+fn76448/jONu3bqluXPnqkCBApKk9evXa9++fTp79qzxxvP48eO1fPlyLVmyRF27dk0T5+jRozV8+PBH9gUA7vv+++8lSXPmzFGfPn0UGRkpSRozZozGjBmjtWvXqk+fPtqyZYtsbW2N83788UeVKFGCL2oA8ArjuRPAi2bjxo0qWrSobt++rUGDBqlDhw6KjIzUuHHjNG7cODVv3lxHjx5VcHCw3nzzTZUsWdI4d926dRo+fHiaF1ObNm2qpk2bKj4+Xu+++67q1atndh4A4PlhRMYDAgICVLNmTfn7+6tZs2aaMWOGLl269FRtVKxYMc1+XFycWVm5cuXM9mNjY/Xpp5/KwcHB2Lp06aLExERdu3ZNcXFxKlq0qNlbAP+8TlxcnAICApQrV66HHpNZHpz/sVChQpLMf+S/X3Z/REVsbKwiIiLM+le7dm2lpKTo2LFjiouLk42Njdl9KVWq1GMXIl+yZImqVKkiV1dXOTg4aPDgwUpISDA7xtPT00hiSJKbm9tjR3pIj/4snD17VqdOnVLNmjXTPTcuLk7u7u5GEkOSfH19lSdPHrPPgoeHh5HEuH+frly5IhcXF7N7dezYMR05ciTdaw0YMEBJSUnGduLEicf2DQA6dOigDRs26MKFC2blISEhunz5svbt22dWPnPmTEZjAMArjudOAC+aokWLSpJy5Mihjz76SJs2bdL58+e1bNkyNW/eXNK9F0krVKigrVu3GudFR0erY8eO+uWXXx6apPD09FSFChW0YsWK598RAIAkEhlmrK2ttWbNGq1cuVK+vr766quvVLJkSR07dkxWVlZppph6cD2GR/nnFB25c+c2209JSdHw4cO1e/duY9u3b58OHTqknDlzpju11T/bfJrpr57Vg4tS348jvbKUlBTjP//973+b9W/Pnj06dOiQXn/9dSP2p5lbctu2bWrZsqXq1q2rFStWaNeuXRo4cKBu3br10FjvX+N+XI/yqM/C/fkyHyY1NTXdvvyzPL3PgZubm9l92r17tw4ePKg+ffqkey07Ozs5OTmZbQDwT8nJyTp16pSxv2zZMrm4uMjJyUmHDh0yynfs2KGzZ8/Ky8vLKDt27Jh27NihVq1aZWnMAIDshedOAC+Sq1evGutgSNL8+fNVtmxZ5c2bVzlz5lR0dLQk6fz589q2bZuxIPjGjRvVrl07/fTTTwoICDBr88EXE8+dO6d169ax0DcAZCGmlvoHk8mkypUrq3LlyhoyZIg8PDy0bNkyFShQQImJicZxd+/e1f79+1W9enWz87dt25Zmv1SpUo+8ZlBQkA4ePGissfBPvr6+SkhI0KlTp1S4cGFJ0u+//57mmLlz5+r69evGD+3/jOWfbG1tdffu3UcekxmCgoL0559/PrR/Pj4+unPnjmJiYvTmm29Kkg4ePGj20PFPW7ZskYeHhwYOHGiUHT9+PFPjfthnoVevXvL09NS6devS/PtL/+/f68SJE8aojAMHDigpKemR02UFBQXp9OnTsrGxkaenZ6b2BcCrLSkpSU2aNNH169dlZWWlAgUKaMWKFUpJSVFYWJiSkpJkbW2t3Llza8mSJcqbN69x7qxZs9SkSRN+sAIAAMAL48yZM2rSpInu3r2r1NRUeXl56fvvv5e1tbUWLVqkXr166c6dO7p9+7Z69+5tTAHdqVMn3bx5Ux07djTamjt3rvz9/fXVV18pOjpaOXLkUGpqqj7++GOzacQBAM8XiYwHbN++XevWrdM777yjggULavv27Tp37px8fHyUO3du9erVS7/++qtef/11TZw4Md0f2rds2aKxY8eqcePGWrNmjRYvXqxff/31kdcdMmSIGjRoIHd3dzVr1kxWVlbau3ev9u3bp5EjRyokJEQlS5ZU+/btNWHCBCUnJ5v9gC/dW3dj4MCB6tSpkwYNGqT4+HiNHz/+kdf19PTUlStXtG7dOmNaqgenpsos/fr101tvvaXu3burS5cuyp07t+Li4rRmzRpjpEOdOnXUpUsXffvtt7KxsdFHH330yJEPxYsXV0JCghYsWKDy5cvr119/1bJlyzIt5kd9FiRp2LBh6tatmwoWLKi6devq8uXL2rJliz744AOFhISoTJkyatOmjSZNmqQ7d+7o/fffV7Vq1dJMK/agkJAQVaxYUY0bN9bnn3+ukiVL6tSpU4qMjFTjxo0feS4APIq7u7t27NiRbt2WLVseee6IESOeR0gAAADAc+Pl5aVdu3alWxcSEqLY2Nh06x4crfxP06ZNy5TYAAAZw9RSD3ByctLGjRtVr149eXt7a9CgQZowYYLq1q2r8PBwdejQQe3bt1e1atVUrFixdN/G/+STTxQbG6uyZctqxIgRmjBhgmrXrv3I69auXVsrVqzQmjVrVL58eb311lv64osvjEWmraystGzZMt28eVNvvvmmOnfunGaxagcHB/3yyy86cOCAypYtq4EDB+rzzz9/5HUrVaqkbt26qUWLFipQoIDGjh37lHfsyZQpU0bR0dE6dOiQ3n77bZUtW1aDBw+Wm5ubcczs2bPl7u6uatWqKTQ0VF27dlXBggUf2majRo308ccfq0ePHgoMDNTWrVs1ePDgTIv5UZ8F6d788pMmTdK0adPk5+enBg0aGA88JpNJy5cvV968eVW1alWFhITIy8tLCxcufOQ1TSaTIiMjVbVqVYWHh8vb21stW7ZUfHy8se4IAAAAAAAAALxqTKlZubgCgOcqOTlZzs7OajtuhWztcz/+BAAvjZndgy0dAgDgFXL/uTNpyutysre2dDgAXkXhBy0dAQAgCzEiAwAAAAAAAAAAZFskMmDYtGmTHBwcHrq9TBISEh7Z14SEBEuHCAAAAAAAAAAQi33jAeXKldPu3bstHUaWKFy48CP7Wrhw4awLBgAAAAAAAADwUCQyYLC3t1fx4sUtHUaWsLGxeWX6CgAAAAAAAAAvMhb7Bl4ixqKLSUlycnKydDgAAAB4SfHcCQAAgKzEGhkAAAAAAAAAACDbIpEBAAAAAAAAAACyLRIZAAAAAAAAAAAg2yKRAQAAAAAAAAAAsi0SGQAAAAAAAAAAINuysXQAADJf9283ydY+t6XDQDY3s3uwpUMAAAAvurlBkr21paMA8CoJP2jpCAAAFsCIDAAAAAAAAAAAkG2RyAAAAAAAAAAAANkWiQwAAAAAAAAAAJBtkcgAAAAAAAAAAADZFokMAAAAAAAAAACQbZHIAAAAAAAAAAAA2RaJDAAAAAAAAAAAkG2RyMALIz4+XiaTSbt37zbKtmzZIn9/f+XIkUONGze2WGzpMZlMWr58uaXDADKkZ8+e8vT0lMlk0v79+43ymJgYVaxYUWXLlpWPj4/Gjh1r1A0cOFD+/v4KDAxUYGCgFi5caInQAQAAALzCPD09VapUqTTfSypVqmSUlS5dWiaTSXv37pUkHTp0SLVq1VJAQID8/PzMvssMGzZMBQsWNM5t06aNRfoFAK86G0sHADyLXr16KTAwUCtXrpSDg4OGDRum5cuXmyU7MsPzahfIrpo2baq+ffuqSpUqZuVdunTR8OHD1bBhQ128eFGlSpVSgwYN5Ovrqz59+uizzz6TJJ06dUqlSpXSO++8o7x581qiCwAAAABeUUuWLFHp0qXNyrZu3WpWP3z4cJUpU0aSFBYWpi5duigsLExnzpxR+fLlVaVKFb322muSpPbt22v8+PFZ1wEAQBqMyMAL7ciRI6pRo4aKFCmiPHnyWDoc4KVRtWpVFSlSJN26v//+W5J09epV2draKl++fJJk9t/By5cvy2QyKSUl5XmHCgAAAABPZdasWerUqZOxv2fPHtWrV0+SVKhQIQUEBDDCHACyGRIZyHJLliyRv7+/7O3t5eLiopCQEF29elWSNHv2bPn4+ChnzpwqVaqUpk2blm4b96eZunDhgsLDw2UymRQREaHhw4drz549MplMRpkkJSUlqWvXripYsKCcnJxUo0YN7dmzR5J07tw5ubq6atSoUUb727dvl62trX777bdHtvs0/ve//6lFixbKmzevXFxc1KhRI8XHxxv1YWFhaty4scaPHy83Nze5uLioe/fuun379kPbvHnzppKTk8024HmaPXu2Bg8erKJFi8rb21ujR4+Wq6urUf/ll1+qZMmSCgoK0rfffisXFxcLRgsAADILz50AXiRt2rSRv7+/OnfurHPnzpnV/e9//1NUVJTatm1rlJUvX14//PCDpHsvTG7dutXs+/r8+fMVEBCgGjVqaMOGDVnSBwCAORIZyFKJiYlq1aqVwsPDFRcXp6ioKIWGhio1NVUzZszQwIED9dlnnykuLk6jRo3S4MGDNWfOnDTtuLu7KzExUU5OTpo0aZISExPVokULffLJJ/Lz81NiYqJRlpqaqvr16+v06dOKjIxUbGysgoKCVLNmTV28eFEFChTQrFmzNGzYMMXExOjKlStq27at3n//fb3zzjsPbfdpXLt2TdWrV5eDg4M2btyozZs3y8HBQXXq1NGtW7eM4zZs2KAjR45ow4YNmjNnjiIiIh6ZNBk9erScnZ2Nzd3d/aniAp7WuHHjNG7cOCUkJOjPP//UwIEDdfDgQaO+Z8+eOnjwoLZu3aqRI0fqwoULFowWAABkFp47AbwoNm7cqD179mjnzp1ycXFRhw4dzOojIiLUoEED5c+f36zs999/V2BgoPr06aOQkBDlyJFDktStWzfFx8drz549GjFihFq0aKHjx49naZ8AAKyRgSyWmJioO3fuKDQ0VB4eHpIkf39/SdKIESM0YcIEhYaGSpKKFSumAwcOaPr06WkePKytreXq6iqTySRnZ2fjjXAHBwfZ2NiYvSG+fv167du3T2fPnpWdnZ0kafz48Vq+fLmWLFmirl27ql69eurSpYvatGmj8uXLK2fOnBozZowkyd7ePt12n8aCBQtkZWWl7777TiaTSdK9N9vz5MmjqKgovfPOO5KkvHnzasqUKbK2tlapUqVUv359rVu3Tl26dEm33QEDBqhXr17GfnJyMl8q8dycP39ey5Yt07x58yRJXl5eqlChgrZu3aqSJUuaHRsQEKDXXntNUVFRatKkiSXCBQAAmYjnTgAviqJFi0qScuTIoY8++kje3t5GXWpqqmbPnq2pU6eanePh4aHFixcb+3Xq1DG+pz/4O0DlypVVtmxZxcTEGL9pAACyBokMZKmAgADVrFlT/v7+ql27tt555x01bdpUd+7c0YkTJ9SpUyezH+3v3LkjZ2fnZ7pmbGysrly5kmaKm+vXr+vIkSPG/vjx41W6dGktWrRIMTExypkz5zNd958xHD58WI6OjmblN27cMIvBz89P1tbWxr6bm5v27dv30Hbt7OyM5AzwvOXNm1c5c+ZUdHS0qlWrpvPnz2vbtm3q27evJCkuLk4+Pj6S7g3H3rVrl3x9fS0ZMgAAyCQ8dwJ4EVy9elW3b9821u+bP3++ypYta9RHR0fr1q1bqlWrltl5Z86cUcGCBWUymbR69WodOHBArVu3liSdPHnSWD/w0KFD2r17t/FCJgAg65DIQJaytrbWmjVrtHXrVv3222/66quvNHDgQP3yyy+SpBkzZqhChQppznkWKSkpcnNzU1RUVJq6BxcnPnr0qE6dOqWUlBQdP35cZcqUeabr/jOGN954w3iT/UEFChQw/r4/dPU+FkuGpXTv3l0//fSTTp8+rZCQEDk4OOjw4cNatGiRevXqpTt37uj27dvq3bu3ypcvL0nq37+/Dh8+rBw5csjGxkZTpkwxEhsAAAAA8LydOXNGTZo00d27d5WamiovLy99//33Rv3MmTPVsWNHWVmZz7T+yy+/aMyYMbKxsZGbm5siIyNlb28vSRo4cKBiY2NlY2Mja2trTZ061WyUBwAga5DIQJYzmUyqXLmyKleurCFDhsjDw0NbtmzRa6+9pqNHj6pNmzYZbtvW1lZ37941KwsKCtLp06dlY2MjT0/PdM+7deuW2rRpoxYtWqhUqVLq1KmT9u3bp0KFCj203acRFBSkhQsXGouNA9nd1KlT0wy3lqSQkBDFxsame85PP/30vMMCAAAAgIfy8vLSrl27Hlo/d+7cdMs7d+6szp07p1uX3rqdAICsx2LfyFLbt2/XqFGjFBMTo4SEBC1dulTnzp2Tj4+Phg0bptGjR2vy5Mn666+/tG/fPs2ePVtffPHFE7fv6empY8eOaffu3Tp//rxu3rypkJAQVaxYUY0bN9bq1asVHx+vrVu3atCgQYqJiZF07w2LpKQkffnll+rbt698fHzUqVOnR7b7NNq0aaP8+fOrUaNG2rRpk44dO6bo6Gh9+OGHOnny5FO1BQAAAAAAAACvEhIZyFJOTk7auHGj6tWrJ29vbw0aNEgTJkxQ3bp11blzZ3333XeKiIiQv7+/qlWrpoiICBUrVuyJ22/SpInq1Kmj6tWrq0CBApo/f75MJpMiIyNVtWpVhYeHy9vbWy1btlR8fLwKFSqkqKgoTZo0SXPnzpWTk5OsrKw0d+5cbd68WV9//fVD230auXLl0saNG1W0aFGFhobKx8dH4eHhun79OiM0AAAAAAAAAOARTKmpqamWDgJA5khOTpazs7PajlshW/vclg4H2dzM7sGWDgEAALyg7j93Jk15XU72z7amHQA8lfCDlo4AAGABjMgAAAAAAAAAAADZFokMIAPmzZsnBweHdDc/Pz9LhwcAAAAAAAAALw0bSwcAvIgaNmyoChUqpFuXI0eOLI4GAAAAAAAAAF5eJDKADHB0dJSjo6OlwwAAAAAAAACAlx6LfQMvEWPRxaQkOTk5WTocAAAAvKR47gQAAEBWYo0MAAAAAAAAAACQbZHIAAAAAAAAAAAA2RaJDAAAAAAAAAAAkG2RyAAAAAAAAAAAANkWiQwAAAAAAAAAAJBt2Vg6AACZr/u3m2Rrn/uh9TO7B2ddMAAAAHh5zQ2S7K0tHQWQPYUftHQEAAC8NBiRAQAAAAAAAAAAsi0SGQAAAAAAAAAAINsikQEAAAAAAAAAALItEhkAAAAAAAAAACDbIpEBAAAAAAAAAACyLRIZAAAAAAAAAAAg2yKRgceKioqSyWTS33///cjjPD09NWnSpCyJ6XkJCwtT48aNLR2GRfXs2VOenp4ymUzav3+/UT5q1CiVLFlSVlZWWrFihQUjBAAAAICXx/Dhw82+f509e1Z16tRRiRIlVLp0aW3evNk4NiwsTEWKFFFgYKACAwPVp08fo+7XX39VuXLlZGdnp969e2d5PwAAeJ5IZCCN4OBgffTRR8Z+pUqVlJiYKGdnZ0lSRESE8uTJY5ngMkl8fLxMJpN2795tVj558mRFRERYJKZ/MplMWr58eZZft2nTptq8ebM8PDzMymvWrKnIyEhVrVo1y2MCAAAAgJfRzp07tW3bNhUtWtQo69+/v9566y0dOnRIs2fPVps2bXTnzh2z+t27d2v37t0aN26cUV6iRAnNnDnTLLkBAMDLwsbSASD7s7W1laurq6XDyBL3kzWvsoclKipUqJDFkQAAAADAy+vmzZvq3r27/vOf/6h69epG+aJFi3Ts2DFJUvny5VWoUCFt3rxZwcHBj2zP29tbkrRs2bLnFjMAAJbCiAyYCQsLU3R0tCZPniyTySSTyaSIiAhjaqmoqCh17NhRSUlJRv2wYcPSbSspKUldu3ZVwYIF5eTkpBo1amjPnj1PFMeePXtUvXp1OTo6ysnJSW+88YZiYmKM+q1bt6pq1aqyt7eXu7u7evbsqatXrxr1np6eGjVqlMLDw+Xo6KiiRYvq22+/NeqLFSsmSSpbtqxMJpPxQPjPqaWCg4P1wQcf6KOPPlLevHlVqFAhffvtt7p69ao6duwoR0dHvf7661q5cqVZ/AcOHFC9evXk4OCgQoUKqV27djp//rxZuz179lTfvn2VL18+ubq6mt1HT09PSdK7774rk8lk7P/TzZs3lZycbLYBAAAAmY3nTiDzDRkyRG3btjW+n0rShQsXlJKSogIFChhlnp6eSkhIMPa/+OILlSlTRg0aNEgzywAAAC8rEhkwM3nyZFWsWFFdunRRYmKiEhMT5e7ubtRXqlRJkyZNkpOTk1Gf3tybqampql+/vk6fPq3IyEjFxsYqKChINWvW1MWLFx8bR5s2bVSkSBH98ccfio2NVf/+/ZUjRw5J0r59+1S7dm2FhoZq7969WrhwoTZv3qwePXqYtTFhwgSVK1dOu3bt0vvvv6/33ntP//3vfyVJO3bskCStXbtWiYmJWrp06UNjmTNnjvLnz68dO3bogw8+0HvvvadmzZqpUqVK2rlzp2rXrq127drp2rVrkqTExERVq1ZNgYGBiomJ0apVq3TmzBk1b948Tbu5c+fW9u3bNXbsWH366adas2aNJOmPP/6QJM2ePVuJiYnG/j+NHj1azs7OxvbgvxUAAACQWXjuBDLX77//rj/++EPvv/9+mjqTyWS2n5qaavz92Wef6fDhw9q7d686deqkunXr6sqVK889XgAALI1EBsw4OzvL1tZWuXLlkqurq1xdXWVtbW3U29raytnZWSaTyah3cHBI086GDRu0b98+LV68WOXKlVOJEiU0fvx45cmTR0uWLHlsHAkJCQoJCVGpUqVUokQJNWvWTAEBAZKkcePGqXXr1vroo49UokQJVapUSV9++aW+//573bhxw2ijXr16ev/991W8eHH169dP+fPnV1RUlCQZb7e4uLjI1dVV+fLle2gsAQEBGjRokEqUKKEBAwbI3t5e+fPnV5cuXVSiRAkNGTJEFy5c0N69eyVJX3/9tYKCgjRq1CiVKlVKZcuW1axZs7Rhwwb99ddfRrtlypTR0KFDVaJECbVv317lypXTunXrzOLLkyePXF1dzd7GedCAAQOUlJRkbCdOnHjsvQUAAACeFs+dQOaKjo7Wf//7XxUrVkyenp46efKkateubbx0d+7cOePY48ePG2tovPbaa7KyuvdTzrvvvisnJycdPHgw6zsAAEAWI5GB5yI2NlZXrlyRi4uLHBwcjO3YsWM6cuTIY8/v1auXOnfurJCQEI0ZM8bsnNjYWEVERJi1W7t2baWkpBjziEr3EgX33U+8nD179qn78mA71tbWcnFxkb+/v1FWqFAhSTLajo2N1YYNG8ziK1WqlCSZ9ePBdiXJzc3tqeOzs7OTk5OT2QYAAABkNp47gczVv39/nTp1SvHx8YqPj1eRIkW0evVq1a1bV82aNdPUqVMl3Rutf/r0aVWpUkWSdPLkSaONbdu26cKFCypevLhF+gAAQFZisW88FykpKXJzczNGQDwoT548jz1/2LBhat26tX799VetXLlSQ4cO1YIFC/Tuu+8qJSVF//73v9WzZ880591/S0WSMRXVfSaTSSkpKU/dl/TaebDs/rDf+22npKToX//6lz7//PM0bbm5uWV6fJmte/fu+umnn3T69GmFhITIwcFBhw8f1ujRozV16lSdO3dOYWFhypkzp3bt2vXQ0SIAAAAAgKf3+eefq127dipRooRsbW01d+5c2djc+/kmLCxMZ86ckbW1tezt7bV48WI5OztLkqKiotS2bVslJycrNTVVCxYs0LRp09SwYUNLdgcAgExBIgNp2Nra6u7duxmul6SgoCCdPn1aNjY2D12o+nG8vb3l7e2tjz/+WK1atdLs2bP17rvvKigoSH/++eczvXVia2srSY/tR0YEBQXpxx9/lKenp/GwmRE5cuR4LvE9ztSpU423fx40YMAADRgwIMvjAQAAAICXXXx8vPF3oUKF9Ntvv6V73Nq1ax/aRnBwsNmIDQAAXiZMLYU0PD09tX37dsXHx+v8+fNpRgl4enrqypUrWrdunc6fP28scv2gkJAQVaxYUY0bN9bq1asVHx+vrVu3atCgQYqJiXnk9a9fv64ePXooKipKx48f15YtW/THH3/Ix8dHktSvXz/9/vvv6t69u3bv3q1Dhw7p559/1gcffPDEfSxYsKDs7e2NhbiTkpKe+NzH6d69uy5evKhWrVppx44dOnr0qH777TeFh4c/VWLC09NT69at0+nTp3Xp0qVMiw8AAAAAAAAAXiQkMpBG7969ZW1tLV9fXxUoUEAJCQlm9ZUqVVK3bt3UokULFShQQGPHjk3ThslkUmRkpKpWrarw8HB5e3urZcuWio+PN9aUeBhra2tduHBB7du3l7e3t5o3b666detq+PDhku6tLREdHa1Dhw7p7bffVtmyZTV48GCzaZsex8bGRl9++aWmT5+uwoULq1GjRk987uMULlxYW7Zs0d27d1W7dm2VLl1aH374oZydnY1F2Z7EhAkTtGbNGrm7u6ts2bKZFh8AAAAAAAAAvEhMqampqZYOAkDmSE5OlrOzs9qOWyFb+9wPPW5m9+CsCwoAAAAvnfvPnUlTXpeTvbWlwwGyp/CDlo4AAICXBiMyAAAAAAAAAABAtkUiAxbh5+cnBweHdLd58+ZZOjwAAAAAAAAAQDZhY+kA8GqKjIzU7du306173BoaAAAAAAAAAIBXB4kMWISHh4elQwAAAAAAAAAAvABY7Bt4iRiLLiYlycnJydLhAAAA4CXFcycAAACyEmtkAAAAAAAAAACAbItEBgAAAAAAAAAAyLZIZAAAAAAAAAAAgGyLRAYAAAAAAAAAAMi2SGQAAAAAAAAAAIBsy8bSAQDIfN2/3SRb+9yWDiPDZnYPtnQIAAAAeBJzgyR7a0tHAZgLP2jpCAAAQCZjRAYAAAAAAAAAAMi2SGQAAAAAAAAAAIBsi0QGAAAAAAAAAADItkhkAAAAAAAAAACAbItEBgAAAAAAAAAAyLZIZAAAAAAAAAAAgGyLRAaeq+DgYH300UeWDiNDvv32W7m7u8vKykqTJk166vOHDRumwMDATI8LAAAAAAAAAF4lJDKAdCQnJ6tHjx7q16+f/ve//6lr166WDgkPuHnzpnr06KESJUrIz89Pbdu2NaufM2eOTCaTVqxYYaEIAQAAAGRX77zzjsqUKaPAwEC9/fbb2r17tySpY8eORnn58uW1bt0645ymTZsqMDDQ2KysrPTzzz9Lkn799VeVK1dOdnZ26t27tyW6BADAS8/G0gEAme3WrVuytbV9pjYSEhJ0+/Zt1a9fX25ubpkUGTJL//79ZWVlpb/++ksmk0mJiYlG3cmTJzV9+nS99dZbFowQAAAAQHa1aNEi5cmTR5K0fPlyhYeHa+fOnZo4caJRvnv3boWEhOjcuXMymUxasmSJcX5MTIzq1Kmj2rVrS5JKlCihmTNnavHixbpx40ZWdwcAgFcCIzLw3KWkpKhv377Kly+fXF1dNWzYMKMuISFBjRo1koODg5ycnNS8eXOdOXPGqA8LC1Pjxo3N2vvoo48UHBxs7AcHB6tHjx7q1auX8ufPr1q1aj02pkddNyIiQv7+/pIkLy8vmUwmxcfHP7bNMWPGqFChQnJ0dFSnTp3SPMD+8ccfqlWrlvLnzy9nZ2dVq1ZNO3fuNOrDw8PVoEEDs3Pu3LkjV1dXzZo167HXf1VcvXpVs2fP1qhRo2QymSTJLNnUtWtXTZw4UXZ2dpYKEQAAAEA2dj9ZIUlJSUmysrJKU/73338b3zf+adasWWrbtq3xncPb21sBAQGyseFdUQAAnhcSGXju5syZo9y5c2v79u0aO3asPv30U61Zs0apqalq3LixLl68qOjoaK1Zs0ZHjhxRixYtMnQNGxsbbdmyRdOnT3/ksY+7bosWLbR27VpJ0o4dO5SYmCh3d/dHtrlo0SINHTpUn332mWJiYuTm5qZp06aZHXP58mV16NBBmzZt0rZt21SiRAnVq1dPly9fliR17txZq1atMhtdEBkZqStXrqh58+bpXvfmzZtKTk422152R44ckYuLi0aOHKly5crp7bffNoZ8f/311/Lz81OFChUsHCUAAMDL5VV87sTLrX379nJ3d9egQYM0Z84co7x///56/fXXFRoaqsWLF6dJZty4cUPz589Xp06dsjpkAABeabwugOeuTJkyGjp0qKR7Q26nTJli/PC8d+9eHTt2zEgUzJ07V35+fvrjjz9Uvnz5J75G8eLFNXbs2Cc6du3atY+9rouLiySpQIECcnV1fWybkyZNUnh4uDp37ixJGjlypNauXWs2KqNGjRpm50yfPl158+ZVdHS0GjRooEqVKqlkyZKaO3eu+vbtK0maPXu2mjVrJgcHh3SvO3r0aA0fPvyJ+v2yuH37to4ePSpfX1+NGTNGe/bsUUhIiCIjIzVjxgxt2bLF0iECAAC8dF7F50683L7//ntJ916K69OnjyIjIyXdG2k/ZswYrV27Vn369NGWLVvMpi7+8ccfVaJECWMUPwAAyBqMyMBzV6ZMGbN9Nzc3nT17VnFxcXJ3dzcb7eDr66s8efIoLi7uqa5Rrly5Jz42M6/7YJsVK1Y0K/vn/tmzZ9WtWzd5e3vL2dlZzs7OunLlihISEoxjOnfurNmzZxvH//rrrwoPD3/odQcMGKCkpCRjO3HiRIbif5F4eHjIyspKbdq0kSQFBASoWLFiOnTokE6dOiUfHx95enpq27Zt6tSpk2bMmGHhiAEAAF58r+JzJ14NHTp00IYNG3ThwgWz8pCQEF2+fFn79u0zK585cyajMQAAsABGZOC5y5Ejh9m+yWRSSkqKUlNT051z9MFyKysrpaammtXfvn07zTm5c+d+4nie5LrPQ1hYmM6dO6dJkybJw8NDdnZ2qlixom7dumUc0759e/Xv31+///67fv/9d3l6eurtt99+aJt2dnav3FoQ+fPnV82aNbV69WrVq1dPx48f17Fjx1S9enWdPn3aOC44OFi9e/dOs+4IAAAAnt6r+NyJl1NycrKuXLmiwoULS5KWLVsmFxcXOTk56dChQypRooSke9MMnz17Vl5eXsa5x44d044dO7R8+XJLhA4AwCuNRAYsxtfXVwkJCTpx4oQxOuLAgQNKSkqSj4+PpHtTO+3fv9/svN27d6dJjmT2dZ+Wj4+Ptm3bpvbt2xtl27ZtMztm06ZNmjZtmurVqydJOnHihM6fP292jIuLixo3bqzZs2fr999/V8eOHTMUz8vum2++UXh4uPr16ydra2t9++23Zgt+AwAAAEB6kpKS1KRJE12/fl1WVlYqUKCAVqxYoZSUFIWFhSkpKUnW1tbKnTu3lixZorx58xrnzpo1S02aNJGTk5NZm1FRUWrbtq2Sk5OVmpqqBQsWaNq0aWrYsGFWdw8AgJcWiQxYTEhIiMqUKaM2bdpo0qRJunPnjt5//31Vq1bNmCqqRo0aGjdunL7//ntVrFhRP/zwg/bv36+yZcs+1+s+rQ8//FAdOnRQuXLlVKVKFc2bN09//vmn2ds7xYsX19y5c1WuXDklJyerT58+sre3T9NW586d1aBBA929e1cdOnTIcD9fZl5eXoqKinrkMY+rBwAAAPDqcXd3144dO9Kte9x6eyNGjEi3PDg4WCdPnnzm2AAAwMOxRgYsxmQyafny5cqbN6+qVq2qkJAQeXl5aeHChcYxtWvX1uDBg9W3b1+VL19ely9fNhv18Lyu+7RatGihIUOGqF+/fnrjjTd0/Phxvffee2bHzJo1S5cuXVLZsmXVrl079ezZUwULFkzTVkhIiNzc3FS7dm1juDMAAAAAAAAAvKpMqf9cgACARV27dk2FCxfWrFmzFBoa+lTnJicny9nZWW3HrZCt/ZOvG5LdzOwebOkQAAAA8Aj3nzuTprwuJ3trS4cDmAs/aOkIAABAJmNqKSCbSElJ0enTpzVhwgQ5OzsznyoAAAAAAAAAiKml8BKaN2+eHBwc0t38/Pwy1Kafn99D25w3b16mxJ2QkKDXXntNixYt0qxZs2RjQ54RAAAAAAAAAPilFC+dhg0bqkKFCunW5ciRI0NtRkZG6vbt2+nWFSpUKENt/pOnp6eY6Q0AAAAAAAAAzJHIwEvH0dFRjo6Omdqmh4dHprYHAAAAAAAAAHgyLPYNvESMRReTkuTk5GTpcAAAAPCS4rkTAAAAWYk1MgAAAAAAAAAAQLZFIgMAAAAAAAAAAGRbJDIAAAAAAAAAAEC2RSIDAAAAAAAAAABkWyQyAAAAAAAAAABAtmVj6QAAZL7u326SrX1us7KZ3YMtEwwAAABeXnODJHtrS0eBzBZ+0NIRAAAAmGFEBgAAAAAAAAAAyLZIZAAAAAAAAAAAgGyLRAYAAAAAAAAAAMi2SGQAAAAAAAAAAIBsi0QGAAAAAAAAAADItkhkAAAAAAAAAACAbItExiskPj5eJpNJu3fvNsq2bNkif39/5ciRQ40bN7ZYbNlFevcIAAAAAAAAAGA5JDJecb169VJgYKCOHTumiIgIDRs2TIGBgZl+nefV7rMICwtLk7xxd3dXYmKiSpcubZmgHpCV9+zvv/9WYGCgsXl7e8vGxkYXL17MkusDAAAAeDHcuHFDjRs3lre3twIDA1WnTh3Fx8dLkjp27KgyZcooMDBQ5cuX17p164zzDh06pFq1aikgIEB+fn5auHChUffrr7+qXLlysrOzU+/evbO6SwAA4AVgY+kAYFlHjhxRt27dVKRIEUuHki1YW1vL1dXV0mFkuTx58piNQhk/fryio6OVL18+ywUFAAAAIFvq2rWr6tatK5PJpClTpqhr16767bffNHHiROXJk0eStHv3boWEhOjcuXMymUwKCwtTly5dFBYWpjNnzqh8+fKqUqWKXnvtNZUoUUIzZ87U4sWLdePGDct2DgAAZEuMyHgBLVmyRP7+/rK3t5eLi4tCQkJ09epVSdLs2bPl4+OjnDlzqlSpUpo2bVq6bdyfQunChQsKDw+XyWRSRESEhg8frj179shkMhllkpSUlKSuXbuqYMGCcnJyUo0aNbRnzx5J0rlz5+Tq6qpRo0YZ7W/fvl22trb67bffHtnuowwbNkxFixaVnZ2dChcurJ49exp1t27dUt++ffXaa68pd+7cqlChgqKiooz6iIgI5cmTR6tXr5aPj48cHBxUp04dJSYmGm3PmTNHP/30kxFTVFRUmqmloqKiZDKZtHr1apUtW1b29vaqUaOGzp49q5UrV8rHx0dOTk5q1aqVrl27Zlw/NTVVY8eOlZeXl+zt7RUQEKAlS5YY9ffbXbduncqVK6dcuXKpUqVKOnjwoBF/Ru5ZZpk9e7Y6deqUZdcDAAAA8GLImTOn6tWrJ5PJJEl66623dPToUUkykhjSvVHf94+RpD179qhevXqSpEKFCikgIMAYleHt7a2AgADZ2PCuJQAASB9PCS+YxMREtWrVSmPHjtW7776ry5cva9OmTUpNTdWMGTM0dOhQTZkyRWXLltWuXbvUpUsX5c6dWx06dDBr5/4USiVLltSnn36qFi1ayNnZWfv379eqVau0du1aSZKzs7NSU1NVv3595cuXT5GRkXJ2dtb06dNVs2ZN/fXXXypQoIBmzZqlxo0b65133lGpUqXUtm1bvf/++3rnnXd0/fr1dNt9lCVLlmjixIlasGCB/Pz8dPr0aSNxIt0bshwfH68FCxaocOHCWrZsmerUqaN9+/apRIkSkqRr165p/Pjxmjt3rqysrNS2bVv17t1b8+bNU+/evRUXF6fk5GTNnj1bkpQvXz6dOnUq3XiGDRumKVOmKFeuXGrevLmaN28uOzs7/ec//9GVK1f07rvv6quvvlK/fv0kSYMGDdLSpUv19ddfq0SJEtq4caPatm2rAgUKqFq1aka7AwcO1IQJE1SgQAF169ZN4eHh2rJli1q0aPFE9+zmzZu6efOmsZ+cnPzI+/okfv/9d124cEENGjR45rYAAADwcngez514OXz55Zf617/+Zez3799fixcv1qVLl7R06VIjmVG+fHn98MMP6tWrl44cOaKtW7eqWLFilgobAAC8YEhkvGASExN1584dhYaGysPDQ5Lk7+8vSRoxYoQmTJig0NBQSVKxYsV04MABTZ8+PU0i4/4USiaTSc7OzsZ0Sg4ODrKxsTGbXmn9+vXat2+fzp49Kzs7O0n3ph5avny5lixZoq5du6pevXrq0qWL2rRpo/LlyytnzpwaM2aMJMne3j7ddh8lISFBrq6uCgkJUY4cOVS0aFG9+eabku5NhzV//nydPHlShQsXliT17t1bq1at0uzZs42RIbdv39Y333yj119/XZLUo0cPffrpp0Y/7e3tdfPmzSeKaeTIkapcubIkqVOnThowYICOHDkiLy8vSVLTpk21YcMG9evXT1evXtUXX3yh9evXq2LFipIkLy8vbd68WdOnTzdLZHz22WfGfv/+/VW/fn3duHHjie/Z6NGjNXz48Ce6p09q1qxZat++PW9DAQAAwPA8njvx4hs1apQOHTqkb775xigbM2aMxowZo7Vr16pPnz7asmWLbG1tFRERod69eyswMFBeXl7Gdz0AAIAnwdRSL5iAgADVrFlT/v7+atasmWbMmKFLly7p3LlzOnHihDp16iQHBwdjGzlypI4cOfJM14yNjdWVK1fk4uJi1vaxY8fM2h4/frzu3LmjRYsWad68ecqZM2eGr9msWTNdv35dXl5e6tKli5YtW6Y7d+5Iknbu3KnU1FR5e3ubxRMdHW0WT65cuYwkhiS5ubnp7NmzGYqnTJkyxt+FChVSrly5jCTG/bL7bR84cEA3btxQrVq1zOL7/vvv0/xbPNium5ubJD1VjAMGDFBSUpKxnThxIkP9u+/q1atauHChwsPDn6kdAAAAvFwy+7kTL77x48dr6dKlWrlypXLlypWmPiQkRJcvX9a+ffskSR4eHlq8eLF2796tpUuXKikpSb6+vlkdNgAAeEHxyvULxtraWmvWrNHWrVv122+/6auvvtLAgQP1yy+/SJJmzJihChUqpDnnWaSkpMjNzc1sDYr7HpwD9ejRozp16pRSUlJ0/Phxsx/pn5a7u7sOHjyoNWvWaO3atXr//fc1btw4RUdHKyUlRdbW1oqNjU3TNwcHB+Pvf77dYzKZlJqamqF4HmzLZDKl23ZKSookGf/566+/6rXXXjM77v6Iloe1++D5T8LOzi5Nm89i8eLFKlOmjEqVKpVpbQIAAODFl9nPnXixffHFF5o/f77Wrl1rfCe8c+eOjh07Zkz1u2PHDp09e9Z4AezMmTMqWLCgsQbhgQMH1Lp1a0t1AQAAvGBIZLyATCaTKleurMqVK2vIkCHy8PDQli1b9Nprr+no0aNq06ZNhtu2tbXV3bt3zcqCgoJ0+vRp2djYyNPTM93zbt26pTZt2qhFixYqVaqUOnXqpH379qlQoUIPbfdx7O3t1bBhQzVs2FDdu3dXqVKltG/fPpUtW1Z3797V2bNn9fbbb2eonxmN6Un4+vrKzs5OCQkJZtNIPa3nFd+jzJw5k0W+AQAAADzUyZMn9cknn8jLy0vVq1eXdC/RtXHjRoWFhSkpKUnW1tbKnTu3lixZorx580qSfvnlF40ZM0Y2NjZyc3NTZGSk7O3tJUlRUVFq27atkpOTlZqaqgULFmjatGlq2LChxfoJAACyFxIZL5jt27dr3bp1euedd1SwYEFt375d586dk4+Pj4YNG6aePXvKyclJdevW1c2bNxUTE6NLly6pV69eT9S+p6enjh07pt27d6tIkSJydHRUSEiIKlasqMaNG+vzzz9XyZIlderUKUVGRqpx48YqV66cBg4cqKSkJH355ZdycHDQypUr1alTJ61YseKh7T7qja6IiAjdvXtXFSpUUK5cuTR37lzZ29vLw8NDLi4uatOmjdq3b68JEyaobNmyOn/+vNavXy9/f3/Vq1fvifu6evVqHTx4UC4uLo9dgPxJOTo6qnfv3vr444+VkpKiKlWqKDk5WVu3bpWDg0Oa9UoeFd/T3LPMsGnTpufaPgAAAIAXW5EiRR460n3Lli0PPa9z587q3LlzunXBwcE6efJkpsQHAABeTs+0Rsaff/6pli1b6vXXX5ednZ127twpSRo4cKBWrlyZKQHCnJOTkzZu3Kh69erJ29tbgwYN0oQJE1S3bl117txZ3333nSIiIuTv769q1aopIiJCxYoVe+L2mzRpojp16qh69eoqUKCA5s+fL5PJpMjISFWtWlXh4eHy9vZWy5YtFR8fr0KFCikqKkqTJk3S3Llz5eTkJCsrK82dO1ebN2/W119//dB2HyVPnjyaMWOGKleurDJlymjdunX65Zdf5OLiIkmaPXu22rdvr08++UQlS5ZUw4YNtX37drm7uz9xX7t06aKSJUuqXLlyKlCgwCMfup/WiBEjNGTIEI0ePVo+Pj6qXbu2fvnll2f+twAAAAAAAACAV40pNYOLBqxZs0b169dXUFCQatasqdGjRysmJkZBQUEaNmyYYmNjjXUbAGSN5ORkOTs7q+24FbK1z21WN7N7sGWCAgAAwEvn/nNn0pTX5WT/bGvyIRsKP2jpCAAAAMxkeETGgAED1LJlS23btk3Dhw83qytbtqx27dr1zMEBAAAAAAAAAIBXW4YTGfv371e7du0k3Vt8+kF58uTR+fPnny0yvNTmzZsnBweHdDc/Pz9LhwcAAAAAAAAAyCYyvNh3vnz5dOrUqXTr/vrrL7m5uWU4KLz8GjZsqAoVKqRblyNHjiyOBgAAAAAAAACQXWU4kdG4cWMNHTpUb731looXLy7p3siM06dPa/z48WrSpEmmBYmXj6OjoxwdHS0dBgAAAAAAAAAgm8vwYt9JSUkKCQnR3r175e/vr507dyogIEBHjx5VyZIltX79ejk4OGR2vAAewVh0MSlJTk5Olg4HAAAALymeOwEAAJCVMjwiw9nZWVu3btUPP/ygNWvWKF++fMqXL5+6d++u9u3by9bWNjPjBAAAAAAAAAAAr6AMjci4ceOGmjdvrk8++UTVqlV7HnEByADejAMAAEBW4LkTAAAAWckqIyflzJlT0dHRSklJyex4AAAAAAAAAAAADBlKZEjSO++8ozVr1mRmLAAAAAAAAAAAAGYyvEZGx44d1a1bN125ckV169ZVwYIFZTKZzI4JCgp65gABAAAAAAAAAMCrK0NrZEiSlZX5YI4HkxipqakymUy6e/fus0UH4KkwVzEAAACygvHcOeV1OdlbWzqcl0f4QUtHAAAAkC1leETGhg0bMjMOAAAAAAAAAACANDKcyKhWrVpmxgEAAAAAAAAAAJBGhhf7BgAAAAAAAAAAeN4yPCLDysoqzeLe/8QaGQAAAAAAAAAA4FlkOJExduzYNImMixcvas2aNTpz5ow++OCDZw4OAAAAAAAAAAC82jKcyOjdu3e65Z999pnatm2r5OTkDAcFAAAAAAAAAAAgPac1Mtq3b69vv/32eTQNAAAAAAAAAABeIc8lkfHXX3+xPgYMwcHB+uijjywdhuHbb7+Vu7u7rKysNGnSJEuHYyY+Pl4mk0m7d++2dCgAAAAAspGePXvK09NTJpNJ+/fvN8orVaqkwMBABQYGqnTp0jKZTNq7d68k6dq1a2rVqpWKFy8ub29vLV261DjvzJkzCg0NVZkyZVSqVKls990IAADgQRmeWuqLL75IU3br1i3FxcVp8eLFat269TMFBjwPycnJ6tGjh7744gs1adJEzs7Olg4JAAAAAB6radOm6tu3r6pUqWJWvnXrVuPvJUuWaPjw4SpTpowkafz48bKzs9Phw4d17NgxVaxYUdWrV1fevHnVq1cv+fv7a+nSpbpy5YoqVaqkypUrq3z58lnaLwAAgCeRqWtk2NnZqUiRIvrwww81ePDgZwoMeB4SEhJ0+/Zt1a9fX25ubpYOBwAAAACeSNWqVR97zKxZs9SpUydjf+HChYqIiJAkFStWTFWrVtVPP/2ksLAw7dmzRx9++KEkycHBQdWqVdPcuXNJZAAAgGwpw1NLpaSkpNmuX7+uQ4cOafTo0cqVK1dmxokXxNWrV9W+fXs5ODjIzc1NEyZMMKv/4YcfVK5cOTk6OsrV1VWtW7fW2bNnJUmpqakqXry4xo8fb3bO/v37ZWVlpSNHjjz2+gkJCWrUqJEcHBzk5OSk5s2b68yZM5KkiIgI+fv7S5K8vLxkMpkUHx//0LaSkpJkbW2t2NhYI758+fKZPdjPnz/fLCHyv//9Ty1atFDevHnl4uKiRo0apbnG7Nmz5ePjo5w5c6pUqVKaNm3aQ2NISUlRly5d5O3trePHj6epv3nzppKTk802AAAAILPx3Jn9/e9//1NUVJTatm1rlCUkJMjDw8PY9/T0VEJCgiSpfPny+s9//qOUlBSdPXtWq1evfuT3IwAAAEvKcCLj+++/14ULF9Ktu3jxor7//vsMB4UXV58+fbRhwwYtW7ZMv/32m6KiooxEgHRv+rERI0Zoz549Wr58uY4dO6awsDBJkslkUnh4uGbPnm3W5qxZs/T222/r9ddff+S1U1NT1bhxY128eFHR0dFas2aNjhw5ohYtWkiSWrRoobVr10qSduzYocTERLm7uz+0PWdnZwUGBioqKkqSjHlm9+7da3xxi4qKUrVq1STdm3+2evXqcnBw0MaNG7V582Y5ODioTp06unXrliRpxowZGjhwoD777DPFxcVp1KhRGjx4sObMmZPm+rdu3VLz5s0VExOjzZs3m30BuW/06NFydnY2tkf1BwAAAMgonjuzv4iICDVo0ED58+c3KzeZTMbfqampxt8TJkxQcnKygoKC1L59e9WoUUM5cuTIsngBAACeRoYTGR07dnzoG/LHjh1Tx44dMxwUXkxXrlzRzJkzNX78eNWqVUv+/v6aM2eO2cLv4eHhqlu3rry8vPTWW2/pyy+/1MqVK3XlyhVJ9z5XBw8e1I4dOyRJt2/f1g8//KDw8PDHXn/t2rXau3ev/vOf/+iNN95QhQoVNHfuXEVHR+uPP/6Qvb29XFxcJEkFChSQq6urrK2tH9lmcHCwkciIiopSzZo1Vbp0aW3evNkoCw4OliQtWLBAVlZW+u677+Tv7y8fHx/Nnj1bCQkJRhsjRozQhAkTFBoaqmLFiik0NFQff/yxpk+fnuZe1q9fX6dPn1ZUVJQKFiyYbnwDBgxQUlKSsZ04ceKx9wkAAAB4Wjx3Zm+pqamaPXu22bRSklS0aFGzURbHjx9X0aJFJUn58uXTrFmztHv3bq1atUqS5Ovrm2UxAwAAPI0MJzIefJPjny5duiRHR8eMNo0X1JEjR3Tr1i1VrFjRKMuXL59Klixp7O/atUuNGjWSh4eHHB0djSTA/eHNbm5uql+/vmbNmiVJWrFihW7cuKFmzZo99vpxcXFyd3c3ezvM19dXefLkUVxcXIb6FBwcrE2bNiklJUXR0dEKDg5WcHCwoqOjdfr0af3111/GiIzY2FgdPnxYjo6OcnBwkIODg/Lly6cbN27oyJEjOnfunE6cOKFOnToZ9Q4ODho5cmSapGCrVq105coV/fbbb49ckNzOzk5OTk5mGwAAAJDZeO7M3qKjo3Xr1i3VqlXLrLxZs2aaOnWqpHsvHEZHR6thw4aSpAsXLuj27duSpJ07d2r58uV6//33szZwAACAJ/RUi32vXLlSK1euNPYnTJigQoUKmR1z48YNrV+/XoGBgZkSIF4cj0puSffWz3jnnXf0zjvv6IcfflCBAgWUkJCg2rVrG1MvSVLnzp3Vrl07TZw4UbNnz1aLFi2eaM2V1NRUs2HTjyt/ElWrVtXly5e1c+dObdq0SSNGjJC7u7tGjRqlwMBAFSxYUD4+PpLurWfxxhtvaN68eWnaKVCggG7cuCHp3vRSFSpUMKv/58iQevXq6YcfftC2bdtUo0aNDMUOAAAA4OXRvXt3/fTTTzp9+rRCQkLk4OCgw4cPS5Jmzpypjh07ysrK/F3FPn36KDw8XMWLF5eVlZWmTp2qfPnySbo33e4HH3ygHDlyyNHRUYsWLTJb/w8AACA7eapExl9//aVffvlF0r15Njdt2iQ7OzuzY2xtbVW6dGmNGjUq86LEC6F48eLKkSOHtm3bZgxXvnTpkjFq4b///a/Onz+vMWPGGKMmYmJi0rRTr1495c6dW19//bVWrlypjRs3PtH1fX19lZCQoBMnThjtHzhwQElJSUay4WndXydjypQpMplM8vX1VeHChbVr1y6tWLHCGI0hSUFBQVq4cKEKFiyY7htqzs7Oeu2113T06FG1adPmkdd97733VLp0aTVs2FC//vqr2XUAAAAAvHqmTp1qjK74p7lz56Zbnjt3bi1cuDDdurp16xqJEAAAgOzuqRIZH374oT788ENJUrFixbR8+XIFBAQ8l8Dw4nFwcFCnTp3Up08fubi4qFChQho4cKDxVlDRokVla2urr776St26ddP+/fs1YsSINO1YW1srLCxMAwYMUPHixc2mqnqUkJAQlSlTRm3atNGkSZN0584dvf/++6pWrZrKlSuX4X4FBwdr8uTJevfdd2UymZQ3b175+vpq4cKF+vLLL43j2rRpo3HjxqlRo0b69NNPVaRIESUkJGjp0qXq06ePihQpomHDhqlnz55ycnJS3bp1dfPmTcXExOjSpUvq1auX2XU/+OAD3b17Vw0aNNDKlStVpUqVDPcBAAAAAAAAAF5UGV4j49ixYyQxkMa4ceNUtWpVNWzYUCEhIapSpYreeOMNSfemV4qIiNDixYvl6+urMWPGaPz48em206lTJ926deuJFvm+z2Qyafny5cqbN6+qVq2qkJAQeXl5PfQNpCdVvXp13b1711jPQ5KqVaumu3fvmo2UyJUrlzZu3KiiRYsqNDRUPj4+Cg8P1/Xr140RGp07d9Z3332niIgI+fv7q1q1aoqIiFCxYsXSvfZHH32k4cOHq169etq6desz9QMAAAAAAAAAXkSm1MctbPAYhw8f1l9//WXM//+g0NDQZ2kar7AtW7YoODhYJ0+eTLMOCx4uOTlZzs7OSkpKYgFGAAAAPDfGc+eU1+Vkb/34E/Bkwg9aOgIAAIBs6ammlnpQcnKyQkNDtWHDBkn/b6HnBxdVvnv37jOGh1fNzZs3deLECQ0ePFjNmzcniQEAAAAAAAAAr7gMTy3Vr18/JSYmatOmTUpNTdWyZcsUFRWlTp06qVixYtq2bVtmxolXxPz581WyZEklJSVp7NixZnXz5s2Tg4NDupufn1+Grufn5/fQNufNm5cZXQIAAAAAAAAAPIMMTy1VrFgxffbZZ2rRooVy5Mih7du3q3z58pKk3r176+TJk1qwYEGmBotX2+XLl3XmzJl063LkyCEPD4+nbvP48eO6fft2unWFChWSo6PjU7dpSUwtBQAAgKzA1FLPCVNLAQAApCvDU0udPXtW7u7usra2Vu7cuXXhwgWjrm7dumrSpEmmBAjc5+jomOmJhYwkPwAAAAAAAAAAWSfDiQx3d3edP39eklSiRAn9/PPPqlOnjiRp69atypkzZ+ZECAAAAADIntrtlBgJDAAAgOcsw4mMWrVqae3atXr33Xf18ccfq0OHDtq+fbtsbW21Y8cOffLJJ5kZJwAAAAAAAAAAeAVleI2Ma9eu6dq1a8qfP78kadmyZVqyZImuX7+uWrVq6d///resrDK8ljiADGCNDAAAAGQFnjsBAACQlTKcyACQ/fCFEgAAAFmB504AAABkpQxPLXVfXFycYmJidOLECYWHh8vV1VWHDx9WoUKFMn1hZgAAAAAAAAAA8GrJcCLj2rVr6ty5sxYtWiRJSk1NVZ06deTq6qoBAwaoWLFiGjt2bKYFCgAAAAAAAAAAXj0ZTmT07t1b69ev14oVK/T222+bjb6oV6+eJk6cSCIDsJDu326SrX1ui8Yws3uwRa8PAACALDA3SLK3tnQUL6bwg5aOAAAA4IWR4UTGkiVLNG7cONWpU0d37941q/P09FR8fPyzxgYAAAAAAAAAAF5xVhk98cqVK3Jzc0u37urVqxkOCAAAAAAAAAAA4L4MJzLKlCmjH3/8Md26X3/9VeXKlctwUAAAAAAAAAAAANIzTC01ePBgNWrUSNeuXVOzZs1kMpm0Y8cOzZ8/X7NmzVJkZGRmxgkAAAAAAAAAAF5BGR6RUb9+fS1YsECbN29W48aNlZqaqvfff18LFy7UvHnzVLNmzcyMEwAAAAAAAAAAvIKeakSGr6+vFi5cKH9/f0lS06ZNdePGDXl7e+vOnTvKly+fSpUq9VwCBQAAAAAAAAAAr56nGpHx3//+V9evXzf27969qw4dOsjGxkaVKlUiiZFNRUVFyWQy6e+//37kcZ6enpo0aVKmXHPYsGEKDAzMlLZeNCaTScuXL7d0GC+E4cOHy2Qyaf/+/Wblc+bMkclk0ooVKywUGQAAAGA5PXv2lKenZ5pn5dTUVA0bNkze3t4qXbq0goODjbpr166pVatWKl68uLy9vbV06VKzNn/88Uf5+/vLz89Pvr6+io+Pz6LeAAAAPLsMTy11X2pqambEgUwUHBysjz76yNivVKmSEhMT5ezsLEmKiIhQnjx5LBMc8P/buXOntm3bpqJFi5qVnzx5UtOnT9dbb71locgAAAAAy2ratKk2b94sDw8Ps/Ivv/xS+/bt0/79+7V//37Nnz/fqBs/frzs7Ox0+PBhrV69Wu+//74uXbokSdq1a5cGDRqk1atX688//9S2bdtUsGDBLO0TAADAs3jmRAayP1tbW7m6uspkMlk6FGTQrVu3LB1Cprp586a6d++uadOmpflcdu3aVRMnTpSdnZ2FogMAAAAsq2rVqipSpEia8nHjxunzzz+Xra2tJMnNzc2oW7hwobp37y5JKlasmKpWraqffvpJkjRhwgR98sknKly4sCTJyclJuXLlet7dAAAAyDRPnchI78dwfiDPPsLCwhQdHa3JkyfLZDLJZDIpIiLCmFoqKipKHTt2VFJSklE/bNiwdNtKSkpS165dVbBgQTk5OalGjRras2fPU8Uzd+5ceXp6ytnZWS1bttTly5eNulWrVqlKlSrKkyePXFxc1KBBAx05csSov3Xrlnr06CE3NzflzJlTnp6eGj169BNd12Qy6bvvvtO7776rXLlyqUSJEvr555+N+vRGpSxfvtzss3x/eqxZs2apaNGicnBw0Hvvvae7d+9q7NixcnV1VcGCBfXZZ5+luX5iYqLq1q0re3t7FStWTIsXLzar/9///qcWLVoob968cnFxUaNGjcyGdoeFhalx48YaPXq0ChcuLG9v73T7efPmTSUnJ5ttL4IhQ4aobdu2KlasmFn5119/LT8/P1WoUMFCkQEAACA9L+pz58skOTlZ586d07Jly/TWW2/prbfe0sKFC436hIQEsxEcnp6eSkhIkCQdOHBACQkJqlatmsqWLavBgwfr7t27Wd4HAACAjHrqREb16tXl5OQkJycn5c2bV5L09ttvG2X3t/vTGCFrTZ48WRUrVlSXLl2UmJioxMREubu7G/WVKlXSpEmT5OTkZNT37t07TTupqamqX7++Tp8+rcjISMXGxiooKEg1a9bUxYsXnyiWI0eOaPny5VqxYoVWrFih6OhojRkzxqi/evWqevXqpT/++EPr1q2TlZWV3n33XaWkpEi6N2z6559/1qJFi3Tw4EH98MMP8vT0fOJ7MXz4cDVv3lx79+5VvXr11KZNmyeO/cE+rFy5UqtWrdL8+fM1a9Ys1a9fXydPnlR0dLQ+//xzDRo0SNu2bTM7b/DgwWrSpIn27Nmjtm3bqlWrVoqLi5N0b+7a6tWry8HBQRs3btTmzZvl4OCgOnXqmI28WLduneLi4rRmzZqHrhUxevRoOTs7G9uD/9bZ1e+//64//vhD77//vln5sWPHNGPGDH366acWigwAAAAP8yI+d75sbt++rVu3bun69evatm2bFi1apF69epmtofHgi1kPTgN9+/ZtxcbGatWqVdqyZYt+//13TZ8+PUvjBwAAeBY2T3Pw0KFDn1ccyCTOzs6ytbVVrly55OrqKuneIu332draytnZWSaTyahPz4YNG7Rv3z6dPXvWmOJn/PjxWr58uZYsWaKuXbs+NpaUlBRFRETI0dFRktSuXTutW7fOGMHQpEkTs+NnzpypggUL6sCBAypdurQSEhJUokQJValSRSaTKc38sI8TFhamVq1aSZJGjRqlr776Sjt27FCdOnWeuI2UlBTNmjVLjo6O8vX1VfXq1XXw4EFFRkbKyspKJUuW1Oeff66oqCizNR2aNWumzp07S5JGjBihNWvW6KuvvtK0adO0YMECWVlZ6bvvvjO+aMyePVt58uRRVFSU3nnnHUlS7ty59d133xnDxtMzYMAA9erVy9hPTk7O9l8qo6Oj9d///tcYjXHy5EnVrl1bY8eO1alTp+Tj4yNJOn36tDp16qSRI0eqS5culgwZAADglfciPne+bFxcXOTg4KC2bdtKkooWLarKlSsrJiZGpUuXVtGiRRUfH68CBQpIko4fP6569epJkjw8PBQaGip7e3tJUmhoqHbs2JHm5SIAAIDsikQG0hUbG6srV67IxcXFrPz69etm0z89iqenp5HEkO7N33r27Flj/8iRIxo8eLC2bdum8+fPGyMxEhISVLp0aYWFhalWrVoqWbKk6tSpowYNGhg/8j+JMmXKGH/nzp1bjo6OZtfPSB8KFSoka2trWVlZmZX9s92KFSum2d+9e7eke/f28OHDZu1K0o0bN8zurb+//yOTGJJkZ2f3wq0l0b9/f/Xv39/Y9/T01IoVK1S6dGm1adPGKA8ODlbv3r3VoEEDS4QJAACAB7yIz50vo1atWmnVqlXGQt47duwwnq2bNWumqVOnKiIiQseOHVN0dLS++eYbSVLr1q31888/KywsTKmpqVqzZo2qVq1qya4AAAA8ladKZODVkZKSIjc3N0VFRaWp++faEg+TI0cOs32TyWQkKyTpX//6l9zd3TVjxgwVLlxYKSkpKl26tDG9UlBQkI4dO6aVK1dq7dq1at68uUJCQrRkyZJnvr6VlZXZUGvp3nDrJ2njcf16mPujL1JSUvTGG29o3rx5aY65//aUdC/5AgAAAODV0717d/300086ffq0QkJC5ODgoMOHD2vUqFHq2LGjpk2bJuneSJmgoCBJUp8+fRQeHq7ixYvLyspKU6dOVb58+SRJLVu2VExMjPz8/GRtba2qVauqR48eFusfAADA0yKR8RKytbV95MJtj6uX7iURTp8+LRsbm6dal+JJXbhwQXFxcZo+fbrefvttSdLmzZvTHOfk5KQWLVqoRYsWatq0qerUqaOLFy8aD+QZVaBAAV2+fFlXr141Egb3R0xkhm3btql9+/Zm+2XLlpV0794uXLjQWET9VffgIucPSi+JBgAAALwKpk6dqqlTp6Ypz58/v3755Zd0z8mdO7fZ4t8PsrKy0hdffKEvvvgiU+MEAADIKk+92DeyP09PT23fvl3x8fFmUzY9WH/lyhWtW7dO58+f17Vr19K0ERISoooVK6px48ZavXq14uPjtXXrVg0aNEgxMTHPHGPevHnl4uKib7/9VocPH9b69evN5tyVpIkTJ2rBggX673//q7/++kuLFy+Wq6vrE48IeZQKFSooV65c+r//+z8dPnxY//nPfxQREfHM7d63ePFizZo1S3/99ZeGDh2qHTt2GG88tWnTRvnz51ejRo20adMmY9j3hx9+qJMnT2ZaDAAAAAAAAADwMiCR8RLq3bu3rK2t5evrqwIFCighIcGsvlKlSurWrZtatGihAgUKaOzYsWnaMJlMioyMVNWqVRUeHi5vb2+1bNlS8fHxKlSo0DPHaGVlpQULFig2NlalS5fWxx9/rHHjxpkd4+DgoM8//1zlypVT+fLlFR8fbyyy/azy5cunH374QZGRkfL399f8+fM1bNiwZ273vuHDh2vBggUqU6aM5syZo3nz5snX11eSlCtXLm3cuFFFixZVaGiofHx8FB4eruvXrzNCAwAAAAAAAAD+wZT6z4UCALywkpOT5ezsrLbjVsjW3rJrbMzsHmzR6wMAAOD5uf/cmTTldTnZW1s6nBdT+EFLRwAAAPDCYEQGAAAAAAAAAADItkhkIEP8/Pzk4OCQ7jZv3rzneu158+Y99Np+fn7P9doAAAAAAAAAgKxlY+kA8GKKjIzU7du3063LjDU0HqVhw4aqUKFCunU5cuR4rtcGAAAAAAAAAGQtEhnIEA8PD4td29HRUY6Ojha7PgAAAAAAAAAg67DYN/ASMRZdTEqSk5OTpcMBAADAS4rnTgAAAGQl1sgAAAAAAAAAAADZFokMAAAAAAAAAACQbZHIAAAAAAAAAAAA2RaJDAAAAAAAAAAAkG2RyAAAAAAAAAAAANmWjaUDAJD5un+7Sbb2uS0dBtIxs3uwpUMAAADIPHODJHtrS0fx4gk/aOkIAAAAXiiMyAAAAAAAAAAAANkWiQwAAAAAAAAAAJBtkcgAAAAAAAAAAADZFokMAAAAAAAAAACQbZHIAAAAAAAAAAAA2RaJDAAAAAAAAAAAkG2RyECWCA4O1kcffWTpMAAAAAAAAAAALxgSGcgSS5cu1YgRI56pjeeVDMmOSZbsGBOev549e8rT01Mmk0n79+83yjt27KgyZcooMDBQ5cuX17p164y6pk2bKjAw0NisrKz0888/WyJ8AAAAZJKHPRcGBwfLy8vLePabOHGiUXfo0CHVqlVLAQEB8vPz08KFC83a/PHHH+Xv7y8/Pz/5+voqPj4+q7oDAADwzGwsHQBeDfny5bN0CEC217RpU/Xt21dVqlQxK584caLy5MkjSdq9e7dCQkJ07tw5mUwmLVmyxDguJiZGderUUe3atbMybAAAAGSyhz0XStKXX36pBg0apCkPCwtTly5dFBYWpjNnzqh8+fKqUqWKXnvtNe3atUuDBg3SunXrVLhwYSUnJ8vGhp8DAADAi4MRGcgSD44wmDZtmkqUKKGcOXOqUKFCatq06WPPDwsLU3R0tCZPniyTySSTyWS8QXTgwAHVq1dPDg4OKlSokNq1a6fz589LkqKiomRra6tNmzYZbU2YMEH58+dXYmLiI9t9mKioKJlMJv36668KCAhQzpw5VaFCBe3bt8/suB9//FF+fn6ys7OTp6enJkyYYFb/sPuQkZjwcqhataqKFCmSpvx+EkOS/v77b5lMpnTPnzVrltq2bSs7O7vnFSIAAACywMOeCx9lz549qlevniSpUKFCCggIMEZlTJgwQZ988okKFy4sSXJyclKuXLkyN2gAAIDniEQGslRMTIx69uypTz/9VAcPHtSqVatUtWrVx543efJkVaxYUV26dFFiYqISExPl7u6uxMREVatWTYGBgYqJidGqVat05swZNW/eXNL/S6C0a9dOSUlJ2rNnjwYOHKgZM2bIzc3toe0+iT59+mj8+PH6448/VLBgQTVs2FC3b9+WJMXGxqp58+Zq2bKl9u3bp2HDhmnw4MGKiIh47H14mphu3ryp5ORksw0vp/79++v1119XaGioFi9enCaZcePGDc2fP1+dOnWyUIQAAOBlxnNn9tGnTx/5+/urRYsWOnr0qFFevnx5/fDDD5KkI0eOaOvWrWYvfyUkJKhatWoqW7asBg8erLt371oifAAAgAxhLCmyVEJCgnLnzq0GDRrI0dFRHh4eKlu27GPPc3Z2lq2trXLlyiVXV1ej/Ouvv1ZQUJBGjRpllM2aNUvu7u7666+/5O3trZEjR2rt2rXq2rWr/vzzT7Vr107vvvvuI9t9EkOHDlWtWrUkSXPmzFGRIkW0bNkyNW/eXF988YVq1qypwYMHS5K8vb114MABjRs3TmFhYY+8D08T0+jRozV8+PCnihsvpjFjxmjMmDFau3at+vTpoy1btsjW1tao//HHH1WiRAn5+/tbMEoAAPCy4rkze5g7d67c3d2VmpqqqVOnqkGDBjpw4IAkKSIiQr1791ZgYKC8vLwUEhKiHDlySJJu376t2NhYrVq1SqmpqWrYsKGmT5+u999/35LdAQAAeGKMyECWqlWrljw8POTl5aV27dpp3rx5unbtWobbi42N1YYNG+Tg4GBspUqVknTvLSRJsrW11Q8//KAff/xR169f16RJkzKjK6pYsaLxd758+VSyZEnFxcVJkuLi4lS5cmWz4ytXrqxDhw7p7t27mXYfBgwYoKSkJGM7ceLEs3UK2V5ISIguX76cZiqzmTNnMhoDAAA8Nzx3Zg/3R2qbTCb16NFDR48e1YULFyRJHh4eWrx4sXbv3q2lS5cqKSlJvr6+Rl2TJk1kb2+vXLlyKTQ0VDt27LBYPwAAAJ4WiQxkKUdHR+3cuVPz58+Xm5ubhgwZooCAAP39998Zai8lJUX/+te/tHv3brPt0KFDZlNWbd26VZJ08eJFXbx4MTO6kq770/2kpqammfonNTXV+Duz7oOdnZ2cnJzMNrxc7ty5o0OHDhn7O3bs0NmzZ+Xl5WWUHTt2TDt27FCrVq0sESIAAHgF8NxpeXfu3NGZM2eM/R9//FGFChWSi4uLJOnMmTPGd47Vq1frwIEDat26tSSpdevW+u2335SSkqK7d+9qzZo1CggIyPpOAAAAZBBTSyHL2djYKCQkRCEhIRo6dKjy5Mmj9evXKzQ09JHn2drappnHNSgoSD/++KM8PT1lY5P+x/nIkSP6+OOPNWPGDC1atEjt27fXunXrZGVl9dB2n8S2bdtUtGhRSdKlS5f0119/GaNBfH19tXnzZrPjt27dKm9vb1lbWz/2PmQ0JrzYunfvrp9++kmnT59WSEiIHBwc9OeffyosLExJSUmytrZW7ty5tWTJEuXNm9c4b9asWWrSpAk/KAAAALwk0nsu3LNnj+rXr6+bN2/KyspK+fPn188//2yc88svv2jMmDGysbGRm5ubIiMjZW9vL0lq2bKlYmJi5OfnJ2tra1WtWlU9evSwVPcAAACemin1wdfEgeckODhYgYGBCgkJ0dGjR1W1alXlzZtXkZGR6tGjh/bu3Ss/P79HttG1a1ft3r1bixYtkoODg/Lly6fTp08rMDBQ1apVU58+fZQ/f34dPnxYCxYs0IwZMyRJb7/9ttzc3PTjjz/q9OnT8vf3V9++fdWnT5+Htns/yZGeqKgoVa9eXX5+fpo8ebIKFSqkgQMHGiNBbG1ttXPnTpUvX17Dhg1TixYt9Pvvv+u9997TtGnTFBYWphUrVjzyPjxtTPclJyfL2dlZbcetkK197qf4F0JWmdk92NIhAAAAPLP7z51JU16Xk721pcN58YQftHQEAAAALxSmlkKWypMnj5YuXaoaNWrIx8dH33zzjebPn//YJIYk9e7dW9bW1vL19VWBAgWUkJCgwoULa8uWLbp7965q166t0qVL68MPP5Szs7OsrKz02WefKT4+Xt9++60kydXVVd99950GDRqk3bt3P7TdJzFmzBh9+OGHeuONN5SYmKiff/7ZWHw5KChIixYt0oIFC1S6dGkNGTJEn376qcLCwp7oPmQ0JgAAAAAAAAB42TAiA3hK90dkXLp0SXny5LF0OGYYkZH9MSIDAAC8DBiR8YwYkQEAAPBUGJEBAAAAAAAAAACyLRIZyBYSEhLk4ODw0C0rp1bq1q3bQ+Po1q1blsUBAAAAAAAAAJBsLB0AIEmFCxc21qx4WH1W+fTTT9W7d+9065ycnFSwYEExIxsAAAAAAAAAZI3/r707D6uqav8//jmAoDKKieAETiAIiIrlCDg9lnNllpVENpkaWprpY+asOWulWVZqZTmklo+ZOULOKUY5pX5VoAFzhpwZ9u8Pf548IgoJnCO+X9e1rzh7rb32vdcmrWvsTgAAa51JREFUzzrcZ61NIgM2wcHBQTVq1LB2GJIkLy8veXl5WTsMAAAAAAAAAIB42DdQrJgfupiWJjc3N2uHAwAAgGKKcScAAACKEs/IAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzHKwdAICC1/vDjXIs5WztMGzCx72jrB0CAABA8fVZPamUvbWjyKnHAWtHAAAAgALEjAwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgpBVFSU+vXrZ+0wYAVJSUkymUxKTEy0digAAAAAAAAAUCyQyCgES5cu1ahRo6wdBgpZTEyMOnfubO0wcIdWrVql8PBwhYaGqmHDhvr5558lScePH9eDDz6omjVrKjg4WJs2bbJypAAAACgIZ8+eVVhYmHnz9/eXg4ODTp8+rZ07d6pRo0aqW7euAgMDNWHCBPNxMTExqlSpkvm4119/3YpXAQAAcG9xsHYAxZGnp6e1Q0Axc+XKFTk6Olo7jGLnzJkzevrpp7Vx40YFBgYqPj5eTz31lPbs2aNBgwapYcOGWrVqlXbs2KEuXbro8OHDcnDgn00AAIC7mYeHh8UM6kmTJik+Pl6enp5q2bKlRowYoY4dO+r06dOqVauW2rdvr6CgIEnSoEGD1KdPHytFDgAAcO9iRkYhuH5pqZkzZ6pmzZoqWbKkypcvry5duuSpjVWrVqlp06by8PBQ2bJl1b59ex0+fNhcfm0Jo6VLl6p58+YqXbq06tSpo61bt1q0s2TJEtWuXVtOTk7y8/PT5MmTLcr9/Pw0duxY9ejRQ66urqpSpYo+/PBDc3mLFi1yDNRPnTolJycnrV+/3tzG6NGjFR0dLRcXF/n6+uqbb77RiRMn1KlTJ7m4uCgkJEQ7d+7MV2wmk0lff/21xT4PDw/NnTtX0tU/7vfp00c+Pj4qWbKk/Pz8NG7cuDz175QpUxQSEiJnZ2dVrlxZvXr10rlz58zlw4cPV1hYmMUx06ZNk5+fn7l83rx5+uabb2QymWQymRQXF2eue+TIkTu+L6NHj1ZMTIzc3d31wgsv5Om6kD+HDx+Wl5eXAgMDJUmRkZFKTk7Wrl27tGjRIvXu3VuS1KBBA5UvX55ZGQAAAMXQnDlz9Nxzz5lfnz17VpJ0/vx5OTo68kU1AAAAG0AioxDt3LlTsbGxGjlypA4cOKBVq1YpIiIiT8eeP39er732mnbs2KF169bJzs5ODz/8sLKzsy3qDRkyRAMGDFBiYqL8/f3VrVs3ZWZmSpISEhLUtWtXPfHEE9q9e7eGDx+uoUOHmhMB10yePFnh4eH66aef1KtXL7388sv69ddfJUnPP/+8vvjiC12+fNlcf/78+apQoYKaN29u3jd16lQ1adJEP/30k9q1a6fu3bsrOjpaTz/9tHbt2qUaNWooOjpahmHkK7Zbeeedd7R8+XItWrRIBw4c0Oeff25ONNyOnZ2d3nnnHe3Zs0fz5s3T+vXrNXDgwDyfe8CAAeratasefPBBpaamKjU1VY0bNzaXF8R9mThxooKDg5WQkKChQ4feNI7Lly8rPT3dYkPe1axZUydOnNC2bdskScuWLdO5c+d09OhRZWdnq1y5cua6fn5+SklJsVaoAAAAVlVcx51bt27VqVOn1L59e0lXkxpDhw5VlSpV5O/vr3Hjxsnb29tcf8qUKQoNDVX79u15Lh4AAEARYo2UQpSSkiJnZ2e1b99erq6u8vX1Vd26dfN07KOPPmrx+uOPP5aXl5f27dun4OBg8/4BAwaoXbt2kqQRI0aodu3a+r//+z/VqlVLU6ZMUcuWLc1/BPf399e+ffs0ceJExcTEmNto27atevXqJUl64403NHXqVMXFxalWrVp69NFH9corr+ibb75R165dJV0d3MfExMhkMlm08dJLL0mS3nrrLb3//vtq0KCBHnvsMXO7jRo10l9//SVvb+88x3a7/q1Zs6aaNm0qk8kkX1/fPB0nyeJh7FWrVtWoUaP08ssva+bMmXk63sXFRaVKldLly5ctPthcUxD3pUWLFhowYMAt4xg3bpxGjBiRp5iRk7u7u5YsWaJBgwbp77//VtOmTRUUFKRz585Z/H5LMifhAAAA7kXFddz5ySefKDo62rx86MSJEzVx4kR17dpVR44cUVRUlO6//34FBARozJgx8vHxkZ2dnZYtW6aHHnpIhw4dkouLi5WvAgAAoPhjRkYhat26tXx9fVWtWjV1795d8+fP14ULF/J07OHDh/Xkk0+qWrVqcnNzU9WqVSUpxzfCQ0NDzT/7+PhIuvqQYknav3+/mjRpYlG/SZMmOnTokLKysm7ahslkkre3t7kNJycnPf300/rkk08kSYmJifr5559zJBuub6N8+fKSpJCQkBz78hvbrcTExCgxMVEBAQGKjY3V6tWr83ScJG3YsEGtW7dWxYoV5erqqujoaJ06dUrnz5/Pcxu3UhD3JTw8/LbnGTx4sNLS0szbb7/9VhDh31MiIiIUFxenhIQETZgwQX/++af5/pw4ccJcLzk5WVWqVLFWmAAAAFZVHMed58+f18KFC9WjRw9J0smTJ7Vs2TLzF7iqVaumBx54QFu2bJEkVaxYUXZ2Vz9CP/zww3Jzc9OBAwesEzwAAMA9hkRGIXJ1ddWuXbv05ZdfysfHR2+99Zbq1KljXnP1Vjp06KBTp05p9uzZ2r59u7Zv3y7p6nMhrleiRAnzz9e+QX5t+SnDMPL0rfLr27jWzvVLWD3//PNas2aNfv/9d33yySdq2bJljtkPN4vjTmMzmUw59mVkZJh/rlevno4ePapRo0bp4sWL6tq1a56eQZKcnKy2bdsqODhYS5YsUUJCgmbMmGHRvp2d3S3PfTsFcV+cnZ1vex4nJye5ublZbMif1NRU88+jRo1SixYtVKNGDT322GPm34sdO3bo2LFjatq0qbXCBAAAsKriOO5cvHixQkNDVatWLUlSmTJlVLJkScXHx0u6mtjYtm2beUb877//bj5227ZtOnXqlGrUqFH0gQMAANyDWFqqkDk4OKhVq1Zq1aqVhg0bJg8PD61fv16PPPJIrsecOnVK+/fv1wcffKBmzZpJ0r96yHBQUFCO47Zs2SJ/f3/Z29vnuZ2QkBCFh4dr9uzZ+uKLL/Tuu+/mO5Z/E1u5cuUs/sh86NChHDNa3Nzc9Pjjj+vxxx9Xly5d9OCDD+r06dO3fCDfzp07lZmZqcmTJ5u/UbVo0SKLOuXKldOxY8cskg43roHr6OiY59kj1yuo+4KCMXToUG3atEmZmZlq1KiRPv74Y0nS+PHj1b17d9WsWVOOjo767LPPzEsOAAAA4O738ccfWzzk297eXosWLdJrr72mzMxMZWRkaMCAAWrQoIGkqzPC//rrL9nb26tUqVJavHix3N3drRU+AADAPYW/yhWiFStW6MiRI4qIiFCZMmW0cuVKZWdnKyAg4JbHlSlTRmXLltWHH34oHx8fpaSkaNCgQfk+f//+/dWgQQONGjVKjz/+uLZu3ar33nsvz8+BuN7zzz+vPn36qHTp0nr44Yfzffy/ia1FixZ677331LBhQ2VnZ+uNN96wmOkwdepU+fj4KCwsTHZ2dlq8eLG8vb3l4eFxy3NXr15dmZmZevfdd9WhQwdt3rxZs2bNsqgTFRWlEydOaMKECerSpYtWrVql7777zuKbZ35+fvr+++914MABlS1bNs8fYgryvuDOffTRRzfdX758+XwtVwYAAIC7y8aNG3Psa9WqlRISEm5af+3atYUdEgAAAHLB0lKFyMPDQ0uXLlWLFi0UGBioWbNm6csvv1Tt2rVveZydnZ0WLFighIQEBQcH69VXX9XEiRPzff569epp0aJFWrBggYKDg/XWW29p5MiReX6Y9vW6desmBwcHPfnkkypZsmS+j/83sU2ePFmVK1dWRESEnnzySQ0YMEClS5c2l7u4uGj8+PEKDw9XgwYNlJSUpJUrV5pnWeQmLCxMU6ZM0fjx4xUcHKz58+dr3LhxFnUCAwM1c+ZMzZgxQ3Xq1NGPP/6Y48HbL7zwggICAhQeHq5y5cpp8+bNBXbtAAAAAAAAAICrTMbNFucHbvDbb7/Jz89PO3bsUL169awdDnKRnp4ud3d3PT1xhRxL3f4ZG/eCj3tHWTsEAACAYufauDPtvepyK2WDy6P24CHcAAAAxQlLS+GWMjIylJqaqkGDBqlhw4YkMQAAAAAAAAAARYqlpawgJSVFLi4uuW4pKSnWDtFs8+bN8vX1VUJCQo7nSNiq+fPn59q3t1vWCwAAAAAAAABgW5iRYQUVKlRQYmLiLcttRVRUlO621cc6duyoBx544KZl1z8sHAAAAAAAAABg+0hkWIGDg4Nq1Khh7TCKLVdXV7m6ulo7DAAAAAAAAABAAeBh30AxYn7oYlqa3NzcrB0OAAAAiinGnQAAAChKPCMDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM1ysHYAAApe7w83yrGUc76O+bh3VOEEAwAAgOLrs3pSKft/f3yPAwUXCwAAAIotZmQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQz8a1FRUerXr5/V27AlcXFxMplMOnv2rLVDKVCxsbHy8/OTyWTSnj17zPt37typRo0aqW7dugoMDNSECROsGCUAAACKm//85z8KDQ1VWFiYmjVrpsTERIvyefPmyWQyacWKFeZ9Fy5cULdu3VSjRg35+/tr6dKlRRw1AAAACpqDtQPA3Wvp0qUqUaKEtcMolvz8/NSvXz+bSfJ06dJFAwcOVNOmTS32v/DCCxoxYoQ6duyo06dPq1atWmrfvr2CgoKsFCkAAACKk0WLFsnDw0OS9PXXX6tHjx7atWuXJOn333/XBx98oIYNG1ocM2nSJDk5Oen//u//dPToUTVq1EjNmzdXmTJlijp8AAAAFBBmZOBf8/T0lKurq7XDQBGIiIhQpUqVblp2bfbJ+fPn5ejoKE9PzyKMDAAAAMXZtSSGJKWlpcnO7p+PsC+++KKmTp0qJycni2MWLlyo3r17S5KqVq2qiIgIffPNN0USLwAAAAoHiQz8a9cvCzVz5kzVrFlTJUuWVPny5dWlS5d/1eaqVavk7u6uTz/9VJIUExOjzp07a9KkSfLx8VHZsmXVu3dvZWRkmI85c+aMoqOjVaZMGZUuXVoPPfSQDh06JEkyDEPlypXTkiVLzPXDwsLk5eVlfr1161aVKFFC586dkySZTCZ99NFHevjhh1W6dGnVrFlTy5cvz9d1bN68WXXq1FHJkiX1wAMPaPfu3RblS5YsUe3ateXk5CQ/Pz9NnjzZXBYVFaXk5GS9+uqrMplMMplMuZ7n8uXLSk9Pt9iK0pw5czR06FBVqVJF/v7+GjdunLy9vYs0BgAAABQ+a447o6OjVblyZb355puaN2+eJOn9999X7dq19cADD+Son5KSIl9fX/NrPz8/paSkFFm8AAAAKHgkMnDHdu7cqdjYWI0cOVIHDhzQqlWrFBERke92FixYoK5du+rTTz9VdHS0ef+GDRt0+PBhbdiwQfPmzdPcuXM1d+5cc3lMTIx27typ5cuXa+vWrTIMQ23btlVGRoZMJpMiIiIUFxcn6WrSY9++fcrIyNC+ffskXX2uRf369eXi4mJuc8SIEeratat++eUXtW3bVk899ZROnz6d52t5/fXXNWnSJO3YsUNeXl7q2LGjOfmSkJCgrl276oknntDu3bs1fPhwDR061HxNS5cuVaVKlTRy5EilpqYqNTU11/OMGzdO7u7u5q1y5cp5jrEgTJw4URMnTlRKSor27t2rIUOG6MCBA0UaAwAAAAqfNcedn376qX777TeNHj1ar7/+uo4eParZs2dr5MiRuR5z/ZeBDMMoijABAABQiEhk4I6lpKTI2dlZ7du3l6+vr+rWravY2Nh8tTFz5kz17NlT33zzjTp16mRRVqZMGb333nvm5y+0a9dO69atkyQdOnRIy5cv10cffaRmzZqpTp06mj9/vv744w99/fXXkq7OcLiWyPjhhx9Up04dtWjRwrwvLi5OUVFRFueMiYkxPyBw7NixOn/+vH788cc8X8+wYcPUunVrhYSEaN68efrrr7+0bNkySdKUKVPUsmVLDR06VP7+/oqJiVGfPn00ceJESVeX7LK3t5erq6u8vb1vOcNh8ODBSktLM2+//fZbnmO8UydPntSyZcvUtWtXSVK1atX0wAMPaMuWLUUWAwAAAIqGNced1zzzzDPasGGDtmzZoj///FOBgYHy8/PTtm3b9Nxzz2n27NmSpCpVqigpKcl8XHJysqpUqVLk8QIAAKDgkMjAHWvdurV8fX1VrVo1de/eXfPnz9eFCxfyfPySJUvUr18/rV69Ws2bN89RXrt2bdnb25tf+/j46Pjx45Kk/fv3y8HBwWJKedmyZRUQEKD9+/dLuprI2Lt3r06ePKn4+HhFRUUpKipK8fHxyszM1JYtWxQZGWlxztDQUPPPzs7OcnV1NZ8zLxo1amT+2dPT0yKe/fv3q0mTJhb1mzRpokOHDikrKyvP55AkJycnubm5WWxFpUyZMipZsqTi4+MlXU1sbNu2TcHBwUUWAwAAAIqGNcad6enp+vPPP82vly1bprJly+rJJ5/UsWPHlJSUpKSkJDVs2FAff/yxXnjhBUnSY489phkzZkiSjh49qvj4eHXs2LHQ4wUAAEDhIZGBO+bq6qpdu3bpyy+/lI+Pj9566y3VqVPH/BDo2wkLC1O5cuU0Z86cm077LlGihMVrk8mk7OxsSblPEzcMwzydPDg4WGXLllV8fLw5kREZGan4+Hjt2LFDFy9eVNOmTfN8zn/rWjzXx3Z9vLasd+/eqlSpkn7//Xe1atVKNWrUkL29vRYtWqTXXntNderUUUREhAYMGKAGDRpYO1wAAAAUA2lpaercubNCQkJUp04dzZgxQytWrLjlM+Skq8u8Xrx4UTVq1FCbNm00Y8YMeXp6FlHUAAAAKAwO1g4AxYODg4NatWqlVq1aadiwYfLw8ND69ev1yCOP3PbY6tWra/LkyYqKipK9vb3ee++9PJ83KChImZmZ2r59uxo3bixJOnXqlA4ePKjAwEBJMj8n45tvvtGePXvUrFkzubq6KiMjQ7NmzVK9evXk6ur67y48F9u2bTNPXz9z5owOHjyoWrVqmWPetGmTRf0tW7bI39/fPPPE0dEx37MzCtOMGTPM32q7XqtWrZSQkGCFiAAAAFDcVa5cOU/Lu15bMvYaZ2dnLVy4sJCiAgAAgDUwIwN3bMWKFXrnnXeUmJio5ORkffrpp8rOzlZAQECe2/D399eGDRvMy0zlVc2aNdWpUye98MIL2rRpk37++Wc9/fTTqlixosWzNqKiovTFF18oNDRUbm5u5uTG/PnzczwfoyCMHDlS69at0549exQTE6P77rtPnTt3liT1799f69at06hRo3Tw4EHNmzdP7733ngYMGGA+3s/PTz/88IP++OMPnTx5ssDjAwAAAAAAAIC7BYkM3DEPDw8tXbpULVq0UGBgoGbNmqUvv/xStWvXzlc7AQEBWr9+vb788kv1798/z8fNmTNH9evXV/v27dWoUSMZhqGVK1daLA/VvHlzZWVlWSQtIiMjlZWVleP5GAXh7bffVt++fVW/fn2lpqZq+fLlcnR0lCTVq1dPixYt0oIFCxQcHKy33npLI0eOVExMjPn4kSNHKikpSdWrV1e5cuUKPD4AAAAAAAAAuFuYDFtfnB9AnqWnp8vd3V1PT1whx1LO+Tr2495RhRMUAAAAip1r486096rLrZT9v2+ox4GCCwoAAADFFjMyAAAAAAAAAACAzSKRgUKTkpIiFxeXXLeUlBRrh5hvPXv2zPV6evbsae3wAAAAAAAAAKDYcbB2ACi+KlSooMTExFuW321Gjhxp8VDu67m5uRVxNAAAAAAAAABQ/JHIQKFxcHBQjRo1rB1GgfLy8pKXl5e1wwAAAAAAAACAewYP+waKEfNDF9PSmCECAACAQsO4EwAAAEWJZ2QAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkO1g4AAAAAAHCX+qyeVMo+5/4eB4o+FgAAABRbzMgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgPFQlRUlPr162ftMMzyEs/cuXPl4eFRJPEAAAAAtiI2NlZ+fn4ymUzas2ePeX+PHj0UEBCgsLAwRUREKDEx0Vz23//+V4GBgapTp47uv/9+rV+/3gqRAwAAwFpIZAB3IC4uTiaTSWfPnrXYv3TpUo0aNcr82s/PT9OmTSva4AAAAAAb1KVLF23atEm+vr4W+zt37qy9e/cqMTFRAwcOVNeuXc1lzZo1065du/Tzzz9r9uzZevTRR3Xp0qWiDh0AAABW4mDtAIDiyNPT09ohAAAAADYpIiLipvs7duxo/rlhw4ZKTk5Wdna27Ozs9NBDD5nLQkJClJWVpZMnT6pSpUqFHi8AAACsjxkZKDays7M1cOBAeXp6ytvbW8OHDzeXTZkyRSEhIXJ2dlblypXVq1cvnTt3zlyenJysDh06qEyZMnJ2dlbt2rW1cuXKW54vKSlJzZs3lySVKVNGJpNJMTExkiyXloqKilJycrJeffVVmUwmmUymXNv83//+p/r166tkyZKqVq2aRowYoczMzFzrX758Wenp6RYbAAAAUNCKetw5ffp0tW3bVnZ2OT+yzpkzR9WrVyeJAQAAcA8hkYFiY968eXJ2dtb27ds1YcIEjRw5UmvWrJEk2dnZ6Z133tGePXs0b948rV+/XgMHDjQf27t3b12+fFk//PCDdu/erfHjx8vFxeWW56tcubKWLFkiSTpw4IBSU1M1ffr0HPWWLl2qSpUqaeTIkUpNTVVqaupN2/v+++/19NNPKzY2Vvv27dMHH3yguXPnasyYMbnGMG7cOLm7u5u3ypUr37afAAAAgPwqynHn559/rkWLFumDDz7IUbZu3TqNGDFCCxYsKLTzAwAAwPaQyECxERoaqmHDhqlmzZqKjo5WeHi41q1bJ0nq16+fmjdvrqpVq6pFixYaNWqUFi1aZD42JSVFTZo0UUhIiKpVq6b27dvnOuX9Gnt7e/MSUl5eXvL29pa7u3uOep6enrK3t5erq6u8vb3l7e190/bGjBmjQYMG6ZlnnlG1atXUunVrjRo16qYf4K4ZPHiw0tLSzNtvv/12234CAAAA8quoxp0LFy7UiBEjtGbNGnl5eVmUxcfH69lnn9X//vc/BQQEFMr5AQAAYJt4RgaKjdDQUIvXPj4+On78uCRpw4YNGjt2rPbt26f09HRlZmbq0qVLOn/+vJydnRUbG6uXX35Zq1evVqtWrfToo4/maK+wJSQkaMeOHRYzMLKysnTp0iVduHBBpUuXznGMk5OTnJycijJMAAAA3IOKYty5aNEivfnmm1q7dq2qVKliUfbDDz+oe/fu+uabb1SnTp1CjQMAAAC2hxkZKDZKlChh8dpkMik7O1vJyclq27atgoODtWTJEiUkJGjGjBmSpIyMDEnS888/ryNHjqh79+7avXu3wsPD9e677xZp/NnZ2RoxYoQSExPN2+7du3Xo0CGVLFmySGMBAAAACkvv3r1VqVIl/f7772rVqpVq1KghSXrqqad06dIlderUSWFhYQoLC9OpU6ckSc8995wuX76sZ5991ly2e/dua14GAAAAihAzMlDs7dy5U5mZmZo8ebL5YYHXLyt1TeXKldWzZ0/17NlTgwcP1uzZs/XKK6/csm1HR0dJV2dO3K7e7erUq1dPBw4cMH+QAwAAAIqjGTNmmL9YdL1rXzK6mUOHDhVmSAAAALBxzMhAsVe9enVlZmbq3Xff1ZEjR/TZZ59p1qxZFnX69eun77//XkePHtWuXbu0fv16BQYG3rZtX19fmUwmrVixQidOnNC5c+duWs/Pz08//PCD/vjjD508efKmdd566y19+umnGj58uPbu3av9+/dr4cKFevPNN/N/0QAAAAAAAABQTJDIQLEXFhamKVOmaPz48QoODtb8+fM1btw4izpZWVnq3bu3AgMD9eCDDyogIEAzZ868bdsVK1bUiBEjNGjQIJUvX159+vS5ab2RI0cqKSlJ1atXV7ly5W5ap02bNlqxYoXWrFmjBg0aqGHDhpoyZYp8fX3zf9EAAAAAAAAAUEyYDMMwrB0EgIKRnp4ud3d3paWlyc3NzdrhAAAAoJgyjzvfqy63UvY5K/Q4UPRBAQAAoNhiRgYAAAAAAAAAALBZJDKAW+jZs6dcXFxuuvXs2dPa4QEAAAAAAABAsedg7QAAWzZy5EgNGDDgpmUs3QQAAAAAAAAAhY9EBnALXl5e8vLysnYYAAAAAAAAAHDPIpEBAAAAAPh3uu+SmKkMAACAQsYzMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSKjGIqKilK/fv2sHYbNiIuLk8lk0tmzZ4vkfHPnzpWHh8ct6wwfPlxhYWHm1zExMercuXOhxgUAAAAAAAAAdyMHaweAgrd06VKVKFHC2mEgH6ZPny7DMMyvo6KiFBYWpmnTplkvKAAAAAAAAACwASQyiiFPT09rh3DXy8rKkslkkp1d0Uxacnd3L5LzAAAAAAAAAMDdhqWliqHrl5aaOXOmatasqZIlS6p8+fLq0qVLntuIjY3VwIED5enpKW9vbw0fPtyiTlpaml588UV5eXnJzc1NLVq00M8//2wus7e3V0JCgiTJMAx5enqqQYMG5uO//PJL+fj43DaWK1euqE+fPvLx8VHJkiXl5+encePGSZKSkpJkMpmUmJhorn/27FmZTCbFxcVZtLN582bVqVNHJUuW1AMPPKDdu3eby64tB7VixQoFBQXJyclJycnJunLligYOHKiKFSvK2dlZDzzwQI52586dqypVqqh06dJ6+OGHderUqRzX8Pbbb6t8+fJydXXVc889p0uXLlmUX7+0VExMjOLj4zV9+nSZTCaZTCYlJSXdtp8AAAAAAAAAoDgikVGM7dy5U7GxsRo5cqQOHDigVatWKSIiIs/Hz5s3T87Oztq+fbsmTJigkSNHas2aNZKuJibatWunY8eOaeXKlUpISFC9evXUsmVLnT59Wu7u7goLCzP/0f+XX34x/zc9PV3S1WdXREZG3jaOd955R8uXL9eiRYt04MABff755/Lz88tfZ0h6/fXXNWnSJO3YsUNeXl7q2LGjMjIyzOUXLlzQuHHj9NFHH2nv3r3y8vLSs88+q82bN2vBggX65Zdf9Nhjj+nBBx/UoUOHJEnbt29Xjx491KtXLyUmJqp58+YaPXq0xXkXLVqkYcOGacyYMdq5c6d8fHw0c+bMXOOcPn26GjVqpBdeeEGpqalKTU1V5cqVb1r38uXLSk9Pt9gAAACAgsa4EwAAANZEIqMYS0lJkbOzs9q3by9fX1/VrVtXsbGxeT4+NDRUw4YNU82aNRUdHa3w8HCtW7dOkrRhwwbt3r1bixcvVnh4uGrWrKlJkybJw8NDX331laSrszquJTLi4uLUsmVLBQcHa9OmTeZ9UVFRebqOmjVrqmnTpvL19VXTpk3VrVu3/HWGpGHDhql169YKCQnRvHnz9Ndff2nZsmXm8oyMDM2cOVONGzdWQECAjh07pi+//FKLFy9Ws2bNVL16dQ0YMEBNmzbVnDlzJF1NOrRp00aDBg2Sv7+/YmNj1aZNG4vzTps2TT169NDzzz+vgIAAjR49WkFBQbnG6e7uLkdHR5UuXVre3t7y9vaWvb39TeuOGzdO7u7u5i23hAcAAABwJxh3AgAAwJpIZBRjrVu3lq+vr6pVq6bu3btr/vz5unDhQp6PDw0NtXjt4+Oj48ePS5ISEhJ07tw5lS1bVi4uLubt6NGjOnz4sKSriYyNGzcqOztb8fHxioqKUlRUlOLj43Xs2DEdPHgwTzMyYmJilJiYqICAAMXGxmr16tX56IV/NGrUyPyzp6enAgICtH//fvM+R0dHi2vetWuXDMOQv7+/xTXGx8ebr3H//v0W7d54nrzW+bcGDx6stLQ08/bbb78VSLsAAADA9Rh3AgAAwJp42Hcx5urqql27dikuLk6rV6/WW2+9peHDh2vHjh3y8PC47fElSpSweG0ymZSdnS1Jys7Olo+PT47nRUgytx0REaG///5bu3bt0saNGzVq1ChVrlxZY8eOVVhYmLy8vBQYGHjbOOrVq6ejR4/qu+++09q1a9W1a1e1atVKX331lflh3IZhmOtfv1zU7ZhMJvPPpUqVsnidnZ1tfs7HjTMiXFxccpzXGpycnOTk5GTVGAAAAFD8Me4EAACANZHIKOYcHBzUqlUrtWrVSsOGDZOHh4fWr1+vRx555I7arVevno4dOyYHB4dcn1dx7TkZ7733nkwmk4KCglShQgX99NNPWrFiRZ5mY1zj5uamxx9/XI8//ri6dOmiBx98UKdPn1a5cuUkSampqapbt64kWTz4+3rbtm1TlSpVJElnzpzRwYMHVatWrVzPWbduXWVlZen48eNq1qzZTesEBQVp27ZtOc5zvcDAQG3btk3R0dG51rmRo6OjsrKyblkHAAAAAAAAAO4FJDKKsRUrVujIkSOKiIhQmTJltHLlSmVnZysgIOCO227VqpUaNWqkzp07a/z48QoICNCff/6plStXqnPnzgoPD5d0dXmp6dOn6+GHH5bJZFKZMmUUFBSkhQsX6p133snTuaZOnSofHx+FhYXJzs5Oixcvlre3tzw8PGRnZ6eGDRvq7bfflp+fn06ePKk333zzpu2MHDlSZcuWVfny5TVkyBDdd9996ty5c67n9ff311NPPaXo6GhNnjxZdevW1cmTJ7V+/XqFhISobdu2io2NVePGjTVhwgR17txZq1ev1qpVqyza6du3r5555hmFh4eradOmmj9/vvbu3atq1arlem4/Pz9t375dSUlJcnFxkaenp3n2CQAAAAAAAADcS/jLaDHm4eGhpUuXqkWLFgoMDNSsWbP05Zdfqnbt2nfctslk0sqVKxUREaEePXrI399fTzzxhJKSklS+fHlzvebNmysrK8viod6RkZHKysrK84wMFxcXjR8/XuHh4WrQoIGSkpK0cuVK8x/2P/nkE2VkZCg8PFx9+/bV6NGjb9rO22+/rb59+6p+/fpKTU3V8uXL5ejoeMtzz5kzR9HR0erfv78CAgLUsWNHbd++3fxww4YNG+qjjz7Su+++q7CwMK1evTpHIuXxxx/XW2+9pTfeeEP169dXcnKyXn755Vued8CAAbK3t1dQUJDKlSunlJSUPPUVAAAAAAAAABQ3JsPai/wDKDDp6elyd3dXWlqa3NzcrB0OAAAAiinGnQAAAChKzMgAAAAAAAAAAAA2i0TGPSglJUUuLi65bkW9jNHYsWNzjeWhhx4q0lgAAAAAAAAAALaFpaXuQZmZmUpKSsq13M/PTw4ORfcc+NOnT+v06dM3LStVqpQqVqxYZLHc7ZjiDwAAgKLAuBMAAABFqej+Wg2b4eDgoBo1alg7DDNPT095enpaOwwAAAAAAAAAgA1iaSkAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBm4rKipK/fr1s3YYd4W4uDiZTCadPXvW2qEAAAAAAAAAQLHgYO0AYPuWLl2qEiVKWDsMmxMVFaWwsDBNmzbN2qEAAAAAAAAAQLFFIgO35enpae0Q7nkZGRkkkwAAAAAAAADck1haCrd1/dJSM2fOVM2aNVWyZEmVL19eXbp0yXMbsbGxGjhwoDw9PeXt7a3hw4db1ElLS9OLL74oLy8vubm5qUWLFvr555/NZfb29kpISJAkGYYhT09PNWjQwHz8l19+KR8fnzzF88Ybb8jf31+lS5dWtWrVNHToUGVkZJjLY2Ji1LlzZ4tj+vXrp6ioKHN5fHy8pk+fLpPJJJPJpKSkJHPdhIQEhYeHq3Tp0mrcuLEOHDhg0db777+v6tWry9HRUQEBAfrss88syk0mk2bNmqVOnTrJ2dlZo0ePztN1AQAAAAAAAEBxQyIDebZz507FxsZq5MiROnDggFatWqWIiIg8Hz9v3jw5Oztr+/btmjBhgkaOHKk1a9ZIupqYaNeunY4dO6aVK1cqISFB9erVU8uWLXX69Gm5u7srLCxMcXFxkqRffvnF/N/09HRJV59PERkZmadYXF1dNXfuXO3bt0/Tp0/X7NmzNXXq1Dxfy/Tp09WoUSO98MILSk1NVWpqqipXrmwuHzJkiCZPnqydO3fKwcFBPXr0MJctW7ZMffv2Vf/+/bVnzx699NJLevbZZ7VhwwaLcwwbNkydOnXS7t27LY6/3uXLl5Wenm6xAQAAAAWNcScAAACsiUQG8iwlJUXOzs5q3769fH19VbduXcXGxub5+NDQUA0bNkw1a9ZUdHS0wsPDtW7dOknShg0btHv3bi1evFjh4eGqWbOmJk2aJA8PD3311VeSrs7quJbIiIuLU8uWLRUcHKxNmzaZ912bMXE7b775pho3biw/Pz916NBB/fv316JFi/J8Le7u7nJ0dFTp0qXl7e0tb29v2dvbm8vHjBmjyMhIBQUFadCgQdqyZYsuXbokSZo0aZJiYmLUq1cv+fv767XXXtMjjzyiSZMmWZzjySefVI8ePVStWjX5+vreNI5x48bJ3d3dvF2fTAEAAAAKCuNOAAAAWBOJDORZ69at5evrq2rVqql79+6aP3++Lly4kOfjQ0NDLV77+Pjo+PHjkq4uxXTu3DmVLVtWLi4u5u3o0aM6fPiwpKuJjI0bNyo7O1vx8fGKiopSVFSU4uPjdezYMR08eDDPMzK++uorNW3aVN7e3nJxcdHQoUOVkpKS52vJz7VeW+7q2rXu379fTZo0sajfpEkT7d+/32JfeHj4bc8zePBgpaWlmbfffvvtTkMHAAAAcmDcCQAAAGviYd/IM1dXV+3atUtxcXFavXq13nrrLQ0fPlw7duyQh4fHbY+/8WHVJpNJ2dnZkqTs7Gz5+PiYZ1xc71rbERER+vvvv7Vr1y5t3LhRo0aNUuXKlTV27FiFhYXJy8tLgYGBt41j27ZteuKJJzRixAi1adNG7u7uWrBggSZPnmyuY2dnJ8MwLI67/hka+blWk8lkvsYb911jGEaOfc7Ozrc9j5OTk5ycnPIcFwAAAPBvMO4EAACANZHIQL44ODioVatWatWqlYYNGyYPDw+tX79ejzzyyB21W69ePR07dkwODg7y8/O7aZ1rz8l47733ZDKZFBQUpAoVKuinn37SihUr8jwbY/PmzfL19dWQIUPM+5KTky3qlCtXTnv27LHYl5iYaJGgcHR0VFZWVh6v8B+BgYHatGmToqOjzfu2bNmSpyQMAAAAAAAAANxrWFoKebZixQq98847SkxMVHJysj799FNlZ2crICDgjttu1aqVGjVqpM6dO+v7779XUlKStmzZojfffFM7d+4014uKitLnn3+uyMhImUwmlSlTRkFBQVq4cGGen49Ro0YNpaSkaMGCBTp8+LDeeecdLVu2zKJOixYttHPnTn366ac6dOiQhg0bliOx4efnp+3btyspKUknT560mHFxK6+//rrmzp2rWbNm6dChQ5oyZYqWLl2qAQMG5Ol4AAAAAAAAALiXkMhAnnl4eGjp0qVq0aKFAgMDNWvWLH355ZeqXbv2HbdtMpm0cuVKRUREqEePHvL399cTTzyhpKQklS9f3lyvefPmysrKskhaREZGKisrK88zMjp16qRXX31Vffr0UVhYmLZs2aKhQ4da1GnTpo2GDh2qgQMHqkGDBvr7778tZlBI0oABA2Rvb6+goCCVK1cuz8/Y6Ny5s6ZPn66JEyeqdu3a+uCDDzRnzpw8J2IAAAAAAAAA4F5iMm58EACAu1Z6errc3d2VlpYmNzc3a4cDAACAYopxJwAAAIoSMzIAAAAAAAAAAIDNIpGBO5aSkiIXF5dct7wuuVRQxo4dm2ssDz30UJHGAgAAAAAAAAC4MywthTuWmZmppKSkXMv9/Pzk4OBQZPGcPn1ap0+fvmlZqVKlVLFixSKLpagxxR8AAABFgXEnAAAAilLR/XUZxZaDg4Nq1Khh7TDMPD095enpae0wAAAAAAAAAAAFgKWlAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkchAvsTFxclkMuns2bO3rOfn56dp06YVyDmHDx+usLCwAmnrdm6M22Qy6euvvy6ScwMAAAAAAAAAciKRgVuKiopSv379zK8bN26s1NRUubu7S5Lmzp0rDw+PQo1hwIABWrduXaGeAwAAAAAAAABgmxysHQDuLo6OjvL29i7Sc7q4uMjFxaVIzwkAAAAAAAAAsA3MyECuYmJiFB8fr+nTp8tkMslkMmnu3LnmpaXi4uL07LPPKi0tzVw+fPjwm7aVlpamF198UV5eXnJzc1OLFi30888/5ymOG5eWiouL0/333y9nZ2d5eHioSZMmSk5Ovm07hw8fVqdOnVS+fHm5uLioQYMGWrt2bZ5iuOb333/XE088IU9PTzk7Oys8PFzbt2/Pc/t+fn4aNWqUnnzySbm4uKhChQp69913c1xvlSpV5OTkpAoVKig2NjbXeC5fvqz09HSLDQAAAChojDsBAABgTSQykKvp06erUaNGeuGFF5SamqrU1FRVrlzZXN64cWNNmzZNbm5u5vIBAwbkaMcwDLVr107Hjh3TypUrlZCQoHr16qlly5Y6ffp0vmLKzMxU586dFRkZqV9++UVbt27Viy++KJPJdNtjz507p7Zt22rt2rX66aef1KZNG3Xo0EEpKSl5Ove5c+cUGRmpP//8U8uXL9fPP/+sgQMHKjs7O1/tT5w4UaGhodq1a5cGDx6sV199VWvWrJEkffXVV5o6dao++OADHTp0SF9//bVCQkJyjWncuHFyd3c3b9ffHwAAAKCgMO4EAACANbG0FHLl7u4uR0dHlS5d2ryc1K+//moud3R0lLu7u0wm0y2Xm9qwYYN2796t48ePy8nJSZI0adIkff311/rqq6/04osv5jmm9PR0paWlqX379qpevbokKTAwME/H1qlTR3Xq1DG/Hj16tJYtW6bly5erT58+tz3+iy++0IkTJ7Rjxw55enpKkmrUqJHv9ps0aaJBgwZJkvz9/bV582ZNnTpVrVu3VkpKiry9vdWqVSuVKFFCVapU0f33359rTIMHD9Zrr71mfp2ens6HSgAAABQ4xp0AAACwJmZkoNAlJCTo3LlzKlu2rPl5Fy4uLjp69KgOHz6cr7Y8PT0VExNjnu0wffp0paam5unY8+fPa+DAgQoKCpKHh4dcXFz066+/5nlGRmJiourWrWtOYvzb9hs1apTj9f79+yVJjz32mC5evKhq1arphRde0LJly5SZmZlrTE5OTnJzc7PYAAAAgILGuBMAAADWRCIDhS47O1s+Pj5KTEy02A4cOKDXX3893+3NmTNHW7duVePGjbVw4UL5+/tr27Zttz3u9ddf15IlSzRmzBht3LhRiYmJCgkJ0ZUrV/J03lKlShVa+9eWxqpcubIOHDigGTNmqFSpUurVq5ciIiKUkZGRpxgBAAAAAAAAoLhhaSnckqOjo7Kysv51uSTVq1dPx44dk4ODg/z8/Aokrrp166pu3boaPHiwGjVqpC+++EINGza85TEbN25UTEyMHn74YUlXn2mRlJSU53OGhobqo48+0unTp286KyOv7d+YdNm2bZtq1aplfl2qVCl17NhRHTt2VO/evVWrVi3t3r1b9erVy3OsAAAAAAAAAFBcMCMDt+Tn56ft27crKSlJJ0+eND/Y+vryc+fOad26dTp58qQuXLiQo41WrVqpUaNG6ty5s77//nslJSVpy5YtevPNN7Vz5858xXP06FENHjxYW7duVXJyslavXq2DBw/m6TkZNWrU0NKlS5WYmKiff/5ZTz75ZI7ruZVu3brJ29tbnTt31ubNm3XkyBEtWbJEW7duzVf7mzdv1oQJE3Tw4EHNmDFDixcvVt++fSVJc+fO1ccff6w9e/boyJEj+uyzz1SqVCn5+vrmOU4AAAAAAAAAKE5IZOCWBgwYIHt7ewUFBalcuXI5nvfQuHFj9ezZU48//rjKlSunCRMm5GjDZDJp5cqVioiIUI8ePeTv768nnnhCSUlJKl++fL7iKV26tH799Vc9+uij8vf314svvqg+ffropZdeuu2xU6dOVZkyZdS4cWN16NBBbdq0ydcsB0dHR61evVpeXl5q27atQkJC9Pbbb8ve3j5f7ffv318JCQmqW7euRo0apcmTJ6tNmzaSJA8PD82ePVtNmjRRaGio1q1bp//9738qW7ZsnuMEAAAAAAAAgOLEZBiGYe0ggHuFn5+f+vXrp379+hVK++np6XJ3d1daWhoPYAQAAEChYdwJAACAosSMDAAAAAAAAAAAYLNIZMDqateuLRcXl5tu8+fPL/J2AAAAAAAAAAC2w8HaAQArV65URkbGTcvy8wyNgmqnMCUlJVk7BAAAAAAAAAC4q5DIgNX5+vraVDsAAAAAAAAAANvB0lIAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJjGIuKipK/fr1s3YYBW7u3Lny8PCwdhi5iouLk8lk0tmzZ60dCgAAAAAAAADc1UhkAHfoZsmixo0bKzU1Ve7u7tYJCgAAAAAAAACKCQdrBwAUR46OjvL29rZ2GAAAAAAAAABw12NGxj0gOztbAwcOlKenp7y9vTV8+HBz2ZQpUxQSEiJnZ2dVrlxZvXr10rlz58zlycnJ6tChg8qUKSNnZ2fVrl1bK1euzNN59+3bp7Zt28rFxUXly5dX9+7ddfLkSUlXl15ydHTUxo0bzfUnT56s++67T6mpqZKks2fP6sUXX1T58uVVsmRJBQcHa8WKFTc91+HDh9WpUyeVL19eLi4uatCggdauXWtRx8/PT6NHj1Z0dLRcXFzk6+urb775RidOnFCnTp3k4uKikJAQ7dy503zMqVOn1K1bN1WqVEmlS5dWSEiIvvzyS3N5TEyM4uPjNX36dJlMJplMJiUlJd10aaklS5aodu3acnJykp+fnyZPnpwjvrFjx6pHjx5ydXVVlSpV9OGHH96yjy9fvqz09HSLDQAAAChojDsBAABgTSQy7gHz5s2Ts7Oztm/frgkTJmjkyJFas2aNJMnOzk7vvPOO9uzZo3nz5mn9+vUaOHCg+djevXvr8uXL+uGHH7R7926NHz9eLi4utz1namqqIiMjFRYWpp07d2rVqlX666+/1LVrV0n/LMfUvXt3paWl6eeff9aQIUM0e/Zs+fj4KDs7Ww899JC2bNmizz//XPv27dPbb78te3v7m57v3Llzatu2rdauXauffvpJbdq0UYcOHZSSkmJRb+rUqWrSpIl++ukntWvXTt27d1d0dLSefvpp7dq1SzVq1FB0dLQMw5AkXbp0SfXr19eKFSu0Z88evfjii+revbu2b98uSZo+fboaNWqkF154QampqUpNTVXlypVzxJeQkKCuXbvqiSee0O7duzV8+HANHTpUc+fOtag3efJkhYeH66efflKvXr308ssv69dff821n8eNGyd3d3fzdrNzAwAAAHeKcScAAACsyWRc+4stiqWoqChlZWVZzHy4//771aJFC7399ts56i9evFgvv/yyeeZEaGioHn30UQ0bNixf533rrbe0fft2ff/99+Z9v//+uypXrqwDBw7I399fV65cUcOGDVWzZk3t3btXjRo10uzZsyVJq1ev1kMPPaT9+/fL398/R/tz585Vv379bvkw7dq1a+vll19Wnz59JF2d8dCsWTN99tlnkqRjx47Jx8dHQ4cO1ciRIyVJ27ZtU6NGjZSamprr0lDt2rVTYGCgJk2aJOlqH4eFhWnatGnmOnFxcWrevLnOnDkjDw8PPfXUUzpx4oRWr15trjNw4EB9++232rt3703jMwxD3t7eGjFihHr27HnTWC5fvqzLly+bX6enp6ty5cpKS0uTm5tbrn0DAAAA5AfjTgAAAFgTz8i4B4SGhlq89vHx0fHjxyVJGzZs0NixY7Vv3z6lp6crMzNTly5d0vnz5+Xs7KzY2Fi9/PLLWr16tVq1aqVHH300R3s3k5CQoA0bNtx09sbhw4fl7+8vR0dHff755woNDZWvr69FIiAxMVGVKlW6aRLjZs6fP68RI0ZoxYoV+vPPP5WZmamLFy/mmJFxfezly5eXJIWEhOTYd/z4cXl7eysrK0tvv/22Fi5cqD/++MP8Ac7Z2TlPcV2zf/9+derUyWJfkyZNNG3aNGVlZZlnmlwfn8lkkre3t/le3YyTk5OcnJzyFQsAAACQX4w7AQAAYE0sLXUPKFGihMVrk8mk7OxsJScnq23btgoODtaSJUuUkJCgGTNmSJIyMjIkSc8//7yOHDmi7t27a/fu3QoPD9e7775723NmZ2erQ4cOSkxMtNgOHTqkiIgIc70tW7ZIkk6fPq3Tp0+b95cqVSpf1/j6669ryZIlGjNmjDZu3KjExESFhIToypUrufaFyWTKdV92drakq0s9TZ06VQMHDtT69euVmJioNm3a5Gj3dgzDMLd9/b4b5XavAAAAAAAAAOBeRSLjHrZz505lZmZq8uTJatiwofz9/fXnn3/mqFe5cmX17NlTS5cuVf/+/c3LP91KvXr1tHfvXvn5+alGjRoW27XZDIcPH9arr76q2bNnq2HDhoqOjjb/0T40NFS///67Dh48mKdr2bhxo2JiYvTwww8rJCRE3t7eSkpKyntn3KLdTp066emnn1adOnVUrVo1HTp0yKKOo6OjsrKybtlOUFCQNm3aZLFvy5Yt8vf3z/W5HwAAAAAAAAAAEhn3tOrVqyszM1Pvvvuujhw5os8++0yzZs2yqNOvXz99//33Onr0qHbt2qX169crMDDwtm337t1bp0+fVrdu3fTjjz/qyJEjWr16tXr06KGsrCxlZWWpe/fu+s9//qNnn31Wc+bM0Z49ezR58mRJUmRkpCIiIvToo49qzZo1Onr0qL777jutWrXqpuerUaOGli5dqsTERP3888968sknC2QmQ40aNbRmzRpt2bJF+/fv10svvaRjx45Z1PHz89P27duVlJSkkydP3vS8/fv317p16zRq1CgdPHhQ8+bN03vvvacBAwbccYwAAAAAAAAAUJyRyLiHhYWFacqUKRo/fryCg4M1f/58jRs3zqJOVlaWevfurcDAQD344IMKCAjQzJkzb9t2hQoVtHnzZmVlZalNmzYKDg5W37595e7uLjs7O40ZM0ZJSUn68MMPJUne3t766KOP9OabbyoxMVGStGTJEjVo0EDdunVTUFCQBg4cmOvMh6lTp6pMmTJq3LixOnTooDZt2qhevXp31kGShg4dqnr16qlNmzaKioqSt7e3OnfubFFnwIABsre3V1BQkMqVK5fjuRzS1RkqixYt0oIFCxQcHKy33npLI0eOVExMzB3HCAAAAAAAAADFmcm42UL9AO5K6enpcnd3V1pamtzc3KwdDgAAAIopxp0AAAAoSszIAAAAAAAAAAAANotEBv6Vnj17ysXF5aZbz549rR0eAAAAAAAAAKCYYGkp/CvHjx9Xenr6Tcvc3Nzk5eVVxBFBYoo/AAAAigbjTgAAABQlB2sHgLuTl5cXyQoAAAAAAAAAQKFjaSkAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBu5YVFSU+vXrZ+0wbMrw4cMVFhZm7TAAAAAAAAAA4K5HIgO4QyaTSV9//bXFvgEDBmjdunXWCQgAAAAAAAAAihEHawcAFEcuLi5ycXGxdhgAAAAAAAAAcNdjRgYKRHZ2tgYOHChPT095e3tr+PDh5rIpU6YoJCREzs7Oqly5snr16qVz586Zy5OTk9WhQweVKVNGzs7Oql27tlauXJmn865cuVL+/v4qVaqUmjdvrrlz58pkMuns2bOSbr7E07Rp0+Tn52exb86cOQoMDFTJkiVVq1YtzZw501x25coV9enTRz4+PipZsqT8/Pw0btw4STK38/DDD8tkMplf33je7OxsjRw5UpUqVZKTk5PCwsK0atUqc3lSUpJMJpOWLl2q5s2bq3Tp0qpTp462bt2ap34AAAAAAAAAgOKKRAYKxLx58+Ts7Kzt27drwoQJGjlypNasWSNJsrOz0zvvvKM9e/Zo3rx5Wr9+vQYOHGg+tnfv3rp8+bJ++OEH7d69W+PHj8/TbIbffvtNjzzyiNq2bavExEQ9//zzGjRoUL5jnz17toYMGaIxY8Zo//79Gjt2rIYOHap58+ZJkt555x0tX75cixYt0oEDB/T555+bExY7duyQdDURkpqaan59o+nTp2vy5MmaNGmSfvnlF7Vp00YdO3bUoUOHLOoNGTJEAwYMUGJiovz9/dWtWzdlZmbmGvvly5eVnp5usQEAAAAFjXEnAAAArImlpVAgQkNDNWzYMElSzZo19d5772ndunVq3bq1xYPAq1atqlGjRunll182z3pISUnRo48+qpCQEElStWrV8nTO999/X9WqVdPUqVNlMpkUEBBgToTkx6hRozR58mQ98sgj5hj37dunDz74QM8884xSUlJUs2ZNNW3aVCaTSb6+vuZjy5UrJ0ny8PCQt7d3rueYNGmS3njjDT3xxBOSpPHjx2vDhg2aNm2aZsyYYa43YMAAtWvXTpI0YsQI1a5dW//3f/+nWrVq3bTdcePGacSIEfm6XgAAACC/GHcCAADAmpiRgQIRGhpq8drHx0fHjx+XJG3YsEGtW7dWxYoV5erqqujoaJ06dUrnz5+XJMXGxmr06NFq0qSJhg0bpl9++SVP59y/f78aNmwok8lk3teoUaN8xX3ixAn99ttveu6558zPtXBxcdHo0aN1+PBhSVJMTIwSExMVEBCg2NhYrV69Ol/nSE9P159//qkmTZpY7G/SpIn2799vse/6fvTx8ZEkcz/ezODBg5WWlmbefvvtt3zFBgAAAOQF404AAABYE4kMFIgSJUpYvDaZTMrOzlZycrLatm2r4OBgLVmyRAkJCeYZCBkZGZKk559/XkeOHFH37t21e/duhYeH6913373tOQ3DuG0dOzu7HPWunVe6+uwK6eryUomJieZtz5492rZtmySpXr16Onr0qEaNGqWLFy+qa9eu6tKly23PfaPrEy7X4r9x3/X9eK3sWow34+TkJDc3N4sNAAAAKGiMOwEAAGBNJDJQqHbu3KnMzExNnjxZDRs2lL+/v/78888c9SpXrqyePXtq6dKl6t+/v2bPnn3btoOCgszJhmtufF2uXDkdO3bMIpmRmJho/rl8+fKqWLGijhw5oho1alhsVatWNddzc3PT448/rtmzZ2vhwoVasmSJTp8+Lelq8iErKyvXON3c3FShQgVt2rTJYv+WLVsUGBh42+sEAAAAAAAAgHsZz8hAoapevboyMzP17rvvqkOHDtq8ebNmzZplUadfv3566KGH5O/vrzNnzmj9+vV5+gN/z549NXnyZL322mt66aWXlJCQoLlz51rUiYqK0okTJzRhwgR16dJFq1at0nfffWfxDbLhw4crNjZWbm5ueuihh3T58mXt3LlTZ86c0WuvvaapU6fKx8dHYWFhsrOz0+LFi+Xt7S0PDw9Jkp+fn9atW6cmTZrIyclJZcqUyRHr66+/rmHDhql69eoKCwvTnDlzlJiYqPnz5+e/UwEAAAAAAADgHsKMDBSqsLAwTZkyRePHj1dwcLDmz5+vcePGWdTJyspS7969FRgYqAcffFABAQHmB4HfSpUqVbRkyRL973//U506dTRr1iyNHTvWok5gYKBmzpypGTNmqE6dOvrxxx81YMAAizrPP/+8PvroI82dO1chISGKjIzU3LlzzTMyXFxcNH78eIWHh6tBgwZKSkrSypUrZWd39X+fyZMna82aNapcubLq1q1701hjY2PVv39/9e/fXyEhIVq1apWWL1+umjVr5rkvAQAAAAAAAOBeZDLy8qAB4C4RFxen5s2b68yZM+YZE/eS9PR0ubu7Ky0tjXWLAQAAUGgYdwIAAKAoMSMDAAAAAAAAAADYLBIZsFk9e/aUi4vLTbeePXtaOzwAAAAAAAAAQBFgaSnYrOPHjys9Pf2mZW5ubvLy8iriiGwfU/wBAABQFBh3AgAAoCg5WDsAIDdeXl4kKwAAAAAAAADgHsfSUgAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgsxysHQCAgmMYhiQpPT3dypEAAADAVrm6uspkMt1RG4w7AQAAcDsFMe68hkQGUIycOnVKklS5cmUrRwIAAABblZaWJjc3tztqg3EnAAAAbqcgxp3XkMgAihFPT09JUkpKitzd3a0cje1LT09X5cqV9dtvvxXYP6rFFX2VP/RX3tFX+UN/5R19lT/0V/7c7f3l6up6x20w7rQdd/vvY3HCvbAd3Avbwb2wHdwL23Ev3YuCGHdeQyIDKEbs7K4+9sbd3b3Y/0NYkNzc3OivPKKv8of+yjv6Kn/or7yjr/KH/sqfe7m/GHfannv599HWcC9sB/fCdnAvbAf3wnZwL/KHh30DAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZQDHi5OSkYcOGycnJydqh3BXor7yjr/KH/so7+ip/6K+8o6/yh/7KH/qLPrAl3Avbwb2wHdwL28G9sB3cC9vBvfh3TIZhGNYOAgAAAAAAAAAA4GaYkQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZQDEyc+ZMVa1aVSVLllT9+vW1ceNGa4dU5H744Qd16NBBFSpUkMlk0tdff21RbhiGhg8frgoVKqhUqVKKiorS3r17LepcvnxZr7zyiu677z45OzurY8eO+v3334vwKorGuHHj1KBBA7m6usrLy0udO3fWgQMHLOrQX/94//33FRoaKjc3N7m5ualRo0b67rvvzOX0Ve7GjRsnk8mkfv36mffRX/8YPny4TCaTxebt7W0up68s/fHHH3r66adVtmxZlS5dWmFhYUpISDCX01//8PPzy/G7ZTKZ1Lt3b0n01fUyMzP15ptvqmrVqipVqpSqVaumkSNHKjs721yH/rLEuLNgFeW47MyZM+revbvc3d3l7u6u7t276+zZs4V9iXelwhzDcB/ypqje97kfuSvK90juQ05F9TeOvPR9SkqKOnToIGdnZ913332KjY3VlStXCuOybc6t7kNGRobeeOMNhYSEyNnZWRUqVFB0dLT+/PNPiza4DwXAAFAsLFiwwChRooQxe/ZsY9++fUbfvn0NZ2dnIzk52dqhFamVK1caQ4YMMZYsWWJIMpYtW2ZR/vbbbxuurq7GkiVLjN27dxuPP/644ePjY6Snp5vr9OzZ06hYsaKxZs0aY9euXUbz5s2NOnXqGJmZmUV8NYWrTZs2xpw5c4w9e/YYiYmJRrt27YwqVaoY586dM9ehv/6xfPly49tvvzUOHDhgHDhwwPjvf/9rlChRwtizZ49hGPRVbn788UfDz8/PCA0NNfr27WveT3/9Y9iwYUbt2rWN1NRU83b8+HFzOX31j9OnTxu+vr5GTEyMsX37duPo0aPG2rVrjf/7v/8z16G//nH8+HGL36s1a9YYkowNGzYYhkFfXW/06NFG2bJljRUrVhhHjx41Fi9ebLi4uBjTpk0z16G//sG4s+AV5bjswQcfNIKDg40tW7YYW7ZsMYKDg4327dsX6fXeDQp7DMN9uL2ifN/nfuSuKN8juQ85FdXfOG7X95mZmUZwcLDRvHlzY9euXcaaNWuMChUqGH369Cn0PrAFt7oPZ8+eNVq1amUsXLjQ+PXXX42tW7caDzzwgFG/fn2LNrgPd45EBlBM3H///UbPnj0t9tWqVcsYNGiQlSKyvhvfXLKzsw1vb2/j7bffNu+7dOmS4e7ubsyaNcswjKtvQCVKlDAWLFhgrvPHH38YdnZ2xqpVq4osdms4fvy4IcmIj483DIP+yosyZcoYH330EX2Vi7///tuoWbOmsWbNGiMyMtL8RwD6y9KwYcOMOnXq3LSMvrL0xhtvGE2bNs21nP66tb59+xrVq1c3srOz6asbtGvXzujRo4fFvkceecR4+umnDcPgd+tGjDsLX2GNy/bt22dIMrZt22aus3XrVkOS8euvvxbFpd0VCnsMw33Im6J63+d+3FpRvUdyH26vsP7GkZe+X7lypWFnZ2f88ccf5jpffvml4eTkZKSlpRXK9dqqmyWUbvTjjz8aksxf8uA+FAyWlgKKgStXrighIUH/+c9/LPb/5z//0ZYtW6wUle05evSojh07ZtFPTk5OioyMNPdTQkKCMjIyLOpUqFBBwcHBxb4v09LSJEmenp6S6K9bycrK0oIFC3T+/Hk1atSIvspF79691a5dO7Vq1cpiP/2V06FDh1ShQgVVrVpVTzzxhI4cOSKJvrrR8uXLFR4erscee0xeXl6qW7euZs+ebS6nv3J35coVff755+rRo4dMJhN9dYOmTZtq3bp1OnjwoCTp559/1qZNm9S2bVtJ/G5dj3Fn0SiscdnWrVvl7u6uBx54wFynYcOGcnd35/5dp7DHMNyHvCmq933ux60V1Xsk9yH/irLvt27dquDgYFWoUMFcp02bNrp8+bLFcm+4Ki0tTSaTSR4eHpK4DwXFwdoBALhzJ0+eVFZWlsqXL2+xv3z58jp27JiVorI91/riZv2UnJxsruPo6KgyZcrkqFOc+9IwDL322mtq2rSpgoODJdFfN7N79241atRIly5dkouLi5YtW6agoCDzoIK++seCBQu0a9cu7dixI0cZv1uWHnjgAX366afy9/fXX3/9pdGjR6tx48bau3cvfXWDI0eO6P3339drr72m//73v/rxxx8VGxsrJycnRUdH01+38PXXX+vs2bOKiYmRxP+HN3rjjTeUlpamWrVqyd7eXllZWRozZoy6desmif66HuPOwleY47Jjx47Jy8srxzm9vLy4f/9fUYxhuA95U1Tv+9yPWyuq90juQ/4VZd8fO3Ysx3nKlCkjR0dH7s8NLl26pEGDBunJJ5+Um5ubJO5DQSGRARQjJpPJ4rVhGDn24d/1U3Hvyz59+uiXX37Rpk2bcpTRX/8ICAhQYmKizp49qyVLluiZZ55RfHy8uZy+uuq3335T3759tXr1apUsWTLXevTXVQ899JD555CQEDVq1EjVq1fXvHnz1LBhQ0n01TXZ2dkKDw/X2LFjJUl169bV3r179f777ys6Otpcj/7K6eOPP9ZDDz1k8e0tib66ZuHChfr888/1xRdfqHbt2kpMTFS/fv1UoUIFPfPMM+Z69Nc/GHcWnsIel92sPvfvqqIcw3Afbq8o3/e5H7kryvdI7sO/U1R9z/25vYyMDD3xxBPKzs7WzJkzb1uf+5A/LC0FFAP33Xef7O3tc2Rfjx8/niNTey/z9vaWpFv2k7e3t65cuaIzZ87kWqe4eeWVV7R8+XJt2LBBlSpVMu+nv3JydHRUjRo1FB4ernHjxqlOnTqaPn06fXWDhIQEHT9+XPXr15eDg4McHBwUHx+vd955Rw4ODubrpb9uztnZWSEhITp06BC/Wzfw8fFRUFCQxb7AwEClpKRI4t+t3CQnJ2vt2rV6/vnnzfvoK0uvv/66Bg0apCeeeEIhISHq3r27Xn31VY0bN04S/XU9xp2Fq7DHZd7e3vrrr79ynPfEiRPcPxXdGIb7kDdF9b7P/bi1onqP5D7kX1H2vbe3d47znDlzRhkZGdyf/y8jI0Ndu3bV0aNHtWbNGvNsDIn7UFBIZADFgKOjo+rXr681a9ZY7F+zZo0aN25spahsT9WqVeXt7W3RT1euXFF8fLy5n+rXr68SJUpY1ElNTdWePXuKXV8ahqE+ffpo6dKlWr9+vapWrWpRTn/dnmEYunz5Mn11g5YtW2r37t1KTEw0b+Hh4XrqqaeUmJioatWq0V+3cPnyZe3fv18+Pj78bt2gSZMmOnDggMW+gwcPytfXVxL/buVmzpw58vLyUrt27cz76CtLFy5ckJ2d5Ucje3t7ZWdnS6K/rse4s3AU1bisUaNGSktL048//mius337dqWlpXH/VHRjGO5D3hTV+z7349aK6j2S+5B/Rdn3jRo10p49e5Sammqus3r1ajk5Oal+/fqFep13g2tJjEOHDmnt2rUqW7asRTn3oYAU1lPEARStBQsWGCVKlDA+/vhjY9++fUa/fv0MZ2dnIykpydqhFam///7b+Omnn4yffvrJkGRMmTLF+Omnn4zk5GTDMAzj7bffNtzd3Y2lS5cau3fvNrp162b4+PgY6enp5jZ69uxpVKpUyVi7dq2xa9cuo0WLFkadOnWMzMxMa11WoXj55ZcNd3d3Iy4uzkhNTTVvFy5cMNehv/4xePBg44cffjCOHj1q/PLLL8Z///tfw87Ozli9erVhGPTV7URGRhp9+/Y1v6a//tG/f38jLi7OOHLkiLFt2zajffv2hqurq/nfb/rqHz/++KPh4OBgjBkzxjh06JAxf/58o3Tp0sbnn39urkN/WcrKyjKqVKlivPHGGznK6Kt/PPPMM0bFihWNFStWGEePHjWWLl1q3HfffcbAgQPNdeivfzDuLHhFOS578MEHjdDQUGPr1q3G1q1bjZCQEKN9+/ZFer13k8Iaw3Afbq8o3/e5H7kryvdI7kNORfU3jtv1fWZmphEcHGy0bNnS2LVrl7F27VqjUqVKRp8+fYquM6zoVvchIyPD6Nixo1GpUiUjMTHR4n388uXL5ja4D3eORAZQjMyYMcPw9fU1HB0djXr16hnx8fHWDqnIbdiwwZCUY3vmmWcMwzCM7OxsY9iwYYa3t7fh5ORkREREGLt377Zo4+LFi0afPn0MT09Po1SpUkb79u2NlJQUK1xN4bpZP0ky5syZY65Df/2jR48e5v+/ypUrZ7Rs2dKcxDAM+up2bvwjAP31j8cff9zw8fExSpQoYVSoUMF45JFHjL1795rL6StL//vf/4zg4GDDycnJqFWrlvHhhx9alNNflr7//ntDknHgwIEcZfTVP9LT042+ffsaVapUMUqWLGlUq1bNGDJkiMWHT/rLEuPOglWU47JTp04ZTz31lOHq6mq4uroaTz31lHHmzJkiuMq7U2GNYbgPeVNU7/vcj9wV5Xsk9yGnovobR176Pjk52WjXrp1RqlQpw9PT0+jTp49x6dKlwrx8m3Gr+3D06NFc38c3bNhgboP7cOdMhmEYhTrlAwAAAAAAAAAA4F/iGRkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAOTD8OHDZTKZcmy1atUq8HNNmzZNK1euLPB2/62oqCi1b9/e2mHky/Dhw7VlyxZrh3FHVqxYoQoVKujy5cuFep6kpCSZTCZ99dVXhXJcXFycxo4dm2P/559/rsDAQGVlZeXrvAAAFHeMOxl3FjXGnQBsGYkMAADyqVSpUtq6davFtnDhwgI/j619oLwbjRgx4q7+QGkYhoYMGaLXXntNTk5OhXouHx8fbd26VS1atCiU9nP7QNmtWzddunRJ8+bNK5TzAgBwN2Pcefdg3Jl3jDsB/BsO1g4AAIC7jZ2dnRo2bGjtMPLt4sWLKlWqlLXDKBLF5Vo3bNigffv2KSYmptDP5eTkZJXfa3t7e0VHR2v69Onq0aNHkZ8fAABbxrjT9hWXa2XcCcDWMSMDAIAC9u233+qBBx5QqVKlVK5cOb388ss6f/68ufz8+fPq06ePAgICVLp0afn5+alnz55KS0sz1/Hz81NycrJmzJhhXkZg7ty5kiSTyaRJkyZZnHPSpEkymUzm13FxcTKZTPr222/VpUsXubm56bHHHpMknT17Vr169ZKPj4+cnJxUv359rV69Ot/XOXfuXJlMJv34449q2bKlSpcuLX9/f33//ffKzs7W0KFD5e3tLS8vLw0ePFjZ2dnmY4cPHy4XFxft2LFD999/v0qWLKnAwECtWLEix3k+/PBDBQYGysnJSVWqVNGbb76pzMzMHHFs3bpVrVu3lrOzswYMGGDuj9dff93ch3FxcZKkyZMnq0GDBnJ3d5eXl5fat2+vgwcPWpw3JiZGwcHBiouLU926deXs7Kz7779fCQkJFvWys7M1ZcoUc4ze3t567LHHLO7n/v371alTJ7m7u8vZ2Vnt2rXT4cOHb9vH8+bNU2RkpO677z7zvurVq+utt94yv/76669lMpn02muvmfetXbtWJpNJv//+u3nf7X4vbzZV/8qVK4qNjZWnp6fc3d313HPPad68eTKZTEpKSrKI9dKlS+rTp4/KlCkjHx8fDRgwwHyfhg8frhEjRuj8+fPmexEVFWU+9rHHHtMvv/yixMTE2/YJAAD4B+NOxp2MOxl3AvcKEhkAAPwLmZmZFpthGJKkr776Sh07dlRISIiWLVumCRMmaOnSpXruuefMx164cEFZWVkaM2aMvvvuO40ePVrx8fF6+OGHzXWWLVsmb29vdenSxbyMQLt27fId50svvaQaNWpo2bJl6t+/v65cuaLWrVtrxYoVGjNmjJYvX66goCC1a9dOu3fv/ld9ERMTo86dO2vZsmWqWLGiunTpor59+yolJUXz5s1Tnz599Pbbb2vBggUWx2VkZOjxxx/XM888o6VLl6pGjRp6+OGHtWfPHnOdd999Vy+99JJatGih5cuXq2fPnpowYYJeeumlHHE89dRTatmypVasWKHu3btr69atkqRXXnnF3If16tWTJP3+++/q06ePvvnmG3300UfKzs5W48aNdfr0aYs2jx07ptjYWL3++utauHChLly4oIcfflgZGRnmOq+88ooGDhyo9u3b63//+59mzJghV1dXnTt3TpJ05MgRc9tz587VF198oRMnTqhly5a3XX943bp1atKkicW+iIgIxcfHm1//8MMPKlmyZI59VatWVaVKlSTl7ffyZgYNGqQPPvhAb7zxhhYtWiRJevPNN29ad8iQIbKzs9OiRYv00ksvafLkyfroo48kSc8//7yee+45i+UxZs6caT62du3a8vDw0Jo1a24ZDwAA9yLGnf9g3Mm4U2LcCdyzDAAAkGfDhg0zJOXYPvvsMyM7O9vw9fU1unXrZnHMt99+a5hMJmPPnj03bTMjI8PYtGmTIck4cOCAeb+vr6/Ru3fvHPUlGRMnTrTYN3HiROP6t/UNGzYYkoxevXpZ1Pvkk08MBwcHY+/evRb777//fuOxxx675bVHRkYa7dq1M7+eM2eOIcl4//33zft2795tSDIeeOABi2Pr169vdO7c2fz6Wj9+/PHH5n2ZmZmGn5+fuf8yMzON++67L0dcY8eONUwmk3H48GGLOCZMmJAj5pv11Y0yMzONCxcuGC4uLsYHH3xg3v/MM8/kuG9r1qwxJBkbN240DMMwDhw4YJhMJmPs2LG5th8dHW1UrVrVuHjxonnf8ePHDWdnZ2PGjBm5Hvfnn38akozFixdb7P/kk08MJycnc3v169c3+vTpY9jZ2Rlnz541DOPqvXrmmWcMwzDy/Ht59OhRi/OdOnXKKFmypDFy5EiL4yIjIw1JxtGjRy2Ou/E+NWnSxGjZsqX59bBhwwxnZ+dcrzciIsJ49NFHcy0HAOBew7iTcSfjTsadAP7BjAwAAPKpVKlS2rFjh8XWtm1bHTx4UMnJyeratavFt+YiIyNlMpm0c+dOcxufffaZ6tatKxcXF5UoUUJNmzaVpBzTzO9U27ZtLV6vXr1aISEh8vf3t4ixZcuW2rFjx786R6tWrcw/+/v759h3bf9vv/2W49jrvw1ob2+vjh07atu2bZKkX3/9VSdPntTjjz9ucUy3bt1kGIY2b95ssf/Ga72Vbdu2qXXr1ipbtqwcHBxUunRpnTt3Lkf/V6hQQbVr1za/DgoKkiTz1Pn169fLMIxbfsNs9erV6tSpkxwcHMz9XaZMGdWpU+eWfZ6amipJKleunMX+iIgIXb58Wdu3b9fff/+txMRE9ezZU2XLltWmTZt05coVbd++XREREZKUr9/L6+3evVuXLl1Sx44dLfZ36tTppvX/85//WLwOCgqyWGLgdu677z4dO3Ysz/UBALgXMO60xLiTcafEuBO4V/GwbwAA8snOzk7h4eE59u/fv1+S5Yek6137QLVs2TJFR0frxRdf1JgxY1S2bFmlpqbq4Ycf1qVLlwo0Vi8vL4vXJ0+e1E8//aQSJUrkqGtvb/+vzuHh4WH+2dHRMce+a/tvvLYSJUqoTJkyOeK99kHqzJkzkiRvb2+LOtde3zgd/8ZrzU1KSor+85//KDw8XB988IEqVKggR0dHtWvXLkeMN7sOSeZ6p06dkoODwy3PffLkSU2bNk3Tpk3LUXarB0NeO4eTk5PF/urVq6tSpUr64YcfdPHiRZUpU0ZBQUFq1qyZfvjhB7m7u+vSpUuKjIw0n1+6/e/ljXL7QJvbteblnt9KyZIldfHixTzXBwDgXsC40xLjTsadEuNO4F5FIgMAgALi6ekpSXrvvff0wAMP5CivUKGCJGnx4sUKCwvTBx98YC67fp3Z23FyctKVK1cs9t344eqa6x/EeC3G0NBQffzxx3k+X2HJyMjQmTNnLD5UHj9+XD4+PpL+6c+//vrL4rhr3566Vn7Njdeam1WrVuncuXNaunSp+UNQZmZmrn14K2XLllVmZqaOHz+e6wctT09PtWvXTr169cpR5urqmmvb167v7NmzOcqaNWum+Ph4Xbx4Uc2aNZPJZFJERIS+/PJLubu7q0KFCqpevbpFO7f7vbzRtftw4sQJizrHjx/PNeY7cebMGZUtW7ZQ2gYAoLhh3Jk/jDsZd16PcSdwdyKRAQBAAalVq5YqVaqkI0eOqHfv3rnWu3jxovkbVtfMnz8/R73cvllUqVIl87fwrlm7dm2eYmzVqpVWrlypChUq5PpBoigtW7ZMPXr0kCRlZWVp+fLlatiwoSQpICBA5cqV06JFi/TII4+Yj1m4cKFMJpN5WYRbKVGiRI4+vHjxokwmk8W3AxctWqTMzMx8x9+iRQuZTCbNmTNHb7zxxk3rtGrVSnv27FHdunXz9e3DqlWrytHRUUePHs1RFhERof79+ys9PV1PPfWUJCkyMlIDBgyQg4ODeXq/lPffyxuFhISoZMmS+uabb1SnTh3z/q+//jrPbVzP0dHxlg+ZPHr0aI6lIQAAwM0x7sw/xp25Y9wJ4G5AIgMAgAJiMpk0ZcoUPfnkkzp//rzatWsnZ2dnJScn69tvv9XYsWPl7++v1q1bq3fv3ho5cqQaN26s7777TuvWrcvRXmBgoNavX681a9aoTJkyqlq1qsqWLasuXbpo2rRpuv/+++Xv769PP/00z2u8RkdH64MPPlBUVJQGDBggf39/nT17Vj/99JOuXLmicePGFXS35MrR0VGjR4/WpUuXVLVqVc2cOVO///67Bg8eLOnqkgNvvfWWXnnlFZUrV04dOnTQrl27NGzYMD377LOqWrXqbc8RGBiob775Rs2aNZOzs7MCAgLUokULSdKzzz6rl156Sfv27dOkSZNyTFHPC39/f/Xs2VNvvvmmTp8+rZYtW+rChQv69ttvNXz4cFWsWFEjRoxQgwYN1KZNG7344osqX768jh07pvj4eDVr1kzdunW7adtOTk6qX7++EhIScpRFRETowoUL2rFjh/kblqGhoXJxcdHmzZs1c+ZMc928/l7eyNPTUy+//LLGjBmjkiVLKiwsTAsXLtSRI0ckXV3qIj8CAwOVmZmp6dOnq3HjxnJzc1NAQIAkKT09XQcOHNCIESPy1SYAAPcqxp35w7iTcSfjTqAYsO6zxgEAuLsMGzbMcHZ2vmWd1atXG5GRkYazs7Ph7Oxs1K5d2+jfv79x9uxZwzAMIzMz0+jfv79Rrlw5w9XV1ejSpYuxbds2Q5KxePFiczt79uwxmjVrZri6uhqSjDlz5hiGYRjnzp0znn32WcPT09MoV66cMWTIEGP8+PHG9W/rGzZsMCQZO3bsyBFfWlqa8eqrrxpVqlQxSpQoYfj4+Bht27Y1VqxYccvrioyMNNq1a2d+PWfOHEOSceLECYt6koyJEyda7HvmmWeM2rVr5+jHbdu2GfXr1zccHR2NgIAA45tvvslx3lmzZhkBAQFGiRIljEqVKhlDhgwxMjIybhuHYRjGxo0bjXr16hmlSpUyJBkbNmwwDMMw5s2bZ1SrVs0oWbKk0bBhQ+PHH380fH19jd69e+cas2EYxokTJyzuhWEYRlZWljFhwgSjZs2aRokSJQxvb2/j8ccfN9LS0sx1Dh48aHTt2tUoW7as4eTkZPj5+RnR0dHGnj17btbVZpMnTzYqVqxoZGdn5ygrV66c4e7ubmRlZZn3tW/f3pB003Zv93t59OjRHL+Dly9fNvr06WN4eHgYbm5uxjPPPGNMnz7dkHTL4wzDMHr37m34+vqaX2dkZBi9evUyypcvb5hMJiMyMtJctnDhQsPZ2dlIT0+/ZX8AAHAvYdzJuJNxJ+NOAP8wGYZhFFXSBAAAQJKGDx+uSZMm6dy5c9YOxaadOHFClStX1urVqy2m7VvT008/rc2bN9906YF/65FHHpGHh4c++eSTAmsTAABAYtyZV4w7Adg6lpYCAACwUeXKldPLL7+syZMnW+UDZXx8vDZv3qz69esrOztbK1as0BdffKEpU6YU2DmOHDmi7777Tnv27CmwNgEAAJA/jDsB2DoSGQAAADbsv//9r95//31dvnxZTk5ORXpuFxcXrVixQhMmTNCFCxdUtWpVTZkyRf369Suwc/zxxx+aPXu2qlevXmBtAgAAIP8YdwKwZSwtBQAAAAAAAAAAbJadtQMAAAAAAAAAAADIDYkMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDN+n+Po76jQ+kGDgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1600x800 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved xgb_v2_binary_feature_importance.png\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── FEATURE IMPORTANCE PLOTS (4-class and binary) ────────────────────────────\n",
+    "import matplotlib.pyplot as plt\n",
+    "import os\n",
+    "\n",
+    "os.makedirs(\"../outputs/figures\", exist_ok=True)\n",
+    "\n",
+    "# Must match the VectorAssembler input order exactly (21 features)\n",
+    "FEATURE_NAMES = [\n",
+    "    \"title_len\", \"has_question\", \"has_exclamation\", \"title_has_number\", \"title_is_allcaps\",\n",
+    "    \"has_title\", \"is_text_post\", \"selftext_len\",\n",
+    "    \"hour_of_day\", \"day_of_week\",\n",
+    "    \"is_known_bot\", \"is_anonymous_author\",\n",
+    "    \"is_new_author\", \"is_new_subreddit\",\n",
+    "    \"author_post_count\", \"author_mean_score\",\n",
+    "    \"subreddit_post_count\", \"subreddit_median_score\", \"subreddit_median_comments\",\n",
+    "    \"title_sentiment\", \"selftext_sentiment\",\n",
+    "]\n",
+    "\n",
+    "def importance_dict(model, names):\n",
+    "    scores = model.get_booster().get_score(importance_type=\"weight\")\n",
+    "    imp = {names[int(k[1:])]: v for k, v in scores.items()}\n",
+    "    return {n: imp.get(n, 0) for n in names}\n",
+    "\n",
+    "def plot_importance(model_A, model_B, task, fname):\n",
+    "    iA = importance_dict(model_A, FEATURE_NAMES)\n",
+    "    iB = importance_dict(model_B, FEATURE_NAMES)\n",
+    "    order = sorted(FEATURE_NAMES, key=lambda f: iB[f])\n",
+    "    vA = [iA[f] for f in order]; vB = [iB[f] for f in order]\n",
+    "    fig, axes = plt.subplots(1, 2, figsize=(16, 8), sharey=True)\n",
+    "    for ax, vals, title, color in zip(axes, [vA, vB],\n",
+    "            [\"Config A (Conservative)\", \"Config B (Aggressive)\"], [\"steelblue\", \"darkorange\"]):\n",
+    "        bars = ax.barh(order, vals, color=color, alpha=0.85)\n",
+    "        ax.set_title(title, fontsize=13, fontweight=\"bold\")\n",
+    "        ax.set_xlabel(\"Feature Importance (weight)\", fontsize=11)\n",
+    "        ax.spines[\"top\"].set_visible(False); ax.spines[\"right\"].set_visible(False)\n",
+    "        for bar, val in zip(bars, vals):\n",
+    "            if val > 0:\n",
+    "                ax.text(bar.get_width() + max(vals)*0.01, bar.get_y()+bar.get_height()/2,\n",
+    "                        f\"{int(val)}\", va=\"center\", fontsize=8)\n",
+    "    axes[0].set_ylabel(\"Feature\", fontsize=11)\n",
+    "    plt.suptitle(f\"XGBoost Feature Importance — {task} (Leakage-Corrected, 30% sample)\",\n",
+    "                 fontsize=14, fontweight=\"bold\", y=1.01)\n",
+    "    plt.tight_layout()\n",
+    "    plt.savefig(f\"../outputs/figures/{fname}\", dpi=150, bbox_inches=\"tight\")\n",
+    "    plt.show()\n",
+    "    print(f\"Saved {fname}\")\n",
+    "\n",
+    "# Models A and B are in memory if eval ran in same session; else reload:\n",
+    "from xgboost.spark import SparkXGBClassifierModel\n",
+    "model_A     = SparkXGBClassifierModel.load(\"../models/xgb_4class_configA_v2/\")\n",
+    "model_B     = SparkXGBClassifierModel.load(\"../models/xgb_4class_configB_v2/\")\n",
+    "model_A_bin = SparkXGBClassifierModel.load(\"../models/xgb_binary_configA_v2/\")\n",
+    "model_B_bin = SparkXGBClassifierModel.load(\"../models/xgb_binary_configB_v2/\")\n",
+    "\n",
+    "plot_importance(model_A, model_B, \"4-Class Engagement\", \"xgb_v2_4class_feature_importance.png\")\n",
+    "plot_importance(model_A_bin, model_B_bin, \"Binary Engagement\", \"xgb_v2_binary_feature_importance.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6d8846c-f5d5-45a6-b21a-8760a404cc36",
+   "metadata": {},
+   "source": [
+    "### Fitting Analysis (Train vs. Validation vs. Test)\n",
+    "\n",
+    "Weighted F1 across the three splits is plotted for both configurations and tasks to locate each model on the bias–variance spectrum. The v1 models underfit (train F1 below val/test). The leakage correction may alter this picture: removing leaked aggregates lowers the effective signal, and the cold-start gap between the train period and the later held-out periods is now explicit. Comparing the corrected fitting curve to v1's clarifies whether the earlier underfitting was genuine or partly an artifact of leakage inflating the held-out splits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6d7902f7-37ce-479a-ae7c-73496cd32642",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABWgAAAIDCAYAAACZ5/dTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdeVxU1f/H8dew4wKIiKCiaO64oJj7Vm6VWmqLW24/zco2M+vbntq3vW9pi5blvpSVZZmlue9liaYJmhqKC4qKgBsgzP39MXFhBBF1YADfz8djHjLnnnvv584MZz4ezj3HYhiGgYiIiIiIiIiIiIgUOhdnByAiIiIiIiIiIiJyo1IHrYiIiIiIiIiIiIiTqINWRERERERERERExEnUQSsiIiIiIiIiIiLiJOqgFREREREREREREXESddCKiIiIiIiIiIiIOIk6aEVEREREREREREScRB20IiIiIiIiIiIiIk6iDloRERERERERERERJ1EHrYiIyA3gwIEDWCwW87FmzZoCOU/Hjh3NcwwdOrRAznGjCA0NNV/LcePGFdp5C+uzkunuu+82z7Vt27YCPZejDB061Iy5Y8eOzg5HbmDZf1dnzpxplkdGRprl99xzj/MCFBERkXxRB62IiEgxs2bNGrv/lF/ukd8O0vx2yJXEztfNmzfneN1eeuklZ4d1w1i3bh3ffvstAD169KBJkybmtks/59k7n8S59u/fz3/+8x9atGhBQEAAHh4eVK5cmZYtW/L888+zc+dOZ4dY6MaNG2d+VkNDQ50dDk2bNqV79+4ALFy4kPXr1zs5IhEREcmLm7MDEBERkYLn7+/PO++8Yz6/6aabCuQ8Dz/8MD169ACgQYMGBXIOR8qt02/27NlMmDABi8VS+AEVAYX1WQF44YUXzJ/HjBlTYOcRx8jIyOCVV17hjTfewGq12m07evQoR48e5bfffmPy5MkkJiY6J0gxjRkzhiVLlgDw/PPPq5NWRESkCFMHrYiISDHXt29fmjVrlqM8ewepj48PY8eOLZRYiouUlBS++uqrHOWxsbGsWrWKTp06OSEq5yusz8qff/7Jhg0bAKhcuTIdOnQo8HPK9Rk1ahRTp041n3t7e9O7d2/q1atHeno6u3btYunSpQUex5kzZyhbtqzD6pVUHTt2pHLlyhw5coQNGzawY8cOGjVq5OywREREJBea4kBERKSYu+222xg7dmyOx2233WbWudw0BqGhoVSvXt3ueLfccovd/JqZt+6uXbvWrDNr1iy74x04cAC4/DQIuZ1/7ty5NGvWDG9vbwICAhg6dCgJCQk5ru/8+fM899xzVK1aFS8vL+rXr89HH31ETEzMdc2V+t1335mj/CwWi91I0cvdTn/p9e3Zs4d7770Xf39/vL29adWqVa5xfPrpp9x7773UrVuXgIAA3N3d8fHxoUmTJjz77LOcPHkyXzHPnj3bPH+ZMmU4c+aM3fZTp07h7u5u1vnhhx8AOHfuHBMmTKBp06aULVsWd3d3AgMDCQ8P54EHHrDrVMtryov09HQmTpxIq1at8PPzw83NjfLlyxMWFsbgwYP58ssv83UdANOnTzd/7tOnDy4ujklL4+LiePbZZ2nUqBFly5bFy8uL2rVrM2bMGI4dO5aj/ooVK/i///s/mjRpQlBQEJ6enpQqVYpatWrxf//3f1d1u/7Zs2dp1aqV+doFBgayY8eO6zrPwYMHGTBgAOXLl6d06dK0bduW5cuXM3PmTLv36VIpKSl88MEHtGvXDn9/f3MaggEDBlzTXL9Lly6165ytXbs2UVFRzJs3jxdffJFx48bx9ddfExcXl+s0Ib///juDBg0iNDQUT09PypYtS+PGjXn++ec5ceJEjvqXzsG8cuVKOnTogI+PDz4+PkDOaTD27t3Lf//7X2rXro2HhwePPfaYebyMjAxmzZpF586dqVChgvk7cNddd7F69erLXvevv/7K4MGDuemmm/D29qZs2bLUq1ePBx54gMOHD5sxjB8/3tzn4MGDeU7PsWjRInr27ElwcDAeHh74+/vTpUsXc7qPS6Wnp/Pmm29Sq1YtPD09uemmm/jvf//LxYsXLxs3gIuLC7179zafT5s2Lc/6IiIi4kSGiIiIFCurV682APMxY8aMK+4TExNjt8/q1asNwzCMatWq2ZVf+ujQoYPxyiuv5FkHMGJiYgzDMIwOHTqYZUOGDLns+du0aZPrcdq0aWMXd1pamtGuXbtc6/bs2TPXa8qvrl27mvu2b9/eePfdd83npUqVMpKTk3Psk/36GjVqZJQpUyZHXB4eHsZff/1lt19YWFier1/lypWNI0eO2O2T/b155ZVXDMMwjJSUFKNChQpm+aeffmq3z9SpU81tgYGBxsWLFw3DMIyOHTvmef6+ffte9r3K/roOGTIkz+O0aNEi369//fr1zf3mz5+fY/u1fM43bNhg+Pv7Xza+wMBAY9u2bXb7PPLII3lek4eHh7F8+XK7fbK/Dh06dDAMwzDOnTtntG/f3iwPCgoyoqKirus8MTExRlBQUI66FovFuOOOO+zKsjt+/LjRsGHDy57Lzc3NmDVr1hVfz+y6detmd4w//vgj3/u+//77houLy2XjqVixohEZGWm3T/bPf8uWLQ1XV9cc13vpZ+TSdiWzDTp37pxxyy235Pn6v/baaznifumllwyLxXLZfVavXp0jhtwemZ/djIwMY8CAAXnWHTlyZI44+vXrl2vdHj16XPF3ZN68eeb2sLCwfL9nIiIiUrg0xYGIiEgxt3Tp0lxHYPbt25eQkJA8933hhRc4cOAAr7/+uln20EMPmaNJQ0JCCAkJoUyZMkyZMoV//vkHgGbNmtlNZ+Dv739VMW/cuJFWrVrRqVMnfvzxR7Zv326Wb968mVatWgEwadIku3kTGzVqxF133cWff/5pjg69FkeOHGHFihXm8379+tGzZ0+efvppDMPg/PnzfPXVVwwfPvyyx9ixYwcBAQE89NBDHD9+nDlz5gCQlpbGBx98wKeffmrWrVixIjVr1qRGjRr4+/tjsVg4cuQIX331FadOneLIkSP897//ZfLkyXnG7enpyQMPPGC+X59//jkjR440t3/99dfmz4MGDcLNzY3o6GhzFKyLiwuDBw+mdu3anDx5kpiYmHyPPD579ixz5841n9999900bdqUpKQkDh48aDfC+koSExOJiooyn2dfHOxaJSUl0bt3b3MUdo0aNbjvvvtwd3fnq6++Ys+ePcTHx9OnTx+io6Px9PQEoEyZMtxyyy2EhYWZI6FPnTrFkiVLiI6OJi0tjccff9wu3kulpKRw5513sm7dOgCqVKnCypUrqV27tlnnWs7z6KOP2o36veOOO4iIiGDJkiX89NNPl43n/vvvN0fk+vr6MnDgQIKCgli7di0rV64kPT2dESNGEBERQVhY2BVfW6vVavf+Nm7cmIiIiCvuB7B27VrGjBmDYRgAVK9enX79+pGQkMCMGTNIS0vj+PHj9O7dmz179pjvS3a//vorZcuWZeDAgVSqVIk//vgj13Nt3LiRRo0a0b17d6xWK76+vgCMHj3aHCXr6enJgAEDqFGjBtu2bTNHrb7wwgs0a9aMrl27ArBgwQJeffVV89ilS5emf//+VKlShf3795vtz0033cQ777zDL7/8wvLlywEoV64czz//vLnvzTffDMCbb77J/PnzAdvv4r333kuDBg3Yu3cv8+bNIyMjg6lTpxIREWH+Xn/zzTd2I9Nr1qzJfffdx5EjR8w2Jy/Zf7d27dpFYmIifn5+V9xPRERECpmze4hFRETk6uRnxBaXjHzMa1RkXtuyu9zo2PzUufQcLVu2NEd3njp1ym503AcffGDuV7t2bbM8NDTUOH/+vLnt0tGcVzOC9vXXX7cbTRgfH28YhmE3Aq9t27Z5Xp+Li4vx559/mtt69eplbmvatGmOfc+dO2esWLHCmDp1qvHee+8Z77zzjnHXXXeZ+9SoUcOufm4jaA3DMA4dOmT3emXGcPLkScPNzc0s37lzp2EYhhEZGWmW1atXz7BarXbnSU9PNw4cOGA+v9znISEhwSzz8fExUlNT7Y5jtVqNf/7550ovvWEYhvHXX3/ZnePUqVM56lztCNpJkyaZdQMDA43ExERz2+nTpw0vLy9z+7x58+z2zcjIMH777Tdj5syZxsSJE4133nnHGDNmjN35Y2NjzfrZP3utWrUybr/9dvN5tWrVjP379+ca49Wc58iRI3ajN7OPck5JSTHq1KmTY0SpYRjGn3/+aVe+adMmc5vVajVatWplbnvggQfyfE0zxcfH2x0zeyxXkv0zXrZsWePEiRPmttmzZ9sdd+7cuea27J9/Nzc3Y8eOHTmOfelnpF27djk+l5e2L5eO1s4+OrVLly5meZMmTczyMmXKGHv37rXbLzEx0Th58qT5PPudBtWqVcsRa0ZGhlG+fHmzzuuvv263/dlnnzW31apVyyzPPnLZ19fX7nfltddeu+LvyMmTJ+3q7Nq1K0cdERERcT6NoBUREZFCN3z4cNzcbGmIv78/AQEBHD9+HIDTp08DtgV+/v77b3Ofe++9F29vb/P5sGHDmDVr1jWdP/t+nTp1okKFCoBtJO3GjRsB2LBhA/v27aNmzZq5HqNVq1Z2C+7UqVPH/DnzGjK99957vPLKK5w9e/ayMR05ciRfsVepUoVevXqxcOFCAD777DM+/PBDvv32W9LT0wHbiL3MReLq1atH+fLlOXXqFNHR0dSsWZMmTZpQu3ZtGjVqROfOnalWrdoVz1uuXDnCwsLYtWsXycnJVK9enZtvvplatWrRsGFDOnXqlGM+48vJnPs3U+acotcj830DiI+Pz3OU4KZNmxgwYAAAy5cvZ8SIEcTGxuZ5/MOHD+c6In3z5s3mzzVq1GDVqlW5vp5Xe57IyEhz1CnA4MGDzZ89PT3p378/48aNy7F/9tcBoHXr1pc916ZNmwBITk62m182k6+vLw888IBdHFcr8xwAt99+OwEBAebzAQMGMHz4cHMu1U2bNjFw4MAcx+jevTsNGza84rnGjBmDh4eHXdlvv/1GRkaG3Tkz3/vLxXr+/HlzVD/YXvtL24HM0bn5tWfPHk6dOmU+f/755+1G2Wa3d+9eTp48SUBAgN1o4dtuu83uboX777+fF154Ic/zXvq7denvnoiIiBQN6qAVEREp5mbMmGG3IFdxcGkHVvbbmq1WK2C7ZT27oKCgPJ/n1+bNm9mzZ4/5vF+/fubP9957L6NHjzY7dGbNmmV3m3N2+bkGsC0I9NRTT10xrtTU1PxdALZb3zM7aOfNm8c777zDV199ZW4fNmyY+bOXlxdfffUVw4YNIzY2ln/++cecqgLAw8ODN998kyeffPKK550/fz79+/cnKiqKo0eP8v3335vbXFxceOKJJ3jvvfeueJxLO0+Tk5OvepqMS+W2wNzlZC5KdfToUXr16sX58+evuE9+3h9/f/9cr+NaznNpR1p+P//X8jokJCTw9NNP59herVo1HnjgAQICAvDy8iIlJQWA3bt35/sc2f9YERgYaLfN1dWV8uXLm9M4XPqHjUzZp4rIS271rub1OHfuHBcuXOD06dN2ndKhoaH5PsblXE0cYHtvAgIC7D4Hl75+FStWvOJxkpOT7Z5regMREZGiSR20IiIiUujc3d3tnue2Cv2lHQnx8fF2z7PPzXk1Ll1RfdiwYXYdmtnNnj2bCRMm5Bpffq4BbHNZZqpUqRILFy6kSZMmeHp6MnnyZB555JGrvALo2LEjDRs2ZOfOnZw+fZpPP/3UnEvWy8uL/v3729W/9dZbiYmJITIyku3bt7Nv3z42bdrE+vXrSUtLY+zYsdx5553m3MOX06hRI3bt2sXOnTuJjIxk7969REZG8vPPP2O1Wnn//fe588476dixY57HqVSpkt3zEydOXHcHbbly5cyfq1atymOPPXbZupmjnRcvXmx2mlosFubOnUvPnj0pW7YsUVFR+ZqfNSQkhISEBM6dO8cff/xBz549Wbp0KV5eXmadaznPtX7+s78OAK+//nqOz2qmUqVKXfH6wNb53qFDB5YtWwbAn3/+ybZt2/I1d3C5cuXMjuBLryEjI8NuVOmlsV9tnLnVu/SYTz/9dI6Ozuzc3NwoV64cFovF7KQ9cOBAvs6fl0vjGDFihN2o+0tlxujn52e+Rpe+fpl3HeTl0n0u/d0TERGRokEdtCIiIje4SztvLjfKL3u9/IwEvF5lypShbt265mi9b7/9lgkTJpi3MM+YMeOqj5mSkmI30vRKYmNjWbVqFZ06dbrqc2XK3gEVERFBy5YtAdso2+yLel2tRx55hIceegiAZ5991pzeoFevXnadeykpKcTExFCvXj2aNWtGs2bNADAMg3LlypGUlITVamX79u1X7KDdvn074eHhNGzY0O6W88aNG7Njxw4Atm7desUO2nLlylGnTh1zJPO2bdvy7KzKj9atW5uv5/Hjx+nevTv16tWzq5Oens6PP/5I27ZtAfv3xtfXl379+uHi4gJgtzBTXmrUqMHUqVO58847uXjxImvXruWee+7hu+++M39nruU8zZo1s+sk/PLLL7ntttsA2yjbL7744rKvQ3ZBQUG5/gFiy5Yt5qjv0NDQK05j8Pjjj5sdtGCbKmDZsmVUrVrVrt7Zs2eZOnUqY8aMMePJHGmduaBh5jQH8+fPN6c3yC12R2jRogWurq7mqHhvb2/Gjh2bo15UVBQJCQm4u7vj7u5OeHg427ZtA2DOnDk89dRT1KhRw+4609LSzD8sXKl9rFu3rjnVCNjew9ziiI2NJTo6mvLlywO2z0Hm67506VISEhLMc2ZftO9yIiMjzZ/DwsI0glZERKSIUgetiIjIDa5ChQq4u7ubHSUvvPAC27dvx8PDg44dO5odepUrVzb3WbJkCc8++ywBAQEEBAQU2BQLDzzwgDk9wN69e2ndujXdu3fnzz//tLu9Pr++++47u1uGO3XqZDcnZqZFixaZt5rPnDnzujpo69SpY67uvmTJEh544AEqV67MkiVLLrsafX4MGjSIZ599lsTERPPWcyBHZ1xiYiL169cnLCyM5s2bU6lSJby9vdmwYYPdNBL56bhp2bIllSpVol27dlSqVAkfHx/+/PNPs3M2v8cB22uf2UH766+/2k01kZvx48fz0Ucf5SivU6cO8+bNY+jQofz3v//l1KlTpKam0rJlS+677z6qV6/OhQsXiIqKYs2aNSQkJBATE2N2EmdKTEzk9ttvp127dmzdupVFixbl6zrANjfo9OnTGTx4MIZhsGTJEgYPHsy8efNwcXG5pvMEBQXRo0cPFi9eDNim20hKSqJRo0b8+OOPdtN0ZBceHk6nTp1YuXIlYPsdWrx4MeHh4QDExMSwdu1aYmJimDFjBo0bN87XNd5xxx0MHz6cadOmAbZpDurVq0fv3r2pV68eFy9eJCoqiqVLl+Li4mJ20I4ePdr8XU1OTqZ58+b069eP06dPM336dPP4ISEh3H333fmK5WqUL1+eoUOHmnFPmDCBX3/9lZYtW+Lu7k5sbCwbN24kKiqKV155xey8f+aZZ8yR6GfOnKFx48b079+fkJAQDh48yPfff8/XX39t/jEie/t44sQJhg0bRv369bFYLDzyyCN4e3szevRoXnrpJcDW6bt3715uvfVWSpcuzdGjR/n111+JjIxk8ODBdOvWDbDN153ZQZuUlESLFi3o27cvhw8fZs6cOVe8/uxzJF9POyYiIiIFzHnrk4mIiMi1uNrV7Q3DMGJiYuz2Wb16td323r17223PfLzzzjtmne+//z7XOmFhYWadDh06mOVDhgzJ9/mzr9j+yiuvmOVpaWlGu3btcj3v7bffbvd87dq1V3wdunbtatb38/MzLly4kGu9e++916xXqlQpIzk5Oc/rM4zLr+K+d+9eo2zZsjnid3NzMwYOHGhXlp/XJLsnn3zSbv+QkBAjIyPDrk5cXFyur1/2R/PmzY2LFy8ahpH3e+Xp6ZnncapXr24kJiZe8X0wDMPYunWrXdxWq9Vu+6Wf88s9GjdubO6zfv16w9/f/4r7xMTEGIZh+3w1bNgw1zpDhgy57OuQfVuHDh3M8nfeecdun5EjR17XeQ4cOGAEBQXl2MdisRjdunWze57dsWPHLnu+q207srt48aLxzDPPGC4uLnke19fX126/d999N899KlSoYPzxxx92++Tn83/pZyTzfb3U2bNnjVtuueWKr8el53nppZcMi8Vy2frZ36u4uDijVKlSudY7ceKEYRiGkZ6ebvTv3/+KcVzatmRvj7I/srdHub2fGRkZRqVKlczt27dvz/X1EREREeez3VslIiIiN7TPPvuMIUOGULFiRfPW60vdeeedfPTRR9SrV++yc1o6mru7Oz///DP/+c9/qFKlCh4eHtSpU4f333+fF1980a7ulUZuHj16lBUrVpjPBwwYYDdPaHbZR6GeP3/+qqZFuFTNmjVZt24dXbt2pVSpUpQpU4YOHTqwcuVKOnfufM3HBds0B9nfryFDhuR4/8qVK8dHH31E//79qV+/Pv7+/ri6uuLj40OzZs149dVXWblyJW5uV76xasqUKQwbNoxGjRpRoUIF3NzcKFOmDI0aNeKZZ57ht99+y/fq9k2bNqVNmzYAHDp0iHXr1l3Fleeubdu27Nq1i+eee44mTZpQtmxZPDw8qFq1Km3atOGll15i69at5qJP7u7urFq1iqFDh1K+fHk8PT1p0KABU6dOZdy4cVd9/rFjx9otCDd16lSefvrpaz5PtWrVzNHFfn5+eHt706pVK5YsWWI3jcSln/2KFSuyZcsWPvzwQzp06IC/vz9ubm4EBQURERHBww8/zLJlyxg4cOBVXZ+bmxtvvfUWu3fvZuzYsTRr1gx/f3/c3d0JDg6mefPmPPvsszney6eeeopNmzYxYMAAQkJC8PDwoFSpUjRs2JD//Oc/7Ny5k4iIiKuK5WqULl2aFStWMHv2bLp27WreNRAQEEDjxo0ZOnQo3333Hf/5z3/s9pswYQIbN27k/vvvJzQ0FE9PT0qVKkXNmjUZNmwYNWvWNOsGBQWxePFi2rRpQ+nSpXONw9XVlfnz5/P9999z1113UalSJdzd3SlXrhwNGjSgb9++zJs3j0mTJtntN2/ePF577TVq1KiBu7s7oaGhvPDCCyxdujTP6169ejVHjx4FbL8b+R0tLSIiIoXPYhhXmHBKRERExIkuXLiAt7d3jvKxY8fyv//9D7DNV3vq1ClzftobRUpKChUrViQ5ORmLxcLevXuvOI9sUbJu3To6dOgAYHc7v9hYrVbS09NzfK4zMjJo3bo1W7ZsAaBLly788ssvzghRirDu3bvz008/AbbftXbt2jk5IhEREbkczUErIiIiRdott9xCjRo1aNeuHSEhIZw+fZqlS5faLZL04IMP3lCds7/++iuJiYnMmjWL5ORkALp161asOmcB2rdvT58+ffj222/58ccf2bZtG02aNHF2WEVGcnIytWrVYsCAAYSHhxMYGMiRI0eYOXOm2TkLtgW8RLKLjIw0O2fvvvtudc6KiIgUcRpBKyIiIkVaeHg4f/7552W3d+/enYULF5or0t8IQkNDOXjwoPnc09OTLVu20KhRIydGJY6WmJhIuXLlLrvdYrEwfvx4c+EpERERESmeNAetiIiIFGmPPvoo3bp1o3Llynh5eeHp6UmVKlXo1asX33zzDT/++OMN1TmbXdmyZc35bNU5W/KUKlWK5557jpYtWxIYGIi7uzulSpWiTp06DB8+nN9++02dsyIiIiIlgEbQioiIiIiIiIiIiDiJRtCKiIiIiIiIiIiIOIk6aEVEREREREREREScRB20IiIiIiIiIiIiIk6iDloRERERERERERERJ1EHrYiIiIiIiIiIiIiTqINWRERERERERERExEnUQSsiIiIiIiIiIiLiJOqgFREREREREREREXESddCKiIiIiIiIiIiIOIk6aEVEREREREREREScRB20IiIiIiIiIiIiIk6iDloRERERERERERERJ1EHrYiIiIiIiIiIiIiTqINWRERERERERERExEnUQSsiIiIiIiIiIiLiJOqgFREREREREREREXESddCKiIiIiIiIiIiIOIk6aEVEREREREREREScRB20IiIiIiIiIiIiIk6iDloRERERERERERERJ1EHrYiIiIiIiIiIiIiTqINWRERERERERERExEnUQSsiIiIiIiIiIiLiJOqgFREREREREREREXESddCKiIiIiIiIiIiIOIk6aEVEREREREREREScRB20IiIiIiIiIiIiIk6iDloRERERERERERERJ1EHrYiIiIiIiIiIiIiTqINWRERERERERERExEnUQSsiIiIiIiIiIiLiJOqgFREREREREREREXESddCKiIiIiIiIiIiIOIk6aEVEREREREREREScRB20IiIiIiIiIiIiIk6iDloRERERERERERERJ1EHrYiIiIiIiIiIiIiTqINWRERERERERERExEnUQSsiIiIiIiIiIiLiJOqgFSnibrvtNiwWi/nYvXv3VR9jxYoV9O/fn+rVq+Pt7Y2fnx9hYWE89NBD/Pbbb2a90NBQ8zw3omrVqpnXHxsba5YbhkH58uXNbd9++63dfl26dDG3bdiw4arPm7lvaGjoNcc+btw48zgzZ868Yv3t27czbtw4xo0bx5o1a675vHk5cOCAGVPHjh2vWH/o0KF2n/VLH+Hh4Xb1p0yZwl133UVwcLBdvavhiNf+asXHx/PEE09Qq1YtvLy8KF26NFWqVKFNmzY8/PDDxMXFXfOxL/c5uNzv9sSJE83PgYiISEHJ/v2U+XBzc6N8+fK0bduWjz76CKvVarePM76jiyvlsI6lHDZ3ymFFCpabswMQkcubMWMGy5Ytu+b909LSGDZsGPPnz7crT0lJISkpiaioKI4dO8aiRYuuM9KSoV27dsybNw+A9evXM3DgQAB27dpFQkKCWW/9+vX06dMHgPT0dDZv3gyAp6cnN998cyFHfW22b9/O+PHjzef5ST6Lmk8//ZQ///zT2WFclcTERFq0aMGBAwfsys+fP8+RI0fYtGkTw4cPJzg4uFDimThxIgcPHgRQgisiIoUqIyODhIQENm7cyMaNG4mNjeXtt992dljFknLY4kU57PVTDislkUbQihRRR48eZcyYMbi4uODl5XVNx3jsscfMztkyZcrw6aefcuLECVJTU9m1axfjx4/Hz8/PgVEXb+3btzd/XrduXa4/gy25zbR161bOnTsHQPPmzfH09Lzq8xqGgWEYORKeG9krr7xivi6Zj+3bt9vV6dWrF5MmTWL16tXOCfIaTJs2zXyfhw4dytGjR0lJSWHfvn1888039O3b95p/3/Ny4MAB83UUERFxpiFDhmAYBhcuXOD55583yy8dPVmU8qMLFy44O4Q8KYctOpTDOpZyWLmRqINWpIh66KGHSExMZMyYMVSsWPGq99+zZw+fffaZ+fzzzz9n5MiRBAQE4OHhQf369Xn55Zf5/PPP8zxOSkoKw4YNIzw8nAoVKuDh4UHp0qVp1KgRL7/8spnYZfrxxx/p0KED5cqVM29dCw8PZ/jw4Zw+fdqsN3PmTFq0aIGPjw/u7u4EBgbSvHlzRo0a5bQv4Hbt2pk/Z09gM3/u0aMHYPvL/ZkzZwD7xDf7/mfPnmX8+PE0atSI0qVL4+3tTcOGDXnzzTdJS0uzO+/lblGKioritttuo3Tp0gQEBDBy5EgiIyOveMtVRkYGb775JjVq1KBUqVJERESwfPlyc3toaCjDhg0zn48fP948Zva/QP/5558MHDiQKlWq4OHhgb+/P7fddhsrV67Mcc6//vqLbt26UapUKcqXL8/w4cM5depUrvE5yrhx43j88cdp2bKlQ463Y8cOunbtSunSpfH392fYsGHmNcTExODm5obFYqFFixZ2+8XHx+Pu7o7FYqFJkyZ5nuPvv/82f+7cuTPBwcF4enpy0003cffdd/Pll1/SoEEDs87MmTPt3ptJkyZRu3ZtPD09qV27NpMnT87XtV16e1jmcTNHHgDXfIudiIjItfDy8uL+++83n58/f95ue275UfbvxVdeeYVJkyZRp04dvL29CQsLM0eRZlq3bh133XUXN910E76+vri5uREQEECXLl1y3EF26bHffvttatasiZubG19++aVD8oCCohxWOaxyWOWwUgIYIlLkzJ071wCM2rVrG+fPnzeqVatmAAZgREdH5+sY77zzjrnPTTfdlK99sp8n0+nTp82y3B5du3Y16/7xxx+Gm5vbZevu3bvXMAzD+O677/I85sWLF6/i1XKswMBAM474+HjDMAyjcuXKBmAsXrzYqFChggEYy5YtMwzDMHr06GHW//nnnw3DMIxTp04Z9evXv+z1tW/f3khNTTXPmVlerVo1s+yff/4xypUrl2PfkJAQ8+cOHTqY9V955RWzPCgoKMd+Hh4eRkxMjGEY9u/zpY9XXnnFMAzD+P777w13d/dc61gsFmPKlCnmuffv32/4+vrmqJf5ul0a6+UMGTIkRxz5ceHCBbvzXo3MfcqUKWP4+PjkuIbw8HAjJSXFMAzDuO+++8zy3377zTzGpEmTzPJPPvkkz/P997//tXtPevToYbzxxhvGqlWrjPPnz+eoP2PGDLN+5mfv0sdbb71l1s/+OZgxY4ZZfunvdvbj5vYQERFxpOzfT0OGDDEMwzBSUlKMl156ySwfOnSo3T655UfZv79yy5MAY+PGjWb9999/P8/vu/nz5+d67ICAALt6M2bMcEgeUJCUw75iGIZyWOWwIsWXPsEiRcyxY8eM8uXLGy4uLsaGDRsMwzCuqYN21KhR5j49e/bM1z65ddCmpKQY8+bNM/bv32+cOXPGSEtLM/bt22eEh4ebdXfs2GEYhmH873//M8sWLFhgpKWlGfHx8camTZuMl19+2YiLizMMwzAee+wxs97mzZuNtLQ0Iy4uzli1apXx9NNPGxkZGVfzkjlUnz59zNi+/fZbY//+/QZguLi4GKdPnzZ69+5tAMaLL75oZGRkmAmoi4uLkZSUZBiGYTz66KPmMT766CMjOTnZSExMNB5//HG78ky5JbeDBw82y7t162YcPXrU+Oeff4xmzZpdMbktW7as8csvvxiJiYnGgAEDzPI33njDrJ89ubk0kTx//ryZSIWGhhq///67kZqaauzZs8eoU6eOARje3t7GiRMncsTavXt349ixY8aBAweMli1bXnNym1fifSlHJLeAMXLkSOPUqVPGX3/9ZdSqVStHwvr777+bZYMGDTKP0bx5c/N1P3PmTJ7ni4uLM8qXL5/r9ZUpU8YYM2aMmUwbhv375OnpaSxevNg4c+aMMXPmTLPc29vbSEhIMAwj/8ntlcpFREQcKfv3U26Ppk2bGsnJyXb75JYfZf9edHV1Nb744gsjKSnJeOaZZ8zyBx980Ky/bds2Y+XKlcaxY8eM1NRU49y5c8bixYvtzpvbsQHjnXfeMRISEoy4uDjj8OHDDskDCpJyWOWwymFFijdNcSBSxDzyyCOcOnWKxx9/nDZt2lzzcYxs0wRcz+0enp6epKSkMGTIEKpWrYqXlxc1a9a0m0spKioKgJtuusks+/jjj3nrrbdYs2YNAQEBjB8/nqCgoBz1Xn/9dd577z1+/fVXatasydtvv42Li/Oapuy3eK1bt868/atBgwb4+fmZc3ytX7+enTt3mtM2NG7cGB8fHwC+++478xiPPvooPj4++Pn58cEHH5jlS5cuzTOOX375xfz57bffJjg4mOrVq/Pqq69e8RpGjBhBly5d8PX1pX///mZ5fucH27hxIydOnDD3ufnmm/H09KROnTrs2bMHsM3Ftnbt2hyxvvnmm1SsWJFq1arZLeBQ1Lm5ufHee+/h7+9PWFgYY8eONbdlXl+zZs3MW/K++uorTpw4wd69e9myZQsAAwcOpEyZMnmeJygoiO3btzN06FD8/f3ttp09e5b33nuPF154Idd9+/TpQ48ePShTpgxDhgyhVatWgO29uJaVl0VERIqKyMhI7rzzTjIyMvK9z5133km/fv3w8fFh0KBBZnn2fKdKlSosXryYjh074ufnR+nSpenZs6e5PTOHvdStt97K2LFjKVeuHEFBQVSuXNkheUBBUg6rHFY5rEjxpg5akSLkjz/+YOHChfj5+dG7d2/++OMP/vjjD7v5nnbt2mUmk+PGjbObc8disTB06FDAvhN0165d1xzT//73P4YPH86GDRs4ffo0Vqs1R53MhRPuuusunnrqKUqVKsW6det46aWXuO+++6hduzYREREcPXoUgIcffphBgwbh7u7O4sWLefbZZ+nduzdVq1alc+fOnD17Ns+YLr3m/D4unR8rN9kXWVi/fr05d1dmeWby+9tvv7FixQqzbvak+Pjx41c8z8mTJ/O9vVq1aubP+bmGevXqmT+XLl3a/DklJeWK+0L+4oesGLPHGhISYv6cPe6rldsCCwW5QmtAQIDda5U99vj4ePPnzKQ3NTWVzz77zG6uu4ceeihf56pSpQozZswgPj6erVu38v777xMWFmZu//LLL3Pd79LX83IxioiIFGWZi4RdvHiRLVu2UKFCBQDWrFnDjz/+mO/jXCnfsVqtdOrUiYkTJ7J79+5cF/q6XG4UERGRa/n15gHKYfOmHPbqKYcVKTnUQStShGR2TCYmJtKhQwduvvlmbr75ZuLi4sw699xzDwMGDLjisXr06GGORN2/fz9ff/11rvXS09PzPM7cuXPNnydNmsT58+cxDIM+ffrkWv/dd98lISGB33//na+++opHHnkEsI2MmDBhAgAeHh7Mnj2b06dPs2nTJubNm2f+lXzlypV89NFHV7y+ghIeHm6OIti+fbv5l+fM5DVze0pKCh9++KG5X/bkNnNRN4vFwtGjR3MkaYZhsGnTpjzjyPzPCsChQ4fMn2NiYq54De7u7ubPlxs9ndeo6uyL0nXr1i3X+K1WKw8++CBgSwxzizX75P1F3cmTJ+0WvMsee2BgoPnzHXfcQf369QH45JNPzOS2VatWNG7c+IrnSUpKMn92dXWladOmjB49mmXLlpnll1uY4tLX83IxXg0tpiAiIs7i5ubGzTffbNexuHv37nzvf6V8Z+fOnezYsQOw5TY7d+4kPT2d5OTkKx67VKlSuZZfbx5QkJTDKocF5bAixZk6aEWKsXHjxuVIOmbOnAlAnTp1eOCBB8y6I0aM4PPPP+fUqVOkpaURFRXF+PHjGTFiRJ7ncHNzM38uU6YMFouF77//niVLluSou3btWl5//XV27dpFaGgovXr1olevXub22NhYABYuXMikSZOIiYmhXr163H333XTu3DlHvcvJLdnKzyM/t0e5uLjQunVrwLaS7OHDh4Gs5NXV1dXcnj25aNu2rflz7969zTiHDBlCdHQ0Fy9e5NixY3zzzTfcdtttzJkzJ884unbtav78/PPPc/z4cQ4cOMDLL798xWvIj/Lly5s/R0dH243SbtOmjZlc//LLL7z77rucOnWK1NRUdu/ezVtvvUXNmjVzjfW5557j+PHjxMbG8sorrzgk1stJSkri5MmTOZLBkydPcvLkSbtE8krS09MZO3Ysp0+fJioqinfffdfclv36LBaLOQLh0KFD7Nu3D8j/yIN3332Xtm3b8tlnn7F3717S0tI4ffq0+XsL2I1EyO7bb79lyZIlnD17llmzZrF582YAvL297T5/VyP75yD7tCUiIiIFLSMjg99//928FR8gODjYYcfPnsO6urpSpkwZkpKSGDNmzDUf83rzAOWw1085rD3lsMphpQS57llsRaTAXcsiYYZhGGlpaUb//v3znLT+rrvuyvU8md58880c+7i4uBg33XRTjonc58yZk+e5PvzwQ8MwDOPVV1/Ns97ixYsd8rpdq9dff90unpo1a+a5vVatWnbbT506ZYSFheV5jdknv88sy88KuNlXle3YsaNZ/3IT669evdosz1w12TAM48iRI4anp2eO469evdowDMP44YcfDA8PjzyvIdPlVsDNvmJrQayA26FDhzzjy885M+vmZwXcTKmpqUalSpXMOv7+/saFCxeueC7DMIwXXnghz5hdXFzsPv/ZF1jI/t5nf7z55ptm/atdYCH7gn1X87qJiIhcjSstEgYYNWrUsFuoKLf86HILRMXExOT4HktPTzcaNGiQ4zy1a9fONZ/Ja/Gp7K4nDyhoymGVwyqHFSm+NIJWpARzd3dn/vz5/PLLL/Tr14+qVavi6emJj48P9erVY+TIkTz77LN5HmPs2LFMmDCB0NBQPD09ady4Md99912uf+2MiIhgxIgRNGzYEH9/f1xdXSlbtiwtW7Zk6tSpPProowB06tSJQYMGUbduXXx9fXFxcaFcuXJ07NiRb7/9lh49ehTI65Ff2W+1A/tbv3Lbfulr4e/vz2+//carr75KkyZNKF26NJ6enlSrVo0uXbrwv//9j9tvvz3PGKpXr8769evp2rUr3t7e+Pv7M2zYMD777DOzTvbbsq5WpUqVmDdvHg0bNsTb2zvH9p49e7J161YGDx5M1apVcXd3x9fXl3r16jF48GAWLFhg1q1Rowbr16+nS5cueHt7U65cOQYNGsTixYuvOb7CVr58edavX0/nzp0pVaoUfn5+DBkyhOXLl+Pp6WlX18PDg8cee8x8PmTIELy8vPJ1nkGDBjFhwgQ6d+5M9erVKVOmDG5ubgQHB9OrVy9Wr1592c//iBEjmDJlCrVr18bDw4OaNWvy8ccf85///Oear3vcuHEMHDiQihUr6lYxEREpdN7e3tStW5cnn3ySzZs3O3SRLVdXVxYvXkyvXr0oV64cPj4+3H333axateq6jns9eUBBUw6rHFY5rEjxZTGMbEu9i4hIkbFs2TJatmyJr68vACdOnGDYsGHm9BKfffbZFaeokIIxevRoJk2ahKurK7t377a7Xc6RZs6cybBhwwDbohMFuciEiIiI5E9h5QHFlXLYoks5rEjR5XblKiIi4gwPPvggsbGxBAQE4ObmxvHjx7FarQB06dKFoUOHOjfAG1CnTp2Ijo42F+4bNmyY/lMmIiJyg1AekD/KYYsefXZFij5NcSAiUkTdf//9NGrUiIsXLxIfH4+fnx8dOnTg008/5eeff7Zb/EIKx/79+4mLi6NChQo8+OCDdqsgi4iISMmmPCB/lMMWPfrsihR9muJARERERERERERExEk0glZERERERERERETESdRBKyIiIiIiIiIiIuIk6qAVERERERERERERcRJ10ObCMAySk5NxxvS8e/fupXXr1tSuXZvmzZsTFRWVo86aNWsoVaoU4eHh5uPChQsArFixwq68UqVKNG3a1Nx37ty5NGrUiPDwcJo0acLPP/9caNcmIiIiIoXHWTltfvLZ2bNn2+WsAQEB9OnTB4CYmBgiIiIIDw+nYcOG3HvvvZw+fdrcV/msiIiIlDRaJCwXycnJ+Pr6kpSUhI+PT4Gfz2q1Eh8fT2BgIJ07d2bw4MEMHTqUb775hv/9739s3rzZrv6aNWsYO3Ysf/zxxxWP3aNHD2655RaeeuopEhISCA0NZc+ePQQHB7Nhwwb69OlDfHx8QV2aiBSy7O2Ji4v+Bici107tSfFXmDnt1eazl2rYsCHjxo3j7rvvJjU1FavVire3NwCjR4/GxcWF9957T/msyA1C30Ei4ijFpT0pupHdgOLj44mMjOT+++8H4O677yYmJoYDBw5c0/GOHj3KqlWrGDRoEGD7UBqGwdmzZwFITEykSpUqDoldRERERORa8tktW7Zw/Phx7rzzTgA8PT3NztmMjAzOnj1r/odK+ayIiIiURG7ODkCyHDp0iEqVKuHmZntbLBYLVatWJTY2ltDQULu6e/bsoWnTpri6ujJs2DBGjRqV43izZs3i9ttvJzAwEICAgAA++eQTmjZtir+/PxcuXGDFihUFfl0iIiIicmO4mnw207Rp0xg0aBDu7u5mWVpaGs2bN+fgwYM0btyYH374AVA+KyIiIiWTRtAWMRaLxe55bjNQNG3alMOHDxMZGcl3333HJ598wldffZWj3owZMxg+fLj5PDk5mcmTJ/PHH39w8OBBpk2bxj333EN6errjL0REREREbkj5yWcznT9/ngULFtjlrAAeHh5s376d48ePU6dOHT755BNA+ayIiIiUTOqgLUJCQkI4fPiwmWAahsGhQ4eoWrWqXT0fHx98fX0BqFKlCv3792f9+vV2ddatW8f58+fp1q2bWfbLL7/g6+tLnTp1AOjZsyenT5/m0KFDBXlZIiIiInKDyG8+m+mbb76hXr161K9fP9ftHh4eDBs2jDlz5gDKZ0VERKRkUgdtERIYGEiTJk2YO3cuAAsXLiQ0NDTH7WBxcXFYrVYAzpw5w48//kiTJk3s6kyfPp2hQ4fi6upqltWoUYPIyEhzEYXNmzdjtVqpXLlyAV6ViIiIiNwo8pvPZpo+fXqO0bOxsbGcO3cOsM05+9VXX9GoUSNA+ayIiIiUTJqDtoj59NNPGTp0KK+//jo+Pj7MmjULgBEjRnDnnXdy5513snDhQqZMmYKbmxvp6ence++9DBs2zDzGmTNnWLhwIX/++afdsZs2bcpzzz1Hx44dcXd3x93dna+++goPD49CvUYRERFHy8jI4OLFi84Oo0SxWq1cvHiRlJQUh6x46+7ubveH45Jm8uTJvPPOO8TFxREWFsbEiRNp165drnWHDh1q5njZ1a9fn127duUo//LLL+nfvz933XUXixYtcnToDpeffBZg//79bN26lcWLF9vt/9dff/Hss88Cts9h06ZN+eCDDwDlsyIiUrIpp3U8R+e0Hh4eDjnOpSxGXpNC3aCSk5Px9fUlKSkJHx+fAj+f1WolPj6ewMDAAnmTReTGofZEbjSGYXDs2DESExOdHUqJYxgGVqsVFxeXHHOKXis/Pz+CgoIcdryiYsGCBQwaNIjJkyfTpk0bPv30Uz7//HOioqJyvbU/KSmJCxcumM/T09Np3Lgxjz32GOPGjbOre/DgQdq0aUONGjXw9/e/qg7awsxp9f0jIo6kNkVuNMppC46jc1oXFxeqV6/u8D8OO30E7dWMNlizZg233HJLjvLo6Gjq1q1rPp84cSJTpkwhNjaWgIAA7rnnHt544w28vLwK7DpERESk8GUmsoGBgZQqVarEdfw5k2EYpKen4+bmdt2vq2EYnD9/3rwtPTg42BEhFhnvvfcew4cPZ8SIEYAtF122bBlTpkzhjTfeyFHf19fXXE8AYNGiRZw+fdrujiiwjaIZOHAg48ePZ/369fpPm4iISAmlnLbgODKntVqtHD16lLi4OKpWrerQ98mpHbQLFixg9OjRdqMNbr/99suONsi0Z88eu1EAFSpUMH+eN28ezz77LNOnT6d169b8/fffDB06FID333+/wK5FRERECldGRoaZyJYvX97Z4ZQ4jkxmAby9vQHMEVElZbqDtLQ0tm7dat6Sn6lr165s2rQpX8eYNm0anTt3plq1anblEyZMoEKFCgwfPjzHgrAiIiJSMiinLViOzmkrVKjA0aNHSU9Px93d3QER2ji1g/ZqRxtkCgwMxM/PL9dtmzdvpk2bNgwYMACA0NBQ+vfvz5YtWxwev4iIiDhP5vxcpUqVcnIkkl+Z79XFixdLTAftyZMnycjIoGLFinblFStW5NixY1fcPy4ujp9//pn58+fblW/cuJFp06axffv2fMeSmppKamqq+Tw5ORmwjfbIXGC2oFitVvMWQhGR66U2RW4kqampGIaBt7c3moW0YGS+ro54fd3d3TEM47L57LVOy+K0DtrrGW3QpEkTUlJSqF+/Pi+++KLdtAdt27Zl7ty5bNmyhebNm/PPP//w008/MWTIkMsez5nJbOZ59OUjIo6g9kRuJJmfd3BMsiU5FcTrm9lG5dZOFed5Bi8dkWEYRr5GacycORM/Pz969epllp05c4b777+fzz77jICAgHzH8MYbbzB+/Pgc5SdOnCAlJSXfx7kWVquVpKQkDMMo1u+jiBQNalPkRnLx4kWsVisZGRmkp6c7O5wSxzAMMjIygJz52rXIyMjAarVy6tSpXEfQBgUFXdNxndZBey2jDYKDg5k6dSoRERGkpqYyZ84cOnXqxJo1a2jfvj0A/fr148SJE7Rt29Ycxvzwww/n6AjOzpnJLOjLR0QcR+2J3Egyk9n09HQlswXA0cks2BbDKoiE1pkCAgJwdXXNkb/Gx8fnyHMvZRgG06dPZ9CgQXYLTezfv58DBw7Qs2dPsyyzQ9vNzY09e/Zw00035Tjec889x5gxY8znycnJhISEUKFChUJZJMxisVChQgV9/4jIdVObIjeSlJQUzpw5g5ubG25uTl8qqsRy1HQEbm5uuLi4UL58eYeudeX0d/5qRhvUqVOHOnXqmM9btWrFoUOHePfdd80O2jVr1vDaa68xefJkWrRowb59+3jiiScIDg7mpZdeyvW4zkxmsWZgHF6Hd+IefLzrYKnSHlxKxi1/IlL4lMzKjUTJbP4YhsGDDz7IwoULOX36NJGRkTz55JM0btyYiRMnXnF/h86tVUAJrTN5eHgQERHB8uXL6d27t1m+fPly7rrrrjz3Xbt2Lfv27WP48OF25XXr1mXnzp12ZS+++CJnzpxh0qRJhISE5Ho8T09PPD09c5S7uLgU7HeCNQOOrMM7bg8uaXVwCemgfFZErpvFYin49kukCHBxccFisZgPySkzn/3mm284ffo027ZtY/To0YSHh18xn83ez+iI1zfzfXJ0++S0/81cz2iD7Fq2bMncuXPN5y+99BKDBg0y57Vt2LAh586dY+TIkbzwwgu5vnhOS2b3fgurnoCzhymXWVamCtw6CWr1KbjzikiJpmRWbhSOTGYzrAZ/xSaQcDYF/zJeNKjqj6tLwSbIx44d47XXXmPJkiUcOXKEwMBAwsPDGT16NJ06dXLYeZYuXcqsWbNYs2YNNWrUICAggG+//RZ3d/c8X7f8JrOHDx+mRo0a1KhRg927d+cZS0EltM42ZswYBg0aRLNmzWjVqhVTp04lNjaWhx56CLANBjhy5AizZ8+222/atGm0aNGCBg0a2JV7eXnlKMtcf+HScqf7N591OXsYv8wy5bMiIiKFrqTnszNnzsw1n3WEq8lnC4rTOmivZ7RBdtu2bSM4ONh8fv78+RwJv6urK4ZhFK356fZ+Cz/cA1wS09kjtvI7v1FSKyIiUgg2RMcxZVkUJ89kTWsUUNaLh7vVp2294Dz2vHYHDhygTZs2+Pn58fbbb9OoUSMuXrzIsmXLeOSRRxyaGO7fv5/g4GBat25tlvn7+zvs+DNnzuS+++5j3bp1bNy4kTZt2jjs2MVF3759OXXqFBMmTCAuLo4GDRrw008/Ua1aNcC2EFhsbKzdPklJSSxcuJBJkyY5I2THUD4rIiJSJCifvT5FIZ916tCFMWPG8PnnnzN9+nSio6N58sknc4w2GDx4sFl/4sSJLFq0iL1797Jr1y6ee+45Fi5cyKOPPmrW6dmzJ1OmTOHLL78kJiaG5cuX89JLL3HnnXcWndWCrRm2kbOXJrOQVbZ6tK2eiIiIFJgN0XG8+k2kXTILcPJMCq9+E8mG6LgCOe+oUaOwWCxs2bKFe+65h9q1axMWFsaYMWP49ddfzXqxsbHcddddlClTBh8fH+677z6OHz9ubh83bhzh4eHMmTOH0NBQfH196devH2fOnAFg6NChPPbYY8TGxmKxWAgNDQWgY8eOjB492jxOXFwc3bt3x9vbm+rVqzN//nyqV6/OBx98kOd1GIbBjBkzGDRoEAMGDGDatGmOe5GKmVGjRnHgwAFSU1PZunWrOf0WYI74yM7X15fz58/zwAMP5Ov4M2fOZNGiRQ6M+DopnxURESkSlM/a5JbPhoaG5msKhKKQzzp1wrarHW2QlpbG2LFjOXLkCN7e3oSFhbFkyRLuuOMOs86LL76IxWLhxRdf5MiRI1SoUIGePXvy2muvFfr1XdaR9XD2cB4VDDhzyFYvpGNhRSUiInJDybAaTFkWlWedT36JolWdIIfeHpaQkMDSpUt57bXXKF26dI7tmbeyG4ZBr169KF26NGvXriU9PZ1Ro0bRt29fu86+/fv3s2jRIn788UdOnz7Nfffdx5tvvslrr73GpEmTuOmmm5g6dSq///77Zf9YPXjwYE6ePMmaNWtwd3dnzJgxxMfHX/FaVq9ezfnz5+ncuTNVqlShRYsWTJo0ibJly17TayPFiPJZERERp1M+m6W457NOX1Fj1KhRjBo1KtdtM2fOtHv+zDPP8Mwzz+R5PDc3N1555RVeeeUVR4XoeGfz+deL/NYTERER06Ofb+D02dQr1ktLzyD5wsU865xITqHfe8vxcLvyXTjlynjy0Yi2V6y3b98+DMOgbt26edZbsWIFO3bsICYmxlwUas6cOYSFhfH7779z8803A7bFAWfOnGkmkYMGDWLlypW89tpr+Pr6UrZsWVxdXQkKCsr1PLt372bFihX8/vvvNGvWDIDPP/+cWrVqXfFapk2bRr9+/XB1dSUsLIyaNWuyYMECcy0AKcGUz4qIiBQY5bM3Xj7r9A7aG1KZfM7/4elXoGGIiIiURKfPpua4xet62JLevBPfq5E5J/6VFjaLjo4mJCTETGYB6tevj5+fH9HR0WZCGxoaavcX/uDg4HyNFsi0Z88e3NzcaNq0qVlWs2ZNypUrl8dekJiYyLfffsuGDRvMsvvvv5/p06erg/ZGkN989vTfYBigValFRETyTfnsjZfPqoPWGSq3s61ue/YIuc/b9a/lD0KXT6DGHZevIyIiInbKlfHMV738jDgA8PF2z/eIg/yoVasWFouF6OhoevXqddl6hmHkmvReWn7p6rUWiwWr1ZqvWDKPdzXlmebPn09KSgotWrSw28dqtRIVFUX9+vXzHYMUQ/nNZzePg2NboNNH4Fu9sKITEREp1pTP3nj5rDponcHFFW6d9O+qtxYum9SePQTfdYc6/Wz1SwUWZpQiIiLFUn5uywLbnF2DP1iV5+iECj5ezHrsVofO2eXv70+3bt34+OOPefzxx3PM25WYmIifnx/169cnNjaWQ4cOmaMOoqKiSEpKol69eg6Lp27duqSnp7Nt2zYiIiIA221riYmJee43bdo0nnrqKYYOHWpX/vjjjzN9+nTeffddh8UoRVCe+ewlz2N+gplh0PJlaDYGXD0KN1YREZFiRvns1SkJ+axLoZ1J7NXqA3d+A2Uq25eXDYFOH0PVTllle76EGfXgr5m2W8RERETkurm6WHi4W95/FX+oa32HJrOZJk+eTEZGBs2bN2fhwoXs3buX6OhoPvjgA1q1agVA586dadSoEQMHDiQyMpItW7YwePBgOnToYM6t5Qh169alc+fOjBw5ki1btrBt2zZGjhyJt7f3ZW9b2759O5GRkYwYMYIGDRrYPfr378/s2bO5eNFxt9FJEXXZfLYK9PwG7lyYtS39Amx4DuY0hcPrCz9WERGREkj5rE1JyGfVQetMtfrAAwew3rOSxDaTsd6zEkbEQPgouGc53DYTvPxtdVMSYNkw+KYLJO53atgiIiIlRdt6wbx0T1MCynrZlVfw8eKle5rStl4+59m8StWrVycyMpJbbrmFp556igYNGtClSxdWrlzJlClTANutXYsWLaJcuXK0b9+ezp07U6NGDRYsWODweGbPnk3FihVp3749vXv35oEHHqBs2bJ4eXnlWn/atGnUr18/14UhevXqRUJCAosXL3Z4nFIEXS6frX23bduwaGg6Giz//rfj1C5Y0B6WDYfzJ50auoiISEmgfNamuOezFuNKEzLcgJKTk/H19SUpKQkfH58CP5/VaiU+Pp7AwEBcXC7pMz8fD6tHw+4vssrcvKHVONstYi6apUJEsuTZnoiUMCkpKcTExFC9evXLJl75lWE1+Cs2gYSzKfiX8aJBVf8CGWlQXBw+fJiQkBCWLl1K165dr7gARH458j2TKyvMnPaK3z/HI23rKxz/I6vMqzx0eBfChmgRMRGxo5xWbiSOyo+Uz9rLzGeXL19Ohw4dcHNzc0hOW1D5rHr3irpSgdB9PtS7H1Y8DGdibbeIrf+PrdO22+dQMcLZUYqIiBRrri4WGoeWd3YYTrNq1SrOnj1Lw4YNiYuL45lnniE0NJR27do5OzQpKSo2hQG/wp+fwIbnIS0ZUk7Z7hDbNQM6fwLlHTcXnYiIyI1G+Wzu+Wz79u2dHVq+6E9RxUWNO2DoLmj6BLaFF4AT22Fec1gzFi6ec2Z0IiIiUoxdvHiR559/nrCwMHr37k2FChVYvXp1jhV1Ra6Liys0eQSG7YY6fbPKD6+D2Y1hwwtw8YLz4hMREZFiK7d8ds2aNcUmn9UI2uLEowzcMhHqDoBfRsDJnWBYYev/YN+3tpEHoV2dHaWIiIgUM926daNbt252ZYZhkJ6e7qSIpEQrEww9voQGw2DFKEj6B6wX4bfXYfeXtgVzq9/m7ChFRESkGMktnwVbTlscaARtcRTcHO7fCm1fA1dPW1lSDCzsBj8P1oILIiIiIlL0hXaDIX9ByxfB5d/RLUn/wLe3w+K+cPaoc+MTERERKSTqoC2uXN2hxfMweAeEdMwqj5oDM+tB9DwoJn8lEBEREZEblLs3tHnVltNW6ZBV/vdXMKMuRH4I1gznxSciIiJSCNRBW9z514Z7V0HXz8HTz1Z24ST8dL9t9EHSAWdGJyIiIiJyZeXrwn2r4bZZ4B1gK0s7A6sfh/kt4PhW58YnIiIiUoDUQVsSWCzQcDgMi4ba92aVH1gGM8Pgj/fAqjnkRERERKQIs1ggbLBtEbGGI7LKj2+1LYy76glITXZefCIiIiIFRB20JUnpIOj5Fdz1PZSpbCtLPw9rn4L5rSD+T+fGJyIiIiJyJd7loetn0Hc9lA+zlRlW2PaBbSqvv7/RVF4iIiJSoqiDtiSqeScMjYLwRwCLrez4HzA3AtY/BxcvODU8EREREZErqtIWBm2Ddm+Bm7et7OxRWHwvfNfdtkiuiIiISAmgDtqSytMHOn0E/TZA+fq2MiMDtrwJsxtB7CrnxiciIiKFwjAMRo4cib+/PxaLhe3bt9OxY0dGjx7t7NBErszVHZo/Yxt8UKN7VnnMz7apvH57AzLSnBefiIiIFLgbIZ9VB21JV7k13B8JrceDq4etLHEffN0Jlv4fXEhwbnwiIiJFgTUDDq2B6C9s/xbCqvHHjh3jscceo0aNGnh6ehISEkLPnj1ZuXKlQ8+zdOlSZs6cyY8//khcXBwNGjTg22+/5dVXX72u444bNw6LxWI+fH19adeuHWvXrnVQ5CLZ+IZCr8Vw58JsU3ldgA3Pw5wmcHi9U8MTERFxOuWzV60o5bNuhX5GKXxuntDqZdsCYr88AEc32sp3zYCYJXDLB1DnPtvCDCIiIjeavd/aFh86ezirrEwVuHUS1OpTIKc8cOAAbdq0wc/Pj7fffptGjRpx8eJFli1bxiOPPMLu3bsddq79+/cTHBxM69atzTJ/f3+HHDssLIwVK1YAkJCQwLvvvkuPHj04fPgwvr6+DjmHiMlisf1OVusCG1+2zUlrWOFUFCxoD2HDoP3bUCrA2ZGKiIgULuWz16yo5LMaQXsjKV8P+q2DzlPAw8dWdj4elvSDRT0hOda58YmIiBS2vd/CD/fYJ7MAZ4/Yyvd+WyCnHTVqFBaLhS1btnDPPfdQu3ZtwsLCGDNmDL/++qtZLzY2lrvuuosyZcrg4+PDfffdx/Hjx83t48aNIzw8nDlz5hAaGoqvry/9+vXjzJkzAAwdOpTHHnuM2NhYLBYLoaGhADluCYuLi6N79+54e3tTvXp15s+fT/Xq1fnggw/yvA43NzeCgoIICgqifv36jB8/nrNnz/L333877sUSuZRHWbjlfRj4BwTdnFW+awbMqAt/zdQiYiIicuNQPgvkns+GhoYyceLEPK+jqOSz6qC90VhcoPFDtnm8avbKKv9niW0er8gPC2UYvIiIiNNZM2wjDcitI+ffstWjHf69mJCQwNKlS3nkkUcoXbp0ju1+fn62CAyDXr16kZCQwNq1a1m+fDn79++nb9++dvX379/PokWL+PHHH/nxxx9Zu3Ytb775JgCTJk1iwoQJVKlShbi4OH7//fdcYxo8eDBHjx5lzZo1LFy4kKlTpxIfH39V15WamsrMmTPx8/OjTp06V7WvyDWp2AT6b4ZOH2cNPkg5BcuGwVcdbSNrRURESjLls6bins9qioMbVdnKcNd3tr+krHwUzsXBxbOw+nHYPQ+6fg4BDZwdpYiIyNWb2wzOHbtyvfRUSDmZRwUDzhyCKUG26YKupHQQ3P/HFavt27cPwzCoW7dunvVWrFjBjh07iImJISQkBIA5c+YQFhbG77//zs0320YOWq1WZs6cSdmyZQEYNGgQK1eu5LXXXsPX15eyZcvi6upKUFBQrufZvXs3K1as4Pfff6dZs2YAfP7559SqVeuK17Jz507KlCkDwPnz5ylbtiwLFizAx8fnivuKOISLK4SPgpq9Yc0Y2POlrfzwOpgdDjc/DS1eAPdSTg1TRETkqiifveHyWXXQ3uhq9YGQW2H9s7DjU1tZ3G+2xRZu/g+0fBHcvJwbo4iIyNU4d8x2S5ej5Jn0Xj3j31uvLVeY+z06OpqQkBAzmQWoX78+fn5+REdHmwltaGiomcwCBAcHX9VogT179uDm5kbTpk3Nspo1a1KuXLkr7lunTh1++OEHAM6cOcOCBQu49957Wb16tZkcixSKMsHQ4wtoMBRWPgKJ+8F6EX57HXZ/AZ0mQ/XbnB2liIhI/iifveHyWXXQCnj5QZdPoN4A+GUknN4D1nT47TX4+2vo+hlUae/sKEVERPKndO5/Wc/hiiMO/uUVkP8RB/lQq1YtLBYL0dHR9OrV67L1DMPINem9tNzd3d1uu8ViwWq15iuWzONdTXl2Hh4e1KxZ03zepEkTFi1axMSJE5k7d26+YxBxmNBuMHgnbHkdtrxl66RNioFvb7ctmHvLRChTydlRioiI5E357A2Xz6qDVrJUaQ+Dt9s6Zre8aeukPf03LOgAjUZCu7dsnbkiIiJFWT5uywJsc3F9Fvrv6ITckjcLlK0CI2Jst1E7iL+/P926dePjjz/m8ccfzzFvV2JiIn5+ftSvX5/Y2FgOHTpkjjqIiooiKSmJevXqOSyeunXrkp6ezrZt24iIiABst60lJiZe0/FcXV25cOGCw+ITuWru3tDmVag7EFY+DIfW2Mr//hoOLIU2r9mmRXDg77WIiIhDKZ+9KiUhn9UiYWLPzcuW0A7aBsEts8p3TIWZ9eHvhVoVV0RESgYXV7h10r9PLv3L/r/Pb5lYIJ04kydPJiMjg+bNm7Nw4UL27t1LdHQ0H3zwAa1atQKgc+fONGrUiIEDBxIZGcmWLVsYPHgwHTp0cOjtVnXr1qVz586MHDmSLVu2sG3bNkaOHIm3t/cVb1tLT0/n2LFjHDt2jL179/Lf//6XqKgo7rrrLofFJ3LNyteFe1fBbbPAO8BWlnbGtubC/BZwfKtz4xMREbleymeBkpHPqoNWchfQAPptgFs/BHfbZMmci4PF98D3veGMA+dCERERcZZafeDOb6BMZfvyslVs5bX6FMhpq1evTmRkJLfccgtPPfUUDRo0oEuXLqxcuZIpU6YAtlu7Fi1aRLly5Wjfvj2dO3emRo0aLFiwwOHxzJ49m4oVK9K+fXt69+7NAw88QNmyZfHyynse+l27dhEcHExwcDDh4eF89dVXTJkyhcGDBzs8RpFrYrFA2GAYthsajsgqP74V5jW3rXydmuy8+ERERK6X8lmg+OezFiM/EzLcYJKTk/H19SUpKalQVm2zWq3Ex8cTGBiIi0sR7DNPPgQrR8E/P2aVefhAuzeh8YNgKYIxi9yginx7IuJAKSkpxMTEUL169SsmXldkzYAj6+FsnG2xocrtbujbnw8fPkxISAhLly6la9euVxx5kF8Ofc/kigozpy023z9HNsKKh+DkX1llpYPhlklQ+x5bh66IOF2xaVNEHMBh+ZHyWTuZ+ezy5cvp0KEDbm5uDslpCyqf1Ry0cmU+IdDrB9jzle2WsPPxkJZs67SNnmdbRKy84+YOERERKXQurhDS0dlROM2qVas4e/YsDRs2JC4ujmeeeYbQ0FDatWvn7NBEHKtyG7g/Era+D5vHQfoF211iP94H1W+HWz8CvxrOjlJEROTqKZ/NNZ9t3754LHqvP0VJ/lgsULcvDI2GBv+XVX50I8wJh03jbasHioiISLFz8eJFnn/+ecLCwujduzcVKlRg9erVOVbUFSkRXN2h+TMwNApqdM8qj/kZZoXBb29ARprz4hMREZGrlls+u2bNmmKTz2oErVwdb3/oNg3qDYTlIyFxvy2B3TwO9iyArp9D5dbOjlJERESuQrdu3ejWrZtdmWEYpKenOykikULgGwq9FsO+72DV47YVsNNTYMPzED0XOn8CVTSKXEREpDjILZ8FW05bHGgErVybqrfC4J3Q/Fmw/DunSUI0fNkWVjyixRZEREREpOizWGyLpwyLhogns9ZWOBUFC9rD0v+D8yedG6OIiIiUeOqglWvn7g3t3oD7t0LFZv8WGvDnZJhZH/Z979TwRERERETyxaMsdHwPBv4BQTdnle+aATPqwl8zoJiMwBEREZHiRx20cv0CG8OAX21JrVspW9nZI/B9L1h8r20FQRERkQJitVqdHYLkk94rKfIqNoH+m6HTx+DhYytLOQXL/g++6mgbWSsiIlIAlCcVDwU1ZYLmoBXHcHG13RZWszeseBgOLLWV//0NHFwO7d+FhsNtt5GJiIg4gIeHBy4uLhw9epQKFSrg4eGBRd8zDpM5B62bm9t1v66GYZCWlsaJEydwcXHBw8PDQVGKFAAXVwgfZctr14yBPV/ayg+vg9nhcPPT0OIFcC/l1DBFRKRkUE5bsByd0544cQKLxeLwxccsRnGZLbcQJScn4+vrS1JSEj4+PgV+PqvVSnx8PIGBgbi4lIBBzYYBu7+A1U/AhWxzdlXpAF2mgn9t58UmUsKVuPZE5ArS0tKIi4vj/Pnzzg6lxDEMA6vViouLi8P+k1CqVCmCg4PVQVtICjOnLdHfPweWwcpHbIvjZvKtDp0mQ/XbnBeXSAlWotsUkVwopy04js5pLRYLVapUoUyZMg6ILttx1UGbkzpoHeT8SVj7FETNzipz9YSWL9lGHrjqP2cijlZi2xORPGT+VTwjI8PZoZQoVquVU6dOUb58eYe0J66urg4ZuSD5pw5aB7p4Aba8AVveBOvFrPLa98ItE6FMJaeFJlISlfg2RSQXymkLhqNzWnd3d1xdXR0QmT1NcSAFp1QA3D4L6g2EFQ9BUgxkpMLGF2HPAuj6GQS3cHaUIiJSzGXeYuTo24xudFarFXd3d7y8vPSfYxF3b2gzAeoOgJUPw6E1tvK/v7ZN7dXmNdu0CC6O/w+biIjcGJTTFoziktMW3cik5AjtCkN2QrOxYPn3I3dyJ8xvBauegLQzzo1PRERERCQ/yteFe1fBbbPAO8BWlnYGVj8O81vA8a3OjU9ERESKJXXQSuFwLw0d3oGBWyCwyb+FBmz7AGaGwT9LnBqeiIiIiEi+WCwQNhiG7YGGI7LKj2+Fec1h1eOQmuy8+ERERKTYUQetFK6KEbZO2vZvg5uXrezMIfiuB/zYH87HOzc+EREREZH88Pa3TdnVbwMENLCVGVbY9iHMqAt7vrYtnisiIiJyBeqglcLn4mZbJGzIX1C1U1b5ni9hRj34a6aSWREREREpHiq3gfsjod1b4OZtKzsXBz/eB991h8R/nBufiIiIFHnqoBXn8bsJ7lkOt80EL39bWUoCLBsG33SBxP1ODU9EREREJF9c3aH5MzA0Cmp0zyqP+RlmhcFvr0NGmvPiExERkSLN6R20kydPpnr16nh5eREREcH69esvW3fNmjVYLJYcj927d9vVS0xM5JFHHiE4OBgvLy/q1avHTz/9VNCXItfCYoGwITAsGur2zyqPXQmzGsCWt8Ga7rz4RERERETyyzcUei2GO7+FMpVtZekpsOEFmB0Oh9c5MzoREREpopzaQbtgwQJGjx7NCy+8wLZt22jXrh233347sbGxee63Z88e4uLizEetWrXMbWlpaXTp0oUDBw7wzTffsGfPHj777DMqV65c0Jcj16NUIHSfD72XQNmqtrL0FFj/H5h7s1bEFREREZHiwWKBWr1tAxAingTLv//lSoiGBR1g6f/B+ZPOjVFERESKFKd20L733nsMHz6cESNGUK9ePSZOnEhISAhTpkzJc7/AwECCgoLMh6urq7lt+vTpJCQksGjRItq0aUO1atVo27YtjRs3LujLEUeocQcM3QVNRwMWW9mJ7bYVcdeMhYvnnBiciIiIiEg+eZSFju/BwD8g6Oas8l0zbIuI/TVD6y6IiIgI4MQO2rS0NLZu3UrXrl3tyrt27cqmTZvy3LdJkyYEBwfTqVMnVq9ebbfthx9+oFWrVjzyyCNUrFiRBg0a8Prrr5ORkeHwa5AC4lEGbnkfBvwKAQ1tZYYVtv4PZjaAA784Nz4RERERkfyq2AT6b4ZOH4OHj60s5RQs+z/biNpTUc6NT0RERJzOzVknPnnyJBkZGVSsWNGuvGLFihw7dizXfYKDg5k6dSoRERGkpqYyZ84cOnXqxJo1a2jfvj0A//zzD6tWrWLgwIH89NNP7N27l0ceeYT09HRefvnlXI+bmppKamqq+Tw5ORkAq9WK1Wp1xOXmyWq1YhhGoZyrWKnYDAb8DlvfxfLrq1gyUiH5ACzshlHvfowO/wPvAGdHKVKkqD0REUdxRnvi4uL05RGu2eTJk3nnnXeIi4sjLCyMiRMn0q5du1zrDh06lFmzZuUor1+/Prt27QLgs88+Y/bs2fz1118ARERE8Prrr9O8efOCuwgpOC6uED4KavaGNWNgz5e28iPrYXZjaPY0tHwR3Es5N04RERFxCqd10GayWCx2zw3DyFGWqU6dOtSpU8d83qpVKw4dOsS7775rdtBarVYCAwOZOnUqrq6uREREcPToUd55553LdtC+8cYbjB8/Pkf5iRMnSElJudZLyzer1UpSUhKGYRTr/5gUmNDhuPp3xGfLM3get42utkTPxfjnJ5IjxpMSerdtri8RUXsiIg7jjPYkKCioUM7jaJnrKkyePJk2bdrw6aefcvvttxMVFUXVqlVz1J80aRJvvvmm+Tw9PZ3GjRtz7733mmVr1qyhf//+tG7dGi8vL95++226du3Krl27tLZCcVYmGHp8AQ2GwcpRkLjftiDuljdsnbadPobqtzs7ShERESlkFsNwzsRHaWlplCpViq+//prevXub5U888QTbt29n7dq1+TrOa6+9xty5c4mOjgagQ4cOuLu7s2LFCrPOzz//zB133EFqaioeHh45jpHbCNqQkBBOnz6Nj4/PtV5ivlmtVk6cOEGFChXUoZIXw4Bd07GsewZLamJWcbWuGJ0mg29158UmUkSoPRERR3FGe1Jc260WLVrQtGlTu3UU6tWrR69evXjjjTeuuP+iRYvo06cPMTExVKtWLdc6GRkZlCtXjo8++ojBgwfnK67k5GR8fX1JSkoq8JzWarUSHx9PYGBgsX0fC93FC7aO2S1vgvViVnnte+CWSVCmkvNiE3EytSki4ijFpT1x2ghaDw8PIiIiWL58uV0H7fLly7nrrrvyfZxt27YRHBxsPm/Tpg3z58/HarWaL/zff/9NcHBwrp2zAJ6ennh6euYod3FxKbQ3z2KxFOr5iq1GD8BNPWHV4/D31wBYDv6CZXYjaPMqNH0cXJw+MFzEqdSeiIijqD25ssx1FZ599lm78vysq5Bp2rRpdO7c+bKdswDnz5/n4sWL+Pv7X7aOM6ft0hQ718DVE1qNgzr9sKx8BMvhNbbyv7/BOLAMo/V/ofHDtukRRG4walNExFEKuz251rzZqT1ZY8aMYdCgQTRr1oxWrVoxdepUYmNjeeihhwB47rnnOHLkCLNnzwZg4sSJhIaGEhYWRlpaGnPnzmXhwoUsXLjQPObDDz/Mhx9+yBNPPMFjjz3G3r17ef3113n88cedco1SAEoHQc+vYN8PtlvDzh6B9POw9inY/QV0/RwCGzs7ShEREbkBXMu6CtnFxcXx888/M3/+/DzrPfvss1SuXJnOnTtfto4zp+3SFDvXwx/az8cr5ht8IsfhkpqAJe0MljVPcHHHNJKav0V6+XBnBylSqNSmiIijFHZ7cq1Tdjm1g7Zv376cOnWKCRMmEBcXR4MGDfjpp5/M0QNxcXHExsaa9dPS0hg7dixHjhzB29ubsLAwlixZwh133GHWCQkJ4ZdffuHJJ5+kUaNGVK5cmSeeeIL//Oc/hX59UsBq3gkhHWHD87B9MmDA8T9gbgQ0GwutXgF3b2dHKSIiIjeAq1lXIbuZM2fi5+dHr169Llvn7bff5osvvmDNmjV4eXldtt5zzz3HmDFjzOeZ03ZVqFChUKY4sFgsmmLnelR8BML7Y6x/DstfnwPgnrCD8su6Q+NRGK0ngKevk4MUKRxqU0TEUYpLe+K0OWiLssKcrwuKz3wYRdqRTbD8ATgVlVXmdxN0mQpVb3VeXCKFTO2JiDiK2pP8uZ51FQzDoHbt2vTo0YP3338/1zrvvvsu//3vf1mxYgXNmjW7qtg0B20xdmQjrHgITv6VVVY62DY3be17tECulHhqU0TEUYpLe1J0IxO5GpVbw/2R0Ho8uP4713Difvi6Eyz9P7iQ4Nz4REREpETKvq5CdsuXL6d169Z57rt27Vr27dvH8OHDc93+zjvv8Oqrr7J06dKr7pyVYq5yG1tu2+4tcPv3jrBzcfDjffDtHZD4j3PjExEREYdSB62UHG6e0OplGLQdKrfNKt81A2bWg91fggaMi4iIiIONGTOGzz//nOnTpxMdHc2TTz6ZY12FwYMH59hv2rRptGjRggYNGuTY9vbbb/Piiy8yffp0QkNDOXbsGMeOHePs2bMFfj1SRLi6Q/NnYGgU1OiRVX5gKcwKg99eh4w058UnIiIiDqMOWil5yteDvmuh8xTw+Pd2vvPxsKQ/LOoJybF57y8iIiJyFfr27cvEiROZMGEC4eHhrFu3Ls91FQCSkpJYuHDhZUfPTp48mbS0NO655x6Cg4PNx7vvvlvg13O99u7dS+vWralduzbNmzcnKioqR53Zs2cTHh5uPgICAujTpw8AZ8+epVu3bgQEBBAQEGC339GjR+nWrRt16tShUaNG3HfffSQklPA7pXxDodcPcOe3UKayrSw9BTa8ALPD4fA6Z0YnIiIiDqA5aHOhOWhLkDNHYNWjsG9RVpl7GWj7OoSPAhdXp4UmUhDUnoiIo6g9Kf6cNQdt586dGTx4MEOHDuWbb77hf//7H5s3b85z/4YNGzJu3DjuvvtuUlNT2bBhA+XLl6dz586cPHnSrHf8+HH27t1L27a2u6WefvppkpKSmDp1aoFeX5GRdgY2vQKRk8CwZpWHDYP2b0OpgMvvK1KM6DtIRByluLQnRTcyEUcoWxnu+g7uXGhbWAHg4llY/Th82QZO7HRufCIiIiIlSHx8PJGRkdx///0A3H333cTExHDgwIHL7rNlyxaOHz/OnXfeCYCnpyedOnXCz88vR92KFSuanbMALVq04J9/bqD5WD3KQsf3YOAfENQ8q3zXDJhRB3ZO15ReIiIixZA6aOXGUKuPbf6uRg9mlcX9BnObwoYXbbeJiYiIiMh1OXToEJUqVcLNzQ0Ai8VC1apVc0zxkN20adMYNGgQ7u7uV3WujIwMPv74Y3r27HldMRdLFZtA/03QaTJ4+trKUhLgl+GwoAOc3OXc+EREROSqqINWbhxeftDlE9v8tOXq2Mqs6fDbazC7sebvEhEREXEAi8Vi9zyvGdXOnz/PggULLjsX7+UYhsGoUaPw8/Pjscceu6Y4iz0XVwh/GIbthjr9ssqPrIc54bD+ebh43mnhiYiISP6pg1ZuPFXaw+Dt0PJFcLGN7uD037bRBr+MhJREZ0YnIiIiUmyFhIRw+PBh0tPTAVtH6qFDh6hatWqu9b/55hvq1atH/fr1r+o8jz/+OIcOHWLBggVFej65QlE6CHp8AXcvA7+bbGXWdNjyBsxqADE/Ozc+ERERuaIbPJuRG5abF7R5FQZtg+CWWeU7P4OZ9eDvhZq/S0REROQqBQYG0qRJE+bOnQvAwoULCQ0NJTQ0NNf606dPv+rRs48//jj79u3ju+++w8PD43pDLjlCu8LgndDyJXD5d7qIpBj49g5YfK9t8VwREREpktRBKze2gAbQbwPc+iG4l7GVnTsGi++B73srkRURERG5Sp9++imffvoptWvX5s0332TatGkAjBgxgh9++MGst3//frZu3Urfvn1zHKNp06a0atWK06dPU6VKFQYNGgTAxo0b+fDDDzlw4AAtWrQgPDyc3r17F86FFQfu3tBmAgzeASEds8r//sY2CCHyA7BmOC08ERERyZ3FyGtSqBtUcnIyvr6+JCUl4ePjU+Dns1qtxMfHExgYqFu0nCn5EKwcBf/8mFXm4QPt3oTGD4JF740UfWpPRMRR1J4Uf4WZ0+rzUgQZBkTPhTVPwYUTWeUVI6DzJxDUzHmxiVyB2hQRcZTi0p4U3chECptPCPT6AXosgFKBtrK0ZFun7Zft4VSUc+MTEREREckviwXqD7ItItbwgazy41thXnNY+RikJjkvPhERETGpg1YkO4sF6twHQ6Ohwf9llR/dCLPDYdN4SE91WngiIiIiIlfF2x+6TrVN6xXQ4N9CA7Z/BDPqwZ6vtPaCiIiIk6mDViQ33v7QbRrcuzLbargXYfM4mNMEjmxyangiIiIiIlelchu4PxLavQVu3rayc3HwY1/bQmKJ/zg3PhERkRuYOmhF8lL1VttquM2fBYurrSwhGr5sCysegdRk58YnIiIiIpJfru7Q/BkYGgU1emSVH1gKs8Lgt9chI8158YmIiNyg1EErciXu3tDuDbh/K1TMXEzBgD8nw8z6sO97p4YnIiIiInJVfENtay/c+S2UqWIrS0+BDS/YpvU6vM6Z0YmIiNxw1EErkl+BjWHAr9DxPXArZSs7ewS+7wWL74WzcU4NT0REREQk3ywWqNUbhkVBxJNg+fe/hgnRsKADLB0G5086N0YREZEbhDpoRa6Gi6stgR26C0Jvyyr/+xuYWQ92fAaG1XnxiYiIiBSyDKvBjoOn2LwvgR0HT5Fh1YJTxYpHWdsAhIF/QFDzrPJdM2FGHdg5XfmtiIhIAXNzdgAixZJvKPT5CXZ/AaufgAsnITUJlo+E6LnQZSr413F2lCIiIiIFakN0HFOWRXHyTMq/JTEElPXi4W71aVsv2KmxyVWq2AT6b4IdU2HDc7bcNiUBfhlu66ztPAUCwpwdpYiISImkEbQi18pigXoDYGg01B+cVX54HcxuDL++pkUWREREpMTaEB3Hq99EZuuctTl5JoVXv4lkQ7Smfyp2XFwh/GEYthvq9s8qP7Ie5oTD+ufg4nmnhSciIlJSqYNW5HqVCoDbZ8Hdy8C3uq0sIxU2vghzm0Hcb86NT0RERMTBMqwGU5ZF5Vnnk1+iNN1BcVU6CLrPt+W3fjfZyqzpsOVNmBkG//zk3PhERERKGHXQijhKaFcYshOajc1aZOHkTpjfClY9AWlnnBufiIiIiIP8FZuQY+TspU4kp7Dz4KlCikgKRGhXGLwTWr4ELu62suQD8F132yK5Z444NTwREZGSQh20Io7kXho6vAMDt0Bgk38LDdj2wb+jDZY4NTwRERERR0g4m3fnbKY3vtvGgo37STyXWsARSYFx94Y2E2DwDgi5Jas8c5HcyA/AmuG8+EREREoAddCKFISKEbZO2vZvg5uXrezMIfiuB/zYH87HOzc+ERERkevgX8YrX/USz6UxfdVuBk5cyesLI/nzwCkMQ9MeFEvl68K9K+H22eBdwVaWdsa2YO685nDsD+fGJyIiUoypg1akoLi4wc1Pw5C/oGqnrPI9X8KMuvDXDNB/UERERKQYalDVn4CyeXfSurtm/Vcj3WqwNiqOZ+b8yogpa/n2139IvqDFVIsdiwXqD7ItItbwgazy+EhbJ+3KxyA1yXnxiYiIFFPqoBUpaH43wT3L4baZ4OVvK0s5Dcv+D77pAon7nRqeiIiIyNVydbHwcLf6edZ5tnc4Mx7pyH2tb8K3lIdZfvjUOT5dHs2A91fy9qLt7DqUoFG1xY23P3SdCv02QkCDfwsN2P4RzKgHe77SQAQREZGrYDGUDeWQnJyMr68vSUlJ+Pj4FPj5rFYr8fHxBAYG4uKiPvMS7Xw8rB4Nu7/IKnPzglbjodkY26hbkeug9kREHEXtSfFXGDnthug4piyLslswrIKPFw91rU/besFmWVp6Bpv2HGfJ1oPsOJiQ4zihFcpyR0RVOjesTGkv9wKJVQpIxkWInAibxkH6+azy0Nug08fgV8NZkUkxpu8gEXGU4tKeqIM2F+qglQL3z0+w4mE4E5tVViEcun1um79W5BqpPRERR1F7UvwVVk6bYTXYefAkMUdOUL1yBRpWC8DVxXLZ+rEnz/JzZCy//HmYsykX7bZ5urvSMSyY7hHVqB3si8Vy+eNIEZN8EFY+Cv/8mFXm5gUtX4JmY8HV4/L7ilxC30Ei4ijFpT1RB20u1EErhSLtLGx8CSInAf/+GlpcoOlo20q57qWdGZ0UU2pPRMRR1J4Uf4WZ017L5yX1Ygbro+P4KTKWXYdO59heM8iHO5pW5ZYGlSnlqbuMigXDgH2LYNXjcPZwVrl/Peg8BUI6OC00KV70HSQijlJc2hN10OZCHbRSqOK2wC8j4OTOrDKfUOjyKYR2dVpYUjypPRERR1F7UvwV9Q7a7A7En2FJ5EFW7DjC+dR0u23eHq7c0qAyPSKqclOQr6NCloKUdsY25UHkJDAyssrDhkL7d6BUgLMik2JC30Ei4ijFpT1RB20u1EErhS7jIvzxDmyeABmpWeX17oeO7yuJlXxTeyIijqL2pPgrTh20mVLS0lkbFcePWw/y99GkHNvrVPKje0RVOoRVwsvd9XpClsIQvx2WPwjHtmSVefnbOmkbDLXdPSaSC30HiYijFJf2RB20uVAHrThNwt+w4kE4tCarzKs83DIR6g0EzcMmV6D2REQcRe1J8VccO2iz2xuXxE+RsazaeYSUixl220p7utG5URXuaFqV0MCyDjmfFBBrBuyYChueg9Rsne6V20LnTyAgzHmxSZGl7yARcZTi0p6ogzYX6qAVpzIM+Gs6rB0LqYlZ5aHdbHN3+VZ3WmhS9Kk9ERFHUXtS/BX3DtpM51Ivsvqvo/y0NZb9x5NzbA8LKUf3plVpVz8YDzeNqi2yzh2DNWNg9xdZZS5utgXEWr4E7qWcF5sUOfoOEhFHKS7tiTpoc6EOWikSzh2zLbDw99dZZW6loM2r0PRxW0Ircgm1JyLiKGpPir+S0kGbyTAM9hxNYsnWg6zddZTUdKvd9rLe7nRpXIU7mlQlJKBMgcQgDnBgOawcBYn7ssp8QqHTx1DjDqeFJUWLvoNExFGKS3uiDtpcqINWipR9P9iS2LNHssoqRkDXzyEw3GlhSdGk9kREHEXtSfFX0jposzubcpGVOw6zJDKWgyfO5tjeOLQ83ZtWpXXdINxd9fktctJT4Lc34Pc3ISMtq7z2PdBxIpSt7LTQpGjQd5CIOEpxaU/UQZsLddBKkZOaDBueh+2TgX9/ZS2utlvCWr0C7t5ODU+KDrUnIuIoak+Kv5LcQZvJMAx2HTrNT5GxrIuK42KG/ahav9IedG0cwh1NqxJcTrfQFzmndtsGIhxanVXmXgba/hfCH9EdYzcwfQeJiKMUl/ZEHbS5UAetFFlHNsHyB+BUVFaZ303QZSpUvdV5cUmRofZERBxF7UnxdyN00GaXfD6N5TsO89PWWA4nnMuxPaJGAN0jqtGiViBuGlVbdBgGRM+zzU974URWeWBT6PIJBN3svNjEaYpCmyIiJUNxaU+KbmQiklPl1nB/JLQeD64etrLE/fB1J1j6f3AhwbnxiYiIiDiJTykP7m5Zg89HdeCtQS1oXz8YNxeLuX3rPyeZ8PVWBn2willr9hCfdMGJ0YrJYoH698Ow3dDwgazy+EiY1wJWPgapSc6LT0REpBBoBG0uNIJWioVT0bB8JBzZkFVWKhBumQR1+tqSXbnhqD0REUdRe1L83WgjaHOTeC6VZdsP81PkQY4l2nfIuljg5pqB3NG0KjfXDMTVRblTkXBkE6x4CE7uzCorHQy3TITa9yrHvUEU1TZFRIqf4tKeqIM2F+qglWLDsMKOqbDuP5CWnFVeozt0mgw+VZ0XmziF2hMRcRS1J8WfOmizWA2DyH9O8tPWg2z+Ox7rJf8FquDjxe1NqnJbkxDKl/VyUpRiyrgIkRNh0zhIP59VHnobdPrINsWXlGhFvU0RkeKjuLQn6qDNhTpopdg5cwRWPQb7vssqcy8DbV/7d4EFV+fFJoVK7YmIOIrak+JPHbS5O3UmhaXbDvHztlhOJKfYbXOxWGhVO5DuEdVoUiMAF43WdK7kg7YpDv5ZnFXm5gUtXoSbn86a8ktKnOLUpohI0VZc2hN10OZCHbRSbO39FlY+CufissqCW0CXz6BCQ+fFJYVG7YmIOIrak+JPHbR5y7Aa/L4vnp8iY9myN55L/1MUXK4UtzcJoWvjEMqV8XRKjIJtEbF939sGI5w9nFXuXw86T4GQDs6LTQpMcWxTRKRoKi7tSdGN7Aa1d+9eWrduTe3atWnevDlRUVE56qxZs4ZSpUoRHh5uPi5csM2pFRMTQ0REBOHh4TRs2JB7772X06dPm/taLBYaNWpk7rd+/fpCuzYpBLX6wNAoaPRgVlncbzC3KWx4EdJTLr+viIiIyA3E1cVCy9oVmdDvZmY/fisD2tXEP1tHbNzp80xftYf7J63ktYWRbD9wEo1tcQKLBWr1gmHREDEGLP/eGZYQDV91hKVD4fwJJwYoIiJy/ZzeQTt58mSqV6+Ol5cXEREReXYYrlmzBovFkuOxe/fuXOt/+eWXWCwWevXqVUDRO96DDz7IyJEj+fvvv3nmmWcYPnx4rvXq16/P9u3bzYe3tzcAlSpVYsOGDWzfvp2dO3dSuXJlXn31Vbt9N23aZO7Xrl27Ar8mKWReftDlE+i7FsrVsZVZ0+G312B2Yzi8zqnhiYiIiBQ1gb7eDOlYhzmP38rL90YQUSPA3JZuNVgXFcd/5vzGiMlrWfjrPySfT3NitDcojzLQ8X9w/x8Q1DyrfNcsmFEXdk6zrc8gIiJSDDm1g3bBggWMHj2aF154gW3bttGuXTtuv/12YmNj89xvz549xMXFmY9atWrlqHPw4EHGjh1brDog4+PjiYyM5P777wfg7rvvJiYmhgMHDuT7GJ6enmZnbUZGBmfPni3SQ7ilAFVpD4O3Q8sXwcXNVnb6b1jQAX4ZCSmJzoxOREREpMhxc3WhTd0gXh/YghmPdOS+1jfhWyprntPDCeeYujyaARNX8vai7fwVm6BRtYUtMBz6b7ItiOvpaytLSYBfRtjy3JO7nBqeiIjItXBqz917773H8OHDGTFiBPXq1WPixImEhIQwZcqUPPcLDAwkKCjIfLi62i+AlJGRwcCBAxk/fjw1atQoyEtwqEOHDlGpUiXc3GydaRaLhapVq+baYb1nzx6aNm3KzTffzOTJk+22paWlER4eTkBAAPv27ePll1+2296xY0caN27MmDFjOHfuXMFdkDifmxe0eRUGbYPgllnlOz+DmfXg74W2eb1ERERExE4l/9IM71SXeaM78VyfJjQOLW9uu5hhZeXOIzw1azMPfrqO77fEcDblohOjvcG4uEL4wzBsN9QdkFV+ZAPMCYf1z8HF804LT0RE5Go5rYM2LS2NrVu30rVrV7vyrl27smnTpjz3bdKkCcHBwXTq1InVq1fn2D5hwgQqVKhw2ekBijLLJSvF5vYX+aZNm3L48GEiIyP57rvv+OSTT/jqq6/M7R4eHmzfvp3jx49Tp04dPvnkE3PbwYMH+eOPP9i0aRMnTpzg6aefLriLkaIjoAH02wC3fgjuZWxl547B4nvg+95w5ohz4xMREREpotxdXegYVom3B7Xk84c70Kdldcp6u5vbD544y+RlUQx4fwX/++FPdh85rVG1haV0EHSfB3f/An41bWXWdNjyJswMg39+cm58IiIi+eTmrBOfPHmSjIwMKlasaFdesWJFjh07lus+wcHBTJ06lYiICFJTU5kzZw6dOnVizZo1tG/fHoCNGzcybdo0tm/fnu9YUlNTSU1NNZ8nJycDtpXerNaCn8fIarViGAaVK1fm8OHDpKWl4ebmhmEYHDp0iCpVqtjFUaZMGXO/SpUq0a9fP9atW8c999xjd1w3NzeGDBnCgw8+yNixYwHMY3l7e/PQQw/x0EMPFco1SlFggcajoEZPLCsfwRKzxFa8/3uMQ6sx2r5uW1zMoikxirPM9kS/1yJyvZzRnmhaJinqQgLK8GCX+gy7pQ7ro+JYEhnLrkO2BXlT06388udhfvnzMDdV9KF7RFVuaVCZUp5O+y/XjSO0CwzZCb+9Ab+/CRlpkHwAvusOte6GWyZC2SrOjlJEROSynJ4t5DZi9NKyTHXq1KFOnTrm81atWnHo0CHeffdd2rdvz5kzZ7j//vv57LPPCAgIyPUYuXnjjTcYP358jvITJ06QklLwq95brVaSkpLw9fUlLCyMKVOm0LdvX3788UcqV65MqVKliI+PN+sfP36cChUq4OLiwtmzZ1m0aBH9+/cnPj6ew4cP4+/vT6lSpbBarcyaNYtatWoRHx9PYmIiHh4e5raZM2dSt25du2PLjcATWn2GV+XFlP3jBVxTTmJJS8ay6lHSds4iqcU7ZPjWufJhpEjKbE8Mw1BHh4hcF2e0J0FBQYVyHpHr5eHmSqdGVejUqAoH4s/wU2QsK3Yc5lxqOgD7jyfzwU9/8dmKaG5pUJnuTatSM9jXyVGXcG5e0GY81BsAK0dB7Cpb+d6FcGAZtP0vhD+StTaDiIhIEWIxnHT/TVpaGqVKleLrr7+md+/eZvkTTzzB9u3bWbt2bb6O89prrzF37lyio6PZvn07TZo0sZuTNnPUh4uLC3v27OGmm27KcYzcRtCGhIRw+vRpfHx8rvUS881qtXLixAkqVKjA3r17+b//+z9OnTqFj48PM2bMICwsjAceeICePXty55138vHHH/PJJ5/g5uZGeno699xzDy+//DIWi4WffvqJ559/3jxukyZNeO+99yhfvjybN2/m4YcfxmKxkJ6eTpMmTZg4cSL+/v4Ffo1SRKUkYFn3DJZdM8wiw8Udo/nzcPN/wM3TicHJtcjenqiDVkSuhzPaE7VbjpWcnIyvry9JSUkFntNarVbi4+MJDAy8Yd/HlIsZrN11lCVbY9lzNDHH9jqV/OgeUZUO9YPx8lAnYYEyDIieB2vGwIUTWeWBTaHLJxB0s/Nik3xRmyIijlJc2hOnddACtGjRgoiICLtFrurXr89dd93FG2+8ka9j3HPPPSQkJLBq1SpSUlLYt2+f3fYXX3yRM2fOMGnSJGrXro2Hh8dljpSlMJNZKD4fFinBYlfD8pGQmO33x78edP0MKrdxXlxy1dSeiIijqD0p/tRB6zz74pJYEhnL6r+OcCEtw25bKU83OjeqTPem1QgNLOukCG8QFxJgw3OwY2q2QguEj4K2r4GnRjUXVWpTRMRRikt74tTIxowZw+eff8706dOJjo7mySefJDY2loceegiA5557jsGDB5v1J06cyKJFi9i7dy+7du3iueeeY+HChTz66KMAeHl50aBBA7uHn58fZcuWpUGDBvnqnBW5IVW9BQbvgObPgeXfEegJ0fBlW1gxClKTnRufiIhIETd58mSqV6+Ol5cXERERrF+//rJ1hw4disViyfEICwuzq7dw4ULq16+Pp6cn9evX57vvvivoyxAHqRnsyxPdGzJ/dGcev6MBNYOyOsjPp6bzw+8HefDTdYyZuYkVOw6TejEjj6PJNfP2hy6fQr+NENDw30IDtn8MM+rC7gW20bYiIiJO5tQO2r59+zJx4kQmTJhAeHg469at46effqJatWoAxMXFERsba9ZPS0tj7NixNGrUiHbt2rFhwwaWLFlCnz59nHUJIiWHuze0ex3u3woVm2WV/zkFZtaHfd87LzYREZEibMGCBYwePZoXXniBbdu20a5dO26//Xa7PDa7SZMmERcXZz4OHTqEv78/9957r1ln8+bN9O3bl0GDBvHnn38yaNAg7rvvPn777bfCuixxgFKebnSPqMZHI9oy6f/a0C28Cp5uWf8F23XoNO98/ycDJ63k01+iOHTyrBOjLcEqt7bluO3fBrdStrJzx2BJP/j2dkjc79z4RETkhufUKQ6KKk1xIDc8awZs+wA2vAjp57PKa90Nt34IZYKdF5vkSe2JiDiK2pP8a9GiBU2bNmXKlClmWb169ejVq1e+pu1atGgRffr0ISYmxhyo0LdvX5KTk/n555/NerfddhvlypXjiy++yFdcmuKgaDqbcpGVO4/w09ZYDpw4k2N7o2r+dI+oRpu6Qbi76rV0uOSDsPIx+GdxVpmbF7R4EZqN1RoMRYTaFBFxlOLSnmh2ehHJycUVIp6Emr1hxcNwYKmtfO9CiF0B7d+BhsPBUnQbNxERkcKQlpbG1q1befbZZ+3Ku3btyqZNm/J1jGnTptG5c2ezcxZsI2iffPJJu3rdunVj4sSJlz1Obgvfgu0/JpkL5xYUq9WKYRgFfp6SoJSHKz0jqtKjaQhRhxP5eVss66KOcTHD9trtOJjAjoMJ+JbyoGvjKtzWpAqVypV2ctQlSJkQuPM72P89ltVPYDl7GNJTYOOLGNFzMTpNhiodnB3lDU9tiog4SmG3J9faCawOWhG5PN9Q6PMT7P4CVj8BF05CapJtQbHoudBlKvjXcXaUIiIiTnPy5EkyMjKoWLGiXXnFihU5duzYFfePi4vj559/Zv78+Xblx44du+pjvvHGG4wfPz5H+YkTJ0hJSbliLNfDarWSlJSEYRhFenRKUVPBEwa3DKZPeAU27D3F6ugTHEuydbInnU/j683/8PXmfwirXJZb61UgvJofbi4WJ0ddQvi0xnLHGsrseIdSez7HYmRgSdiN5etbuVDjPpKbvIThFeDsKG9YalNExFEKuz0JCgq6pv3UQetkGVaDnQdPEXMkgeoXXGlYLQBXJV1SlFgsUG8AVOsKa5+CqNm28sPrYHZjaPkS3Pw0uGoRPhERuXFZLPb5m2EYOcpyM3PmTPz8/OjVq9d1H/O5555jzJgx5vPk5GRCQkKoUKFCoUxxYLFYqFChgjpTrkEgUKNqJQbdarAzNoElkYfYtPsY6VbbbHS7jpxh15Ez+JfxpFvjKnRrEkJFX2/nBl1SVJ6METESVo7Ccsw2x7P3P1/hdXQFRrs3IWyY7hpzArUpIuIoxaU9UQetE22IjmPKsihOnskc0RBDQFkvHu5Wn7b1NMenFDGlAuD2WVBvIKx4CJJiICMVNr4Ie76Erp9DcAtnRykiIlKoAgICcHV1zTGyNT4+PscI2EsZhsH06dMZNGgQHh72f+gMCgq66mN6enri6Zlz/kwXF5dC+Q+JxWIptHOVZOHVKxBevQKJ51JZtv0wP2+LJe60bU2AhLOpfLFxP19u3M/NtQLp3rQqN9cM1ACP6xXUFPpvhJ2fwfpnITUJS0oCluUjbYMTOn8CAWHOjvKGozZFRBylOLQnRTeyEm5DdByvfhOZrXPW5uSZFF79JpIN0XFOikzkCkK7wpCdtkUUMkcTnPwL5reCVU9AWs7FLkREREoqDw8PIiIiWL58uV358uXLad26dZ77rl27ln379jF8+PAc21q1apXjmL/88ssVjyklh19pT/q2uYnpj3Tk9QHNaVM3CJd/R1AbwJa98byy4A+GfLiKuev2cjK5YKexKPFcXKHxQzBsN9QdkFV+ZAPMCYf1z8HF85fdXURE5Hqog9YJMqwGU5ZF5Vnnk1+iyPj3liaRIse9NHR4BwZugcAm/xYasO0DmBkG/yxxangiIiKFacyYMXz++edMnz6d6OhonnzySWJjY3nooYcA29QDgwcPzrHftGnTaNGiBQ0aNMix7YknnuCXX37hrbfeYvfu3bz11lusWLGC0aNHF/TlSBHjYrEQcVMFXr43grlP3MqQjrWp4ONlbj+RnMKctX8z6INVjP/qD/7YfwKrof9HXLPSQdB9Htz9C/jVtJVZ02HLm8pzRUSkwKiD1gn+ik3IMXL2UieSU/grNqGQIhK5RhUjbJ207d8Gt3/nQTtzCL7rAT/2h3PHnRufiIhIIejbty8TJ05kwoQJhIeHs27dOn766SeqVasG2BYCi42NtdsnKSmJhQsX5jp6FqB169Z8+eWXzJgxg0aNGjFz5kwWLFhAixaaTuhGVr6sFwPa1WLWY7cyoV8zWtYKJHN2A6thsGnPcV6Yv4VhH61mwcZ9nD6b6tyAi7PQLra7xlq+nLXWQvIBW577w91w5rBTwxMRkZLFYhj68+qlkpOT8fX1JSkpqUAWVFj91xHe/G77Fes1quZP3zY1CQ8tj5ur+tKliEvcD8sfgtgVWWVe5aDD/yBsqG2xMSlwVquV+Ph4AgMDi/T8OiJS9Kk9Kf4KOqfNTp8X54lPusDSbYdYuj2WU2fsO2TdXCy0rhtE96ZVaRxaPl8L10kuEvbAylEQuyqrzL0MtP0vhD8CLlraxdHUpoiIoxSX9kQdtLko6GT2zwOneGbOr/muX9bbndZ1KtKuXjBNqgeos1aKLsOwLaSwZgykZBsBXrUTdPkU/G5yXmw3iOLy5SMiRZ/ak+JPHbQ3lgyrld/+jufHyFgi95/g0v/kVfEvze1Nq9KlcRV8S3nkegzJg2FA9DxbnnvhRFZ5YBNbnht0s/NiK4HUpoiIoxSX9kQdtLko6GQ2w2ow+INVV5zmIDdlvGydte3rBxNePQB3ddZKUXQ+HlaPht1fZJW5eUGrcRAxBlzdnRVZiVdcvnxEpOhTe1L8qYP2xhV3+jw/R8ay7M9DJJ5Ls9vm7upCu3pB3BFRjQYh5TSq9mqlnIb1z8KOqdkKLRA+Ctq+Bp6+TgutJFGbIiKOUlzaE3XQ5qIwktkN0XG8+k3kZbc/2zscd1cX1kcf49e/j5NyMSNHnTJebrSqE0T7esE0qaHOWimC/vkJVjwMZ7LNu1chHLp9bpu/VhyuuHz5iEjRp/ak+FMHrVzMsLJp9zF+ioxl+4FTObZXDShD94iqdGpYhbLe+gP6VTmyCVY8BCd3ZpWVDoKOE6HOfZre6zqpTRERRyku7Yk6aHNRWMnshug4piyLshtJW8HHi4e61qdtvWCzLPViBn/sP8G6qDh+23ucC2mX6aytHUS7+kE0rfH/7N15XNTV/sfx17AvioissguouKSCO4hLpqUt1rU0W7R9z9tyf+XNbqvXW1nZcrXMLM1K09ablmmGguKGu6AIKCibgOz7LL8/RhknRgMdGL7D5/l49Pj9PN/tTHf6eHhzvud4SVgr2o/6Stj2Iux9D86/bKeygai/Q8yrYO9qyd5ZHaX85SOEaP+kniifBLTiQqeLK1m/N5vfDpymoqbB6JijnQ1xfbtzfXQQvbq7y6za5tI06Me4218CdbWhPWQiXP1fWd7rCkhNEUKYi1LqiQS0JrTlYFaj1XEoq4gTOYWE+nvRP9gTW5uLD4jqGjQkZxSyNTWPHWmmw1pXRztGnFuzNqqHJw52tq35EYRonrxd8Nv9xrMM3EL0a3aFTLBYt6yNUv7yEUK0f1JPlE8CWmFKvVpDYmo+PydnceRUSZPjPXzcmBwdxLh+/rg4yuZXzVKeBb8/AZn/M7TZOcGwF2DwP8DO0XJ9UyipKUIIc1FKPZGA1oS2HMzC5X9Z6tX6mbUJKXnsSDtDdb26yTmujnYM76lfs1bCWmFxmgbY8xYkvQqaC3YZjrwTxrwLLp6W65uVUMpfPkKI9k/qifJJQCv+yskzFazfm82mg6epqjP+WcLJ3pZx/f2ZFBVEhJ+sq9osx3+AzU9A5WlDm0dvGL8YAsdYqleKJDVFCGEuSqknEtCaoJSA9kL1ag3JGUUkpOaRlFZAdV3TsNbF0Y4RPfUza6PDJKwVFnQ2DTY9BKfiDW1O3WDsQoi8Q9bsugJK+ctHCNH+ST1RPgloRXPVNmjYmpLLuuRsjuaUNjne068Lk6ODGNO3O04OMqv2kuor9Use7H0PdBe87dh3JsS9BS5eluubgkhNEUKYi1LqiQS0JigxoL1QvVrD3switqZcIqx1sGN4T2/i+nSXsFZYhk4Hh5fBlmehrtTQHjJRP8ugS6jFuqZkSvnLRwjR/kk9UT4JaMXlyMgvY93ebDYfymmynJqLox1X9/dnclQQoT6t/3OSop3Zr99ELG+noc3JA+LehH736PdkEBclNUUIYS5KqScS0Jqg9ID2Qi0Ja0f18WNwmJeEtaJtVeXD5ichbY2hzc4FYl6DqCfBRmZptIRS/vIRQrR/Uk+UTwJacSWq69TEH8llXXIW6fnlTY73CejKpKgg4vr44WgvPz+YpNPCwSWQ8DzUlRna/WP1ExI8+1mub+2c1BQhhLkopZ5IQGuCNQW0Fzof1iak5pF0rKDJOlOgD2uH9fQmLtKP6DAvGWyJtpPxP9j0qPGaXT7RMGEpeA+0WLeURil/+Qgh2j+pJ8onAa0wB51OR1peGeuTs/njSC51Dcazajs52XPNgAAmRQUR5NnJQr1s56ryIf4ZOPqVoc3GDqKfgRH/AnsXy/WtnZKaIoQwF6XUEwloTbDWgPZC9WoN+04UkZCSz/Zj+SbDWmcHW4ZF6DcYGyxhrWgLdeWQ+E/Yvwg4V5pUtjD4WRjxEtg7W7R7SqCUv3yEEO2f1BPlk4BWmFtVbQO/H8phXXI2Jwsrmhy/KtiDyVHBjOztI2/lmZK1CTY9AqXphja3ELj6Q+gx2WLdao+kpgghzEUp9UQCWhM6QkB7oQaNln2ZRWxNzSPpWD6VtRcPa0dF+jIk3FvCWtG6crbDxgegOMXQ5h4G4z+G4Kst1y8FsHQ9EUJYD6knyicBrWgtOp2OlNMlrEvOZmtKHg0ardHxLi4OTDg3q7a7h6uFetlOqWth139g13zQ1BvaI26Bse9B5wDL9a0dkZoihDAXpdQTCWhN6GgB7YUaNFr2n9CvWbv9WAGVtQ1NznGyt2VYhH7N2iHh3jhJWCtag7oOdr8BO+cZD1773gOjF4Czh+X61o61p3oihFA2qSfKJwGtaAvlNfVsOnCadXuzOV1c1eR4VA9PJkUFMaKnD3a28t1odPYY/P4oZG82tNl30u/DMOjxDr8Pg9QUIYS5KKWeSEBrQkcOaC90PqxNSM1j29GLh7VDI/Rr1g6JkLBWtILiVNj4IOQkGtpcvPUzDHpNA5XKcn1rh9prPRFCKI/UE+WTgFa0JZ1Ox8Gss6zfm01iah5qrfGPmR6dHJk4MJDrBgXi4y5rrgKg00HqlxD/NNQUGtq9B8H4j8BvqOX6ZmFSU4QQ5qKUeiIBrQkS0Dal1mjZf7KYhJQ8th3Lp6KmaVjraG/L0HBv4vr4MTTcCyeHjv1bX2FG53fA3foc1F+wi3CPyXD1InALslzf2hkl1BMhhDJIPVE+CWiFpZRW1fHbgdOs35tNXkm10TEVMCTci0lRwQyN8MJWvi9QWwIJc+Dgxxc0qmDgoxA7Dxy7WKxrliI1RQhhLkqpJxLQmiAB7aWpNVoOnCxma2oe24/mU37RsNaLUZF+DIvwlrBWmEdFDmx+AtK/N7TZu0Lsv2HgY2AjM7iVVk+EEO2X1BPlk4BWWJpWp2PfiSLWJ2ez/VgB2j/96Onp5sR1AwO5dlAQnm5OFuplO5KbBBsfgqJDhjZXXxizEHrd1qHeHJOaIoQwF6XUEwloTZCAtvnUGi0Hsor1a9ZeLKy1s2FIuH7N2mER3jhLWCuu1PHv4PfHoSrP0OY3DK75BLz6W65f7YCS64kQon2ReqJ8EtCK9qS4opYN+0/xy75TnCmrMTpmo1IxLMKbydFBRId5YdOBgsgmNA2w9z3Y/hKoL5h9HDwBrv4vdA23XN/akNQUIYS5KKWeSEBrggS0l+d8WJtwboOxsur6JudIWCvMprYUEp43fhXMxg6GPAfD54Jdx5yFYS31RAhheVJPlE8CWtEeabQ6kjMKWZecxa70M/xpqVp83J2ZNCiIiQMD6drJ0TKdbA/Ks/VvjmX8ZGizddSPcwf/A+ys+9+N1BQhhLkopZ5IQGuCBLRXTqPVcuDk2XMbjOWbDGsdzoW1cZF+DOspYa24TKe3wm8PQskxQ1vXnnDNEggcbbl+WYg11hMhhGVIPVE+CWhFe3emrIZf953i1/3ZFFfUGR2ztVExspcvk6ODGBDSrePOqk3/UR/UVpwytHn0hvGLIXCMxbrV2qSmCCHMRSn1RAJaEySgNS+NVsvBrLNsTfmLsDbM69zMWh9cHCWsFS2groWd/4Zd/wHtBcts9H8A4t4EJ3eLda2tWXs9EUK0HaknyicBrVAKjVbLzuNnWJecTXJGIX/+AbW7hwuTooKYMCCQLi4OFumjRdVX6pc82Pse6DSG9j53w+gF4OJlub61EqkpQghzUUo9kYDWBAloW49Gq+VQ1lm2nptZW1rVNKy1t7VhyLkNxob3lLBWtEDRYfjtAcjbYWhz9YVxH0LELR1iY4WOVE+EEK1L6onySUArlCi/pJr1+7LZsP9Uk58V7G1tiI30ZXJ0MP0Cu6LqAGM7I2f2w6aHIW+noc2pK4x6E/rfCyrr+W9PaooQwlyUUk/MFtBmZGTwwAMPsHnzZnPczqIkoG0bGq2OQ9n6NWsTLxHWDg7zIq6PfhkEV0d7C/RUKIpWAwcWQ8IcaKg0tIfdpN9YobO/5frWBjpqPRFCmF9HrScypr08HfX7IlpPg0ZL0rEC1u3NYv+J4ibHgzw7MSkqiPFXBdDZuQP9jKDTwsEl+r0Y6soM7d1j4JqPwLOf5fpmRlJThBDmopR6YraA9sCBA0RFRaHRaP765HZOAtq2p9HqOJytX7M2MTWfkqq6JufY29oQHeZFXKQvw3v5SFgrLq38FPz+KGT+bGhz6Ayj3oABD1nVDIMLST0RQphLR60nMqa9PB31+yLaRk5xFev3ZfPb/lOU1zQYHXOws2F0n+5Mjg6it797x5lVW1UA8U/D0a8MbTZ2EP0MjHgR7F0t1zczkJoihDAXpdSTZge077///iWP5+TksGDBAhnMXgalfFnaikar48gpw5q1ZysvEtb28GRUHz9G9PTB1UnCWmGCTgdpa/QbK1SfMbR3j4EJS6BbH8v1rZVIPRFCmIu11hMZ07YOa/2+iPalXq0hMTWfdXuzOZx9tsnxUO/OTI4OZlz/7h1nMkfWJv2khJLjhja3YP2bYz0mW65fV0hqihDCXJRST5od0NrY2ODn54eDg+lF2evr68nPz5fB7GVQypfFEjRaHSmn9GvWJqZePKyN6uHJqEg/RvTyoZOEteLPas7C1n/A4WWGNht7GPZPGDoH7Bwt1zczk3oihDAXa60nMqZtHdb6fRHtV1ZhBev3ZrPp4Gkqa9VGx5zsbRnbrzuTo4OJ8OtioR62IXWtfrPcXfNBc8GycRG3wNj3oHOA5fp2maSmCCHMRSn1pNkBbWhoKG+88Qa33XabyeP79+8nOjpaBrOXQSlfFkvTaHWknC4hISWPhNQ8k2GtnY2KqDAv4iSsFaZk/wEbH4TSdEObRyRM+AT8YyzXLzOSeiKEMBdrrScypm0d1vp9Ee1fbYOGrSm5rE/OJjWntMnxnn5dmBQdxNi+3XFysPLNh88e08+mzb5gDW37ThDzGgx6XL8EgkJITRFCmItS6kmzexYdHU1ycvJFj6tUKsy0nK0QJtnaqOgf5MGj1/bly79fzdszR3DTkBC6dTbMflRrdew6foYFPx1g2tsbefHrXfx24BQVf1qrSnRQQWPh7oP6WbMqW33b2VRYFQubHoW6csv2TwghRKuTMa0Q1sXJ3pYJAwJZeG8Mix4YxfXRQbhcEMSm5ZWx8OdD3L7wdz785TCZBVY83vPoBVM3waSV4OKtb2uohPin4MuhkLfLsv0TQghxUc2eQZuSkkJ1dTWDBw82ebyhoYHc3FyCg4PN2kFLkBm0yqLV6Ug5VUJCqn5mbXHFRWbWNq5Z69uxdnoVpp05AL/dDwV7DG2d/PXrdYXfZLl+XSGpJ0IIc7HWeiJj2tZhrd8XoUw19Wr+OJzLuuQs0vObBrKRAe5Mjgomro8fjva2FuhhG6gtgYQ5cPDjCxpVMPBRiJ0Hju176QepKUIIc1FKPWl2QNuRSECrXFqdjtTTJWxN0a9ZW1RR2+QcOxsVgy5Ys9bN2fQadKID0Gpg3/uQOBfU1Yb2iL/BuA+gk5/l+naZpJ4IIcxF6onySUArBKTllrJubzZ/HM6lrsF46ZJOTvZcMyCASVFBBHl2slAPW1luEmx8CIoOGdpcfWHMu9BrGqhUluvbJUhNEUKYi1LqSbMD2s2bNxMXF4ednXLWrblcEtBah/NhbUJqPgmpeRSVNw1rbW1UDAr1JK6PhLUdWtlJ2PQInPzV0ObYBeLegv73gUo5/11KPRFCmIu11hMZ07YOa/2+COtRVdvA5sM5rEvO5sSZiibH+wd5MDk6iJjevjjYWdmsWk0D7H0Ptr9kPCkheIL+7bGu4Zbr20VITRFCmItS6kmzA1pbW1vy8vLw9tavZTN8+HC+/fZb/P39W7WDliABrfXR6nQczSlt3GCs8CJh7cBQT+IifRnZyxc3FwlrOxSdDo5+DX/MhpoiQ3tAHFyzRL+mlwJIPRFCmIu11hMZ07YOa/2+COuj0+lIzSllXXIWW1PyqFdrjY53cXFgwoAArosKwt/D1UK9bCXl2bD5Ccj4ydBm6wjD58Lgf4Cd48WvbWNSU4QQ5qKUetLsgNbGxob8/PzGwWznzp05cOAAPXr0aNUOWoIEtNZNq9NxLKeUran6ZRDOlNU0OcfWRsXAkG6M6uNHjIS1HUt1EWx5BlJWGNpsHWH4izDkH2Dbvr8LUk+EEOZirfVExrStw1q/L8K6ldfUs+lgDuuTszhVXNXk+KBQTyZHBTGilw92tlb0vU7/UR/UVpwytHXtBdd8BIFjLNatC0lNEUKYi1LqiQS0JkhA23HodDqO5ZayNSWPhIuEtTYqFQNDuzEq0o+Y3r50kbC2Yzj5G2x6GMpOGNo8+8GEpeA3zHL9+gtST4QQ5mKt9UTGtK3DWr8vomPQ6XQcyj7LuuRsElPzUGuNf0Tu6urIxIH6WbW+7i4W6qWZ1VfC9pdh70LQXbA2b5+7YfQCcPGyVM8AqSlCCPNRSj1p0RIH+fn5eHnpC7WbmxsHDhwgNDS0VTtoCRLQdkz6sLaMhNQ8ElLyKLhIWDsgpBtxffwY2csHd9f28xqQaAUNVfqBa/I7oDv/+psKBj0Bsa+DQ2dL9s4kqSdCCHOx1noiY9rWYa3fF9HxlFbVsfHAadbtzSavpNromAoYHO7F5KhghkZ4YWsN3/UzB/STEvJ2GNqcusKoN6H/vRbbi0FqihDCXJRST1o0g7Zfv36NGyocPHiQ3r174+BgPJtw79695u9lG5OAVuh0OtLyykhIyWNrah4FpabD2qtCPIg7N7NWwlorVpAMvz0AZ/YZ2joHwvjF0GOy5fplgtQTIYS5WGs9kTFt67DW74vouLQ6HftPFLMuOYuktAI0f5pV69nZiWsHBXLtoEC83Jwt1Esz0Wnh4CeQ8DzUlRrau8folz3w7NfmXZKaIoQwF6XUk2YHtK+88kqzbvjSSy+1qAOLFi3irbfeIi8vj759+7Jw4UJGjRpl8tz4+HjGjh3bpD01NZXevXsD8Mknn7BixQoOHz4MQHR0NP/+978ZOnRos/skAa24kE6n43heGVsvGdbCVcH6NWtjJay1Tlo1JL97bvfbC74DvabD2IXg6mOxrl1I6okQwlystZ601pi2PZKAVgjzKK6oZcP+U/y671STt+xsVDA0wofro4OI6uGFrY3KQr00g6oC/V4MqV8a2mzsIPppGPEvsG+7TdOkpgghzEUp9aTZAW1rWL16NXfddReLFi0iJiaGjz/+mKVLl5KSkkJQUFCT888HtMeOHTMaZHp5eWFrawvAHXfcQUxMDCNHjsTJyYk333yT7777jiNHjjR7d14JaMXFXBjWJqTmkS9hbcdTmgEbH4bsTYY2p64w+m3oOwtUlh2USz0RQpiL1BPlk4BWCPPSaHXszSzk5+Rsdh0v4E+TavHp4sx1UUFMHBiARycny3TSHLI2we+PQslxQ5tbMIz7EMKub5MunK8pZWVl3HPPPRQVFeHu7s7nn39Onz59mpx/6NAhnnjiCQoKCtBqtcyfP59bbrmFTZs28eyzzzaed+bMGXx9fRvfkvjiiy9YsGABGo0GHx8fPvvsM5NZhBBCuZQyRrFoQDts2DCioqJYvHhxY1tkZCRTpkxh/vz5Tc4/H9CWlJTg7u7erGdoNBq6du3Khx9+yN13392saySgFc2h0+lIzy9vDGv/vEYV6MPa/sH6DcZie/vStZOEtVZBp4OUFRD/NNSeNbQHXQ3jP4Ku4RbrmtQTIYS5SD1RPglohWg9Z8pqGmfVFlXUGh2ztVExspcPk6KCGRjaDRsL/wL/sqhrYdd/YNd80NQb2iNugbHvQeeAVn38+ZoyY8YM7r77bmbNmsXatWt5++23SUpKMjq3urqa/v37s3z5cmJjY1Gr1ZSUlDSuNX6h66+/nrFjx/LMM89w9OhRxo0bx759+/Dx8WH58uV88803rFu3rlU/mxCibSlljGKxgLa+vh4XFxfWrFnDzTff3Ng+e/Zs9u/fz5YtW5pccz6gDQkJoba2lj59+jB37lyTyx6cV1FRgbe3N2vWrOH6603/tq+uro66urrGP5eXlxMYGEhJSUmbBbSFhYV4eXm16y+LuDidTkdGfjkJR/NJSM2/aFjbL8iDUb19GdnbFw8Ja5Wv+gyq+KdQHVvV2KSzdUI34iWIegps7du8S1JPhBDmYol6InXLvCSgFaL1abRadh4/w/q92exJL+TPP1x393Bh0qAgrhkQoMw3686mwe+PQPZmQ5t9J4h5DQY9rl8CoRVotVpSUlKIjY2lqKgIOzs7dDodfn5+7Nixg5CQkMZzly5dSnx8PCtXrrzkPXNzcwkPD+fkyZN4e3uzdu1ali1bxvr16wEoLi7Gy8uLwsJCunXr1iqfSwjR9pQyRmmdatoMRUVFja8RXMjHx4f8/HyT1/j5+bFkyRKio6Opq6vjiy++4OqrryY+Pp64uDiT1zz//PP4+/szfvz4i/Zl/vz5JtcjKywspLa21sQV5qXVaikrK0On07XrL4u4NDdbmNy3K5P6uJNdXMOuEyXsziyhoFwf/mt1cDDrLAezzrJoQwq9/DoxJLQrg0O74u7S9kGeMJPB7+Lgdz1ddj2HbXUOKk0tqsQ5NBz5krJhC1B3G9Cm3ZF6IoQwF0vUE19f3zZ5jhBCmIutjQ0je/kyspcv+aXV/LI3mw37T1NSpf8ZIPdsNUt/P8ry+DRievsyOTqI/kEeqJQyq9ajJ0zdBEe/0r89Vn0GGioh/in9G2XjPwK/5u/30hI5OTl07969cVNHlUpFUFAQ2dnZRgFtSkoKTk5OXH/99Zw+fZqrrrqKt99+u8kM2uXLl3Pdddfh7e0NwMCBA0lOTiY9PZ3w8HBWrFiBTqcjKytLAlohRJuzWEB73p//YtLpdBf9y6pXr1706tWr8c8jRozg1KlTLFiwwGRA++abb/L1118THx+Pk9PF1wCaM2cOTz/9dOOfz8+g9fLyarMZtCqVSma8WREfHxjSJwSdTkdmQQUJqfkkHs0j56x+Zq0OOJpXydG8SlZuP0XfoK6M6u1HbG8fPDoreL2qjsr7duh7A7rt/4J976NCh33JYbptmASDZqMb+Uqbbaog9UQIYS5ST4QQomV83V24Z1xv7hzdkx3HCvh5bxb7TxQD0KDREn8kl/gjuQR2c2VSdDDjr/LHzdnBwr1uBpUKIu+A0EmQMAcOfqxvP7MPvhoOAx6B2Hng5N4Kj26aF/xZQ0MDGzZsYMeOHXTv3p25c+fy2GOP8c033xid99lnn7Fw4cLGP4eHh7N48WLuuusuNBoN119/PV26dMHeXibPCCHanqKWODBl3rx5rFy5ktTUVKP2BQsW8Prrr7Np0yYGDx7cor7JGrSiNRjC2jwSUvI4fbaqyTkqoG+QB3GRvsRG+tFNwlrlydsFv90PRYcMbW4hcM3HEDKh1R9/YT3JyMhg5syZl9xUIT4+nkmTJtGzZ8/GtqSkJJydnamsrORvf/sbycnJgP7Nh/Nyc3O55557OHnyJI6OjvTu3ZuPPvoIDw+PVv+MQoi2IeMT5ZMlDoSwvJziKn7Zl82G/acor2kwOuZgZ8PoPt2ZFB1EpL+7cmbV5ibBpoeh8KChzdUXxrwLvaaZZdPc80scxMTEUFxcfMklDhYsWMDBgwdZsWIFoJ9RO2nSJE6ePNl4ztatW5kxYwZZWVmNG4z/WX5+PiEhIZw9exYXF5cr/gxCiPZBKWOUZgW077//frNv+OSTTzb73GHDhhEdHc2iRYsa2/r06cNNN91kcpMwU6ZOncrZs2fZvNmwJs5bb73F66+/zoYNGxg+fHiz+3OeBLSitel0Ok6cqSAhJY+tqXmcLjYd1vYJ7EpcHz9ie/vh6SZhrWJoGmDPW5D0KmgM61sTead+4Ori2WqPvrCejB8//i83VYiPj+fZZ59lz549Te5VV1dHYmIi3bp1Y/z48UYBbUFBAcePHyc2NhaAf/zjH5SVlbFkyZJW+2xCiLZljeOT1hrTtlcS0ArRftSrNSSm5rN+bzaHss82OR7q3ZnJ0UGM6+ePq5MCZnBqGmDf+7DtX6C+YP+N4Alw9X+veNPc8zVl+vTpzJo1q3E8u2DBAnbs2GF0bnZ2NhMnTmTnzp24ubnxzjvvsGXLFn788cfGc2bNmkVAQACvv/660bV5eXn4+fmh0Wi499578fT05O23376ivgsh2heljFGaFdCGhoYa/bmwsJDq6mrc3d0BKC0txcXFBW9vbzIzM5v98NWrV3PXXXfx0UcfMWLECJYsWcInn3zCkSNHCA4OZs6cOeTk5DT+JmzhwoWEhITQt29f6uvrWblyJf/5z3/49ttvueWWWwD9sgYvvvgiX331FTExMY3P6tSpE506dWpWvySgFW1Jp9Nx8kwFW8/NrD1lIqwF6BvYlVGRfoyKlLBWMc6mwaaH4FS8oc2pG4xdqH9NrBVmSZyvJwC9e/f+y00VLhXQnnfy5EkGDx5sFND+2dq1a/noo4/YtGmT2T6LEMKyrHF80lpj2vZKAloh2qeswgrW781m08HTVNaqjY452tsytl93JkcF0bO7u2U62BLl2bD5Ccj4ydBm6wjDXoAh/wd2l7cx2vmaUlJSwr333ktxcTFubm4sX76cvn37cv/993PjjTdy4403ArBixQreeOMN7Ozs8Pf3Z8mSJQQEBAD6jcO7d+/OgQMH6NGjh9Fzrr32WrKzs6mvr2fSpEm89dZbODoqcDM3IcRFKWWM0uIlDr766isWLVrEp59+2rge7LFjx3jggQd46KGHuOOOO1rUgUWLFvHmm2+Sl5dHv379ePfddxvXk501axYnT54kPj4e0IevS5YsIScnB2dnZ/r27cucOXOYNGlS4/1CQkLIyspq8pyXXnqJl19+uVl9koBWWIpOpyOrsJItKbmXDGv7BHRlVB8/RkX64uXm3Ma9FC2i08HhZbDlWagrNbSHTITxi6FL6EUvvRzn68mpU6eYOXMmKSkpjceGDh3aZM3u+Ph4brjhBiIiIrC1teWee+7h0UcfNbrnXwW0Go2G8ePHM2XKFGbPnm3WzyOEsBxrH5+Ye0zbHklAK0T7VtegYWtKHuv2ZpF6urTJ8Qi/LkyKCmJsv+44O1h8+5hLS/9RH9RWnDK0de2lH+8GjW3x7aSmCCHMRSn1pMUBbVhYGGvXrmXQoEFG7cnJyUydOpUTJ06YtYOWIAGtaA/Oh7VbU/JISM0ju6jS5HmRAe7ERfoRG+mHdxcJa9utqnzY/CSkrTG02blAzGsQ9STYmGfQfWFAO2vWLI4cOdJ4bMiQIbz99ttGAW15eTk6nY4uXbpw+vRpJk2axNy5c7ntttsaz7lUQKvT6Xj44Yc5c+YM3377rdQwIayItY9PZExrXtb+fRGitWUWlLN+bza/H8yhut54Vq2Lgx3j+ndnUlQwYb6t//PpZauvhO0vw96FoNMY2vvcDaMXgItXs28lNUUIYS5KqSct7lleXh4NDQ1N2jUaDQUFBWbplBBCv2NpiHdn7h7Tk08eGc3HD8VxZ1wEQZ7GS3Wkni7l442p3PX+Zv7+2Ta+25HJmbIaC/VaXJSrL9zwDUz5CTrpX7dCXQ1bntHvfntmv1kfFxgYyOnTp1Gr9QN8nU7HqVOnCAoKMjrPzc2NLl26ABAQEMDtt99OQkJCs5/z5JNPcurUKVavXt2u/7ITQog/kzGtEKI96eHjxuPX9eOrp67m79f3J8KvS+Ox6no1Pydn8+gnCfx92TY2HjhNXYPmEnezEIdOMGYB3JkMfhfsBZOyAj7rBQeXgk5ruf4JIUQ71uKfpq+++moeeOAB9uzZw/nJt3v27OGhhx5i/PjxZu+gEEIvxLszd43Wh7VLHo7jrrgIgr0uEdYu28a3Eta2P2E3wKwjMPAx9FvBAQXJsHIwbH0OGqoveXlzeXt7M2jQIFauXAnAt99+S0hIiNH6s6APKLRa/UC5oqKCn3/+uclssot58sknSU9P5/vvv8fBwcEs/RZCiLZi7jHtokWLCA0NxcnJiejo6L/8ZVddXR0vvPACwcHBODo6EhYWxrJly4zOWbhwIb169cLZ2ZnAwECeeuopamtrW9w3IYRyODvYcd2gID68P5YP7ovh2kGBONrbNh5PzSllwU8HmLFwE4s3HCGrsMKCvb0I7wFw+zYY/xE4uuvbaktg4wOwahQUHrJo94QQoj1q8RIHhYWFzJw5k19//RV7e/3ukmq1mokTJ/L555/j7e3dKh1tS7LEgVCS7MIKtqbmk5CSx8mLDNB6+7uf22DMFx93lzbuobionO36gWqxYZ1Y3MNg/McQfPVl3fLCenL8+HFmzZp1yU0VPvzwQxYvXoydnR1qtZpbb72Vl156CdW5DcyioqLIy8vjzJkz+Pn5MXbsWL744gu2bdtGbGwsvXv3btxIITQ0lO+///6K/7UIIdoHax+fmHNMe37j20WLFhETE8PHH3/M0qVLSUlJafLmwnk33XQTBQUFvP7664SHh3PmzBnUajUjR44E4Msvv+S+++5j2bJljBw5krS0NGbNmsW0adN49913m9UvWeJACOtQVdvA5sM5rEvO5sSZpuP9fkEeTI4KIjbSFwc7WxN3sKCqAv0bY6lfGtps7CD6aRjxL7B3NXmZ1BQhhLkopZ60OKA9Ly0tjaNHj6LT6YiMjKRnz57m7pvFSEArlCq7qJKEc2vWmhq8AfTq7s6oPr6MivTDV8Jay9PUw67/wM55+v//vL736NfqcvZo0e2kngghzKWj1BNzjGmHDRtGVFQUixcvbmyLjIxkypQpzJ8/v8n5v/76K9OnTyczMxMPD9N1/vHHHyc1NZXff/+9se2ZZ55h165dzV6KRgJaIayLTqfjaE4p65Kz2ZKSS73aeLkAN2d7JgwMZNKgIPy7mQ4+LSbrd/j9ESg5bmhzC4ZxH0LY9U1Ol5oihDAXpdSTyw5o6+vrOXHiBGFhYdjZtfMdJVtIAlphDU4VVZKQmsfWlIuHtT27dyEu0o9RfSSstbjiVNj4IOQkGtpcvGHse9BrGpyb0fpXpJ4IIcylo9STKx3T1tfX4+Liwpo1a7j55psb22fPns3+/fvZsmVLk2seffRR0tLSGDx4MF988QWurq7ceOONvPbaazg76zf8XLVqFQ8//DC//fYbQ4cOJTMzk8mTJzNz5kyef/55k32pq6ujrq6u8c/l5eUEBgZSUlLSJgFtYWEhXl5eVv19EaK9qKhp4PdDOazfl82poqomxweGdGNSVCDDe/pgb9tO/ptU16La/Qbs/g+qCyYm6MKnoBvzHnQ+t0+DVoPu9FbK847h5tcLVUAc2LSzmcFCCMVo6zHK5T6jxaPQ6upqnnjiCZYvXw7oZx306NGDJ598ku7du190wCiEaFuBnp2YMSqCGaMiOF1cydaUPBJS88ksKG88Jy23jLTcMpb+fpSefl0Y1cePuEg/fLtKWNvmukXCtC1wcIl+Ldr6cqg+A+tuh5QvYPxicDP9mqwQQoiWM9eYtqioCI1Gg4+Pj1G7j48P+fn5Jq/JzMwkMTERJycnvv/+e4qKinj00Uc5e/Zs4zq006dPp7CwkNjYWHQ6HWq1mkceeeSS/Zo/fz6vvPJKk/bCwsJWX7tWq9VSVlaGTqeTgFaINjIyxIURwb04ll9JfGoRu0+UoNbq51/tP1nM/pPFdHG2Y1QvT8b08sTLzdHCPQbCHsHWawJuu+fgmK9/G0CV/gO6kxupvOofaFy647b3JWyr8+h67hKNix/l0a9RFzTZcv0WQihWW49RfH19L+u6Fs+gnT17Ntu2bWPhwoVce+21HDx4kB49evDTTz/x0ksvsW/fvsvqSHsiM2iFNbtYWHuhCL8ujIr0I66PH34S1ra9ihzY/ASkX7Ceq70rxP5bv7nYJWYQSD0RQpiLtdcTc41pc3Nz8ff3Z/v27YwYMaKxfd68eXzxxRccPXq0yTUTJkwgISGB/Px8unTR79T+3XffMXXqVKqqqnB2diY+Pp7p06fz+uuvM2zYMNLT05k9ezYPPPAAL774osm+yAxaITq2sup6Nh48zS97T5FbYrzxrAqI7uHJdVFBDIvwwtbS/53qdHD0K1Rbn0VVfcbQfO7/nn937HghzFwFRVXg7hfGsq9+oE+fPk1ud+jQIWbPnk1BQQFarZZ58+Zxyy23sGnTJv7v//6v8bwzZ87g6+vLnj17qKqqYvz48Y2/wPL19WXx4sVNNtUVQiibUmbQtjigDQ4OZvXq1QwfPpzOnTtz4MABevToQXp6OlFRUZSXmw58lEQCWtFR5BRXsTU1j4SUPDIuEtaG+7oR18ePUZF+dPdoZ2tZWbvj38Hvj0NVnqHNbxhc8wl49Td5idQTIYS5WHs9MdeY9nKWOJg5cybbtm0jPT29sS01NZU+ffqQlpZGREQEo0aNYvjw4bz11luN56xcuZIHH3yQysrKZv1vImvQCtExaXU6DpwsZl1yFtuPFaDRGv/I79nZiYkDA7l2UCDeXZwt1MtzaksgYQ4c/Njk4XGL4e7BMGuIirVpHrx9MJykpB1G51RXV9O/f3+WL19ObGwsarWakpISvLy8mtzv+uuvZ+zYsTzzzDNotVqqqqro3LkzAAsXLmTr1q1899135v+cQgiLUcoYpcU9KywsNLmrbVVVVeOu30IIZfDv5srtseEsenAUyx4bwz1jexHua/wDXHp+Ocs2H+Oe/8bz2CcJrEpMJ+ds03WuRCuIuAVmpcBVDxna8nbCyihInAvq1n1dVQghrJm5xrQODg5ER0ezceNGo/aNGzcycuRIk9fExMSQm5tLZWVlY1taWho2NjYEBOjXYKyurm7yQ4StrS06nY7L3EJCCNFB2KhUDAr1ZO7UaFbOHsessb3wcTcEsUUVtXyZcJyZH2zmpdV72HX8TJMQt804dYVrPtJvFvYnZypgbw7cGQWg428RxZzISOPkyZNG53311VeMGDGC2NhYAOzs7EyGs7m5uWzevJm77roL0M9yOx/O6nQ6ysvL23V4I4Swbi2uPkOGDGHdunWNfz4/gP3kk0+MXusSQiiLv4cr02PD+e8D+rD23nGmw9rP/jjGvf+N59ElCXydmE5OsYS1rcrJXT9onbYFuvbSt2nVsHMerBgApy6YmaXVwKl4nE5+D6fi9X8WQghhkjnHtE8//TRLly5l2bJlpKam8tRTT5Gdnc3DDz8MwJw5c7j77rsbz58xYwbdunXjnnvuISUlha1bt/KPf/yDe++9t3GTsBtuuIHFixezatUqTpw4wcaNG3nxxRe58cYbsbWVzXKEEM3j0cmJ22PD+eyxsbx++xBG9PTB5tzvoLQ62JFWwIurdnPPh3/wVcJxiissNAHAyaNJ06ky6O4GdudKnkoFQb5dyc7ONjovJSUFJycnrr/+egYOHMjdd99NYWFhk/stX76c6667rskv58aPH4+vry/ffPMN77//vvk+kxBCtECLNwmbP38+1157LSkpKajVat577z2OHDlCUlKSyVe4hBDK4+/hyrSYcKbFhJN7toqE1HwSUvM4nlfWeE5GQTkZBeV8/scxwnzcGjcY8+8myyC0ioA4uHs/7Pw37PoPaBugJA2+GQP9HwD/UZD4T2wqT+N+/ppOATDuPf1MXCGEEEbMOaadNm0axcXFvPrqq+Tl5dGvXz/Wr19PcHAwAHl5eUaBQqdOndi4cSNPPPEEgwcPplu3btx22228/vrrjefMnTsXlUrF3LlzycnJwcvLixtuuIF58+aZ51+AEKJDsbVRMSTcmyHh3hSW17Bh3yl+2X+KonJ9IFtQVsPy+DRWbj3OiJ4+TIoOYlCoJzZt9ZZsJz+TzX9+vE5l3+SchoYGNmzYwI4dO+jevTtz587lscce45tvvjE677PPPmPhwoVNrt+0aVPjurWvv/46ixYtuuyPIYQQl6vFa9CCfgHuBQsWkJycjFarJSoqiueee47+/U2viag0sgatEKbllVSTcG7N2rQLwtoL9fBxY1SkL3F9/Ajo1qmNe9hBFB2G3x6AvB1/ceK5Ee2NayWkFUK0WEcYn8iY1nw6wvdFCGuj0WrZdbyQ9Xuz2J1eyJ+DAb+uLkyKCmLCgADcXR1btzNaDXwSApU5nN8q7EwFRLwBxa/oZ9HqdOD3b2d2JO0kpJehTi9YsICDBw+yYsUKQD+jdtKkSUZLIWzdupUZM2aQlZV10bcQ8vPziYiIoKKiorU+pRDCApQyRrmsgNbaSUArxF/LPxfWbk3NIy3XdFgb6t25cYOxQE8Ja81Kq4EDi2Hr86C+1DITKugcAPefABt5JVYI0XwyPlE+CWiFEM2VX1rNr/tO8eu+U5RU1Rkds7NRERvpx+ToIPoHebTe3jPHv4Ofpp77gz6mGLMIZg3R/7P2ACzYAjteCIKJn0LweACys7OZOHEiO3fuxM3NjXfeeYctW7bw448/Nt561qxZBAQEGL2pUFBQgL29PR4e+uUVFi5cyJo1a9i2bVvrfD4hhEUoZYzS4oDW1taWvLy8Juu2FBcX4+3tjUaj/DUPJaAVomXyS8/PrM3nWG6pyXNCvTszKtKPUX38CJKw1nyOfgPrpv31ebf9AYFjWr07QgjrYe3jExnTmpe1f1+E6CjUGi1JaQWsS85m34miJscDu7kyKTqY8Vf54+bsYP4OHP8ONs+GytMAHDsDs9Y4UFzvjJtNBcunaenrC/d/AzdOvpYbn18DDp1YsWIFb7zxBnZ2dvj7+7NkyZLGTRcrKiro3r07Bw4coEePHo2PSk5O5oEHHkCtVqPT6QgLC+Pdd98lNDTU/J9LCGExShmjtDigtbGxIT8/v8lgNjc3l7CwMGpqaszaQUuQgFaIy1dQWt24Zu3RnFKT54R4dT63Zq0vQV6d27aD1ib1a1g/46/Pm/QVRN7e+v0RQlgNax+fyJjWvKz9+yJER5Rztopf9mbz24HTlFXXGx1zsLNh1LlZtX0Cupp3Vq1Wg/bUFsrzjuHm1wubwNH6N8HKTsCG++DUH4Zz3UJg4jIIGmu+5wshrIpSxijN3iTs/G6GKpWKpUuX0qmTYQacRqNh69at9O7d2/w9FEIoio+7C1NH9GDqiB4XDWtPFlZwcksFX2xJI9irE3HnZtYGS1jbchfZUKEJF++/PkcIIToAGdMKIUTz+Hu4cv/4SO4e05NtR/NZvzebg1lnAahXa/n9UA6/H8ohxKszk6ODuLq/P65OTTfxajEbWwgcQ61jH9y8veF8oNIlFG7dBPsXw9b/A3U1lJ+ENeNg4OMQ9x+wlw2LhRDK1OwZtOen+WdlZREQEGC0sLaDgwMhISG8+uqrDBs2rHV62oZkBq0Q5nemrKZxg7HUi8ysDfLs1LhmbYi3hLXNYmJDBZN8hsC1n4Fn37bqmRBC4ax1fCJj2tZhrd8XIYSx7MIK1u87xcYDp6isVRsdc7S3ZWzf7kyODqJnd/cres5f1pTSDPj1HshJMLR16aEf7wbEXdGzhRDWRSljlBYvcTB27Fi+++47unbt2lp9sjgJaIVoXWfKakg8t8FY6ulSk+cEeXZiVKQfcX0krP1LJjZUMMnGHobPhaHPg20rrBkmhLAq1j4+kTGteVn790UIYayuQcPWlDzW780m5XRJk+Phvm5Mjg5mbL/uODs0+8XdRs2qKTot7PsQEp4H9fllaVQQ9STE/hvsXVr8XCGE9VHKGKXFAW1HIAGtEG3nTFkNiUfzSUjJMzm4A+OwNtirU+vtHKtkf9pQAYDOgXDVQ5DyBZQcM7R7XQUTPgXfwW3fTyGEYsj4RPkkoBVCtIUTBeWs25vN74dyqK4znlXr4mDH2P7dmRwVTJhv8+tQi2pKyXH9bNrcbYa2rhEw8TPwj2nJRxFCWCGljFFaHNBqNBo+//xzfv/9d86cOYNWqzU6vnnzZrN20BIkoBXCMgrLa0g8t2btkVOmw9rAbq7nNhjTz6yVsPYCF9tQQV0LSa/A7rdAd25XcpUNDH4WRrwM9s4W7bYQon2y9vGJjGnNy9q/L0KIv1Zbryb+SC7rkrNJyytrcry3vzuTooIY3bc7Tva2Ju5g0OKaotXA3vdg2wv6sS8AKoh+GmJek/GuEB2YUsYoLQ5oH3/8cT7//HMmT56Mn59fk3Dk3XffNWsHLUECWiEsr6i8lsSjeWxNySPlVInJF/cDurk2bjAWKmEt8Bf1pCBZv/Nt4QFDW9eeMGEpBIxq244KIdo9ax+fyJjWvKz9+yKEaJnjeWWsS87ij8O51DZojI65Otox/qoAJkUFmVzKTKPVcSiriBM5hYT6e9E/2BNbm2aO84uPwoZZkLfT0Na1F1z7OXQffvkfSAihWEoZo7Q4oPX09GTFihVMmjSptfpkcRLQCtG+FFfUnluzNp8j2WdNh7Ue+pm1oyL96OHTccPav6wnmgbY/QbseA009Yb2gY/BqPngIOv9CiH0rH18ImNa87L274sQ4vJU1TWw+VAu6/dmk1lQ3uR4vyAPJkcFERvpi4OdLYmpeSzekEJRRW3jOZ6dnXhkYh9iI/2a91CtBva8Ddv/BZo6fdv5t8dGvgJ2Tub4aEIIhVDKGKXFAW337t2Jj4+nZ8+erdUni5OAVoj2q7iitnHN2sMXCWv9PVwZFelLXB8/evi4daiwttn1pDgFNtxrPLugcxBM+ARCJrR+R4UQ7Z61j09kTGte1v59EUJcGZ1Ox9GcUtbtzWbLkVzq1cbLyrg529MnsCs70s5c9B4vTo1qfkgL+vHur7Mgf7ehzSMSrlsOvkNa+AmEEEqllDFKiwPat99+m8zMTD788EOrDT0koBVCGYoratl2VL9m7aEs02Ftdw8X/QZjkX6E+Vp/WNuieqLVwL73IfGFC3a+BfrOgjHvgJP17mwuhPhr1j4+kTGteVn790UIYT4VNQ38fug065KzyS6qbPZ1Xm5OLH9iXPOXOwDQqvX7MGx/CbQN+jaVDQx5Dka8BHaOLey9EEJplDJGaVZAe8sttxj9efPmzXh4eNC3b1/s7e2Njn333Xfm7aEFSEArhPI0O6ztrV+zNtxKw9rLqielGfDbA3DqD0Obqy9cvQgibm6djgoh2j1rHJ/ImLb1WOP3RQjRunQ6HYdPlbAuOYutKXlotH89d+zNu4YzIKRbyx9WdBh+mQln9hraPPvp16b1iW75/YQQiqGUMYpdc07q0qWL0Z9vvll+YBdCtC/dOjtx45AQbhwSwtlKfVi79dwyCOfHerlnq1m9PYPV2zPw63puZq0Vh7XN5h4Gt/4Oh5bClmehvhyq8uGnW6DnrTDuA3D1sXQvhRDiismYVggh2g+VSkX/II/Gf95ff/gvrzlbWfuX55jk2Q9m7NDvxZD0qn42bdFh+HIYDPsnDJ8Ltg6Xd28hhDCDFi9x0BHIDFohrEdJZZ1+zdrUPA5lFWPqF/N+XV2I7e3L6L7dFR/WXlhPMjIymDlzJkVFRbi7u/P555/Tp08fo/Pj4+OZNGmSYQ1GbQNJ/wzCOedXAH5OgWfX2aB28GTAkFiWL19Op06dAJg6dSrbt28nLy+PioqKxnYhhHWQ8YnyyQxaIYRSHDhZzP99seMvz5syJIT7xvfGwc728h925oB+bdrC/YY2r6vg2uXgPfDy7yuEaJeUMkZpvz0TQggz6NrJkRsGB/PmXcP56u/jeWJSPwaGdOPCpavySqpZk5TJ40sTmfXhHyzdlEpabilK//3VQw89xIMPPkhaWhr/93//x3333WfyvD59+rB//379PweP4DxtPUz6kkqVB/d9Az/M1JI++wx+1cnM+9dzjdc9/PDD7N+/v40+jRBCCCGEsFb9gjzw7Oz0l+f9sPsk93wYz4+7TlCv1lzew7wHwB079WvQ2px7qbjwIHw5BLa/ApqGy7uvEEJcgRbPoB00aJDJ2WUqlQonJyfCw8OZNWsWY8eONVsn25rMoBXC+pVW1emXQUjN4+BJ0zNrfdydiYvUr1nb06+LImbWnq8nAL1796aoqAg7Ozt0Oh1+fn7s2LGDkJCQxvPj4+N59tln2bNnT5N7rVm5lM/f+xfrpucBkJIPk5apOLl5MVz1gH6DBfT1X2bQCmF9rH18ImNa87L274sQovUlpubx2tq9f33iOd06O3LbyDCuGxSEo/1lzqgt2Ae/zoSiQ4Y270H6tWm9rrq8ewoh2hWljFFa3LNrr72WzMxMXF1dGTt2LGPGjKFTp05kZGQwZMgQ8vLyGD9+PD/++GNr9FcIIczC3dWRydHBvHHncL5+ajyzJ/dnUKgnNhf8sF5QWsOapEye/HQbMz/8g082pXI0Rxkza0+dOkX37t2xs9PPClCpVAQFBZGdnd3k3GPHjhEVFcWQIUNYtGhRY3t2QRnBQ6bATT+Aqx8hHpBTqkP728Ow5mooSW+jTyOEEOYnY1ohhGhfYiP9eHFqVJOZtF5uTrw4NYoP749lRE/DvgjFFXUs3pDCrA//4LudJ6hruIwZtT6D4M49+jVoVedC3jP7YOVg2DEPtOor+UhCCNFszdok7EJFRUU888wzvPjii0btr7/+OllZWfz222+89NJLvPbaa9x0001m66gQQrQWd1dHJkUFMSkqiLLqeradW7N2/4litOfC2ILSGtYmZbI2KROfLs7ERvoS18ePXt3d2+3M2j/3y1SwHBUVxenTp+nSpQunT59m0qRJeHp6cttttxnuEX4TBMTBhr8DK/QXnoqHFVdBzGut+hmEEKK1yJhWCCHan9hIP0b08uVQVhEncgoJ9feif7AntufWJ3t52mAy8sv4cutxth0rAOBsZR0f/5bCN9syuHVkDyZHB+PUkhm1tg76MW3YTfrZtMUp+k3Ets2F9O/1a9N69m2NjyuEEI1avMRBly5dSE5OJjw83Kg9PT2d6OhoysrKOHr0KEOGDKGiosKsnW0rssSBEAKgrLqe7cfySUjJY98FYe2FvM+HtZF+9Pa3fFh74RIHvXr1ori4+JJLHPzZ/Pnzyc3N5YMPPmDNmjV8/vnnrFu3DoCUlBQmTRjHyZecoDyr8RrVs1BxYhedQoa06mcTQrQtax+fyJjWvKz9+yKEaFvNqSkZ+eV8mXCcbUfzjdrdXR2YOqIHN0QH4+TQwjlp6jpIegV2vwE6rb7N1gFGvAJDnjWsWSuEUAyljFFa3DMnJye2b9/epH379u04OelfRdBqtTg6Ol5574QQwoK6uDhw3aAg/n3HMFY/PZ6nru9PdJhX42/wAc6U1fDdjhP8/bPt3PX+Zj7+LYWU0yUmw9y25O3tzaBBg1i5ciUA3377LSEhIU3C2by8PLRa/eCzoqKCn3/+mUGDBgH61393797N0aNHAVi0aBHT75wFMw/DoCeAC8LoVSMh6VXQ1Lf2RxNCCLOQMa0QQihbmK8b/7o1msUPjmJUpG9je2lVPUs3HeXuD/5gzfYMautbsEyBnSOM+jfcngQevfVtmnpInANfx0Bxqpk/hRBC6LX41z9PPPEEDz/8MMnJyQwZMgSVSsWuXbtYunQp//znPwHYsGFD4w/4QghhDdxcHLh2UBDXDgqivLqepLQCtqbkse9EEZpzO4wVltfy3c4TfLfzBJ5uToyK9GNUpC+RAV2N1rZtKx9//DGzZs3i3//+N25ubixfvhyA+++/nxtvvJEbb7yRb7/9lsWLF2NnZ4darebWW2/lnnvuAaBz584sXbqUKVOmoFar6d+/v/4eDp1g3Pvc+J+97N2zE1DTa76aiE9eIv5fa2HiMvAd3OafVwghWkLGtEIIYR16+Lgxd2o0J89U8GXCcRJS8tChfxtu6e9HWZOUyd+G9+DGIcE4N3dGrd9QuGsfbPsXJL+tn02bvwu+GKRfDiH6abC5zI3JhBDChBYvcQDw5Zdf8uGHH3Ls2DFA/xrtE088wYwZMwCoqalp3AFXiWSJAyFEc5XX1JN0rGlYeyFPNydie+vXrG3tsLbN64m69txrYG+B7tzGDCobGPwsjHgZ7J1bvw9CiFbREcYnMqY1n47wfRFCtJ0rqSknz1TwdWI6W47kcuHI3M3Z/lxQG4KLYwvmquUmwa+zoCTN0OY3Aq79DDx6tahvQoi2p5QxymUFtNZOAlohxOU4H9YmpOaxL7MItamwtrMTsZG+jIr0o0+g+cNai9WTgr2w4V4oPGBo6xoBEz6FgFFt1w8hhNnI+ET5JKAVQiiVOWpKdmEFXyWmE3/YOKjt7GzPLcNCuWloCK6O9s27WUONftOw5Hfh/N3snCD23zDoSZlNK0Q7ppQxigS0JkhAK4S4UhU1DSSl6TcY23uRsLZbZ0die/sR18d8Ya1F64mmAXa/CTv+tBbtwMdg1Hxw6Ny2/RFCXBEZnyifBLRCCKUyZ03JLqrk64TjxB/J5cIheScnfVA7ZWgIrk7NDGpPJ8KGe6A03dDmHwsTP4Ou4Re/TghhMUoZozQroPXw8CAtLQ1PT0+6du16yV3Kz549a9YOWoIEtEIIc6qoaWBHWgFbU/PYm1F4ybB2VB8/+l5BWNsu6klxCmy4D/J2GNo6B8GETyBkgmX6JIRosXZRT8xMxrStxxq/L0IIy2mNmnK6uJKvEtL543DOn4JaO24e1oMpQ0Po1JygtqEaEv8Je98ztNk5w6j/wKDH9ct9CSHaDaWMUZoV0C5fvpzp06fj6OjYuMnMxcycOdNsnbMUCWiFEK2lsrahcRmEvZlFNGi0Tc7x6ORIbKQvcZF+9An0wNam+WFtu6knWg3s+0A/eFXXGNr7zoIx74BTV4t1TQjRPO2mnpiRjGlbjzV+X4QQltOaNSWnuIqvE9P5/VAO2gviEFdHO24eFsrNw0KbF9Se2qJf4qss09AWEKefTevew6x9FkJcPqWMUWSJAxMkoBVCtIWq2gaS0gpISMkj+RJhbcy5Dcb6NiOsbXf1pDQTNj4A2ZsNba6+cPUiiLjZcv0SQvyldldPRItJQCuEUKq2qCk5Z6tYlZjOpoPGQa2Lox1ThoZwy7AedHb+i6C2vhISnof9/zW02bvCqDdg4CMym1aIdkApY5TLCmgzMjL47LPPyMjI4L333sPb25tff/2VwMBA+vbt2xr9bFMS0Aoh2lpV7fllEPJJzii8ZFg7KtKPfkFNw1qNVsehrCJO5BQS6u9F/2DPFs2+bTU6HRxaCluehfpyQ3vPW2HcB+DqY7m+CSEuqiOMT2RMaz4d4fsihGg7bVlTcs9WsWqbPqjVaP8U1A4J4ebhobg5O1z6Jtl/6GfTlp80tAWOhYnLoEtIq/RbCNE8ShmjtDig3bJlC9dddx0xMTFs3bqV1NRUevTowZtvvsmuXbtYu3Zta/W1zUhAK4SwpKq6BnamnWFrSh57LhLWdnV1JKa3D6P6+NE/qBtJx/JZvCGFooraxnM8OzvxyMQ+xEb6tWX3L67iNGx6BDJ/NrQ5ecDYhRB5J5hhkzQhhPlY+/hExrTmZe3fFyFE27JETckvqebrbelsPHDaOKh1sOPGIcH8bXgP3FwuEdTWV8DW/4MDHxna7DvB6AVw1YMy1hXCQpQyRmlxz55//nlef/11Nm7ciIODoTiNHTuWpKSkFndg0aJFhIaG4uTkRHR0NAkJCRc9Nz4+HpVK1eSfo0ePGp337bff0qdPHxwdHenTpw/ff/99i/slhBCW4upoz7j+/rw8bTCrnxnPc1MGMrKXD/a2hpJdUlXHz8nZPPfFTqYu+I3X1u41CmcBiipqeW3tXhJT89r6I5jWOQCm/ASTvgSnbvq22rPwy93w/WQoP2XZ/gkhOhRzj2mFEEIom29XF566/iqWPTaGSVFB2J17E626Xs2qbRnc/cFmlv1+lLLqetM3cOgM4xfD336DzoH6toZK2PQwrJ0A5dlt9EmEEErU4oD20KFD3Hxz03UDvby8KC4ubtG9Vq9ezd///ndeeOEF9u3bx6hRo7juuuvIzr504Tp27Bh5eXmN/0RERDQeS0pKYtq0adx1110cOHCAu+66i9tuu42dO3e2qG9CCNEenA9rX7rt4mFtdZ36kvf46LcUo1kAFqVSQeQMuCcFek0ztJ/4BZb31c840DWdMSyEEOZmzjGtEEII6+Hr7sLsyf1Z9tgYJkcbgtqaeg2rt2dw9/ubWbopldKqOtM3CLkGZh6G/vcb2rI3wfJ+cHCpfvkvIYT4kxYHtO7u7uTlNZ2NtW/fPvz9/Vt0r3feeYf77ruP+++/n8jISBYuXEhgYCCLFy++5HXe3t74+vo2/mNra9t4bOHChVxzzTXMmTOH3r17M2fOHK6++moWLlzYor4JIUR7c2FY+80z1/D8zQPpF9j1L68rLK/lcPbZNuhhC7h4w/Wr4KYfwPXcEgz1FfolEL4ZByXpFu2eEML6mXNMK4QQwvr4uLvw5KT+fPb4WK6PDmqcIFHboGFNUiZ3f/DHxYNaRzeY8An87VfodO7vlPoK/ea5312nX/pLCCEu0OKAdsaMGTz33HPk5+ejUqnQarVs27aNZ599lrvvvrvZ96mvryc5OZkJEyYYtU+YMIHt27df8tpBgwbh5+fH1VdfzR9//GF0LCkpqck9J06c+Jf3FEIIJXFxtGNsP3+uHxzcrPPbXUB7XvhNMCsF+t1raDu9BVZcBXveBq3Gcn0TQlg1c41phRBCWDfvLs48Mak/nz0+hhsGBzcGtXUXBLVLNqZQUmkiqA2ZqJ9N2/ceQ9vJDfrZtIc/k9m0QohGdi29YN68ecyaNQt/f390Oh19+vRBo9EwY8YM5s6d2+z7FBUVodFo8PEx3r3bx8eH/Px8k9f4+fmxZMkSoqOjqaur44svvuDqq68mPj6euLg4APLz81t0T4C6ujrq6gzFtLxcv8u4VqtFq239V221Wi06na5NniWEsC5dXf9iR9lzVmxJ41B2MdNjwugf5IGqPW1S4OAG13wCPW9DtelhVOUnQV0DW55Fd+wbdNcsBU/l76YuhNJYYnzSlhs3mGtMK4QQomPwcnPm8ev6MT0mnG+2Z7B+bzYNGi11DRq+3XGCn/dkMTk6mFtH9sCjk5PhQid3uHYZ9Pwb/PYAVOVBXRlsuBfS1upn2nbqbrHPJYRoH1Q6XfN+ZZOenk54eHjjnzMyMti3bx9arZZBgwYZrQPbHLm5ufj7+7N9+3ZGjBjR2D5v3jy++OKLJht/XcwNN9yASqXip59+AsDBwYHly5dz++23N57z5Zdfct9991FbW2vyHi+//DKvvPJKk/a0tDQ6d+7cko91WbRaLWVlZXTp0qVd7ygnhGh/tFodT686RElVQ7OvCfdx5caBflwV6Na+glpA1VBFpwPzcTm2DBX6v550NvZU9vs7VX0eB9vmBdJCiCtnifGJr69vqz/D3GPa9qy8vJwuXbpQVlaGm5tbqz5LKTskCyGUQQk1pbiitjGorVcbfpnpYGfDpKggbhsZRrfOTsYX1ZbAH3+HlBWGNkd3GPc+RN6p369BCGFWSqgn0IIZtD179sTf35+xY8cybtw4xo4dy9SpUy/7wZ6entja2jaZ2XrmzJkmM2AvZfjw4axcubLxz76+vi2+55w5c3j66acb/1xeXk5gYCBeXl6tPpgF/ZdFpVLh5eXVrr8sQoj26bFrdbz+7b6LHp8UFcjezCLyS2sASC+o4p0N6YT5uDEtpgcje/lia9OOBoP+S9ANmAkbH0BVcgyVtoHOB9+iU+6v+tm0voMt3UMhOgRrHZ+Ye0wrhBCiY+rW2YlHJvbltpFhrEnKZF1yFvVqLfVqLT/sOsn6vdlNg1qnrnDdcoj4G2x6CKryoa4UfrlbP5v2mo/BtfV/WSmEaH+aPYM2ISGBLVu2EB8fT1JSErW1tQQFBTUObMeOHdviDRWGDRtGdHQ0ixYtamzr06cPN910E/Pnz2/WPaZOncrZs2fZvHkzANOmTaOiooL169c3nnPdddfh7u7O119/3ax7tuVsA1BOmi+EaL8SU/NYvCGFogrDmwJebk48PKEPsZF+aLRathzJ4+vEdLKLKo2uDezmyrSYcMb2646dbTuqQepaSHoVdr8JunNr0apsYPCzMOJlsHe2aPeEsHbWOj5pjTFteyUzaIUQSqXEmnK2slYf1O7Jou6CGbX2tjZcFxXItJHheLpdMKO2phg2PwlHvzK0OXnAuA+h93SZTSuEmSilnjQ7oL1QQ0MDSUlJxMfHEx8fz44dO6irqyM8PJxjx441+z6rV6/mrrvu4qOPPmLEiBEsWbKETz75hCNHjhAcHMycOXPIyclhxQr99P+FCxcSEhJC3759qa+vZ+XKlfznP//h22+/5ZZbbgFg+/btxMXFMW/ePG666SZ+/PFH5s6dS2JiIsOGDWtWvySgFUIokUar41BWESdyCgn196J/sGeTmbFanY6kYwV8nZjO8bwyo2M+7s7cOiKMiQMDcLCzbcuuX1rBXv0aXYUHDG1dI2DCpxAwynL9EsLKdYTxibnGtO2VBLRCCKVSck0pqaxj7Y5M/rcni7oGw4a39rY2XDsokNtGhuHd5YKJBse/h00PQ/UZQ1v4zTB+Mbg2/+1iIYRpSqknlxXQnldTU0NiYiIbNmzgk08+obKyEo2mZTtuL1q0iDfffJO8vDz69evHu+++27jh16xZszh58iTx8fEAvPnmmyxZsoScnBycnZ3p27cvc+bMYdKkSUb3XLt2LXPnziUzM5OwsDDmzZvXGOA2hwS0Qgilam490el0JGcW8XViOoezzxod8+jkyN+G92BydBDODi3eS7J1aBr0M2l3vAqaekP7wMdg1HxwaP31woXoaDrS+MQcY9r2SAJaIYRSWUNNKa2qY21SJj+ZCGonDgxgWky4IaitLoLNj8Ox1YYbOHWD8Yug121t3HMhrItS6kmLAtra2lq2b9/OH3/8QXx8PLt37yY0NJTRo0cTFxfH6NGjreKVMAlohRBKdTn15FD2WVYlprMno9Co3c3ZnilDQ7lxSAidne1bo7stV5wCG+6DvB2Gts5BMGEJhEy0XL+EsELWPD6RMa35WfP3RQjR9qypppRW1fHtjhP8tPsktRcEtXY2KiYMDGR6TBg+7i76xmNr4PdHoabIcIOet8LV/wUXrzbuuRDWQSn1pNkB7ejRo9m9ezdhYWGNA9fRo0e3aEMvpZCAVgihVFdST47nlfF1YjrbjhpvtOjiYMcNg4O5ZXgo7q6O5uzu5dFqYN8HkPgCqKsN7X1nwuh3wNnDcn0TwopY6/hExrStw1q/L0IIy7DGmlJWXc+3OzL5afdJauqNg9prBgQwPTYcX3cX/VIHmx6F498aLnb20i950PNvFui5EMqmlHrS7IDW3t4ePz8/pkyZwpgxY4iLi8PT07O1+2cREtAKIZTKHPUkq7CC1dsy+ONwLtoL/opwsLPhukFBTB3Rw3jdLEspzYSND0D2ZkObq69+hkFE85e1EUKYZq3jExnTtg5r/b4IISzDmmtKeXU93+08wY+7TlJdr25st7VRcc1V+qDWz91Zv9zB749B7QXLkfWaDld/CM7dLNBzIZRJKfWk2QFtVVUVCQkJxMfH88cff7B//3569uzJ6NGjGTNmDKNHj8bLyzqm3EtAK4RQKnPWk7ySar7ZnsHGA6dp0Bh2orWzUTH+qgBuiwnD38P1Srt8ZXQ6OLQUtjwL9eWG9p5T9TvgysYKQlw2ax2fyJi2dVjr90UIYRkdoaaU19Tz/Y4T/LD7JNV1hqDWRqVi/FX+3B4bTnfHCtj4MGT8aLjQxQeu+RjCb7JAr4VQHqXUk8veJKyiooLExMTGtbsOHDhAREQEhw8fNncf25wEtEIIpWqNelJUXsvaHZmsT86iTm0Iam1UENenO7fHhhPibeFNuipOw6ZHIPNnQ5uTB4xdCJF3gkplsa4JoVQdZXwiY1rz6CjfFyFE2+hINaWipoHvd57gh10nqPpTUHv1Vf7cHhOG/5kfYfMTUFtiuDDyDhj7vizvJcRfUEo9ueyeubq64uHhgYeHB127dsXOzo7U1FRz9k0IIUQ74OnmxMMT+rDiyXFMjwnDxdEOAK0O4o/k8tDHW3l59R6O5ZZarpOdA2DKTzDpS/2Ot6B/HeyXu+H7yVB+ynJ9E0K0azKmFUIIYUmdne25e0xPVjw5jrviIujkdH6srWPjgdPcv3grb6X1Je/G3dDjesOFqV/C8r6Q8fNF7iyEUJJmz6DVarXs2bOn8XWwbdu2UVVVhb+/P2PHjm38Jzg4uLX73OpkBq0QQqnaop5U1Tbw054svt95grLqeqNjUT08uT02nP5BHqgsNWu1+gxsng3HVhnaHDpD3Jtw1YOgkjorRHNY6/hExrStw1q/L0IIy+jINaWqtoEfdp3ku52ZVNZeOKMWxvbtzn3dd9Nt9/9BXZnhor4zYcxCcHJv8/4K0d4ppZ40O6B1c3OjqqoKPz8/xowZw5gxYxg7dixhYWGt3cc2JwGtEEKp2rKe1NarWb/vFGuTMiiuqDM61jewK9NjwhkS7mW5oDb9J9j0MFTlGdoCRsOEpdA13DJ9EkJBrHV80lpj2kWLFvHWW2+Rl5dH3759WbhwIaNGjbro+XV1dbz66qusXLmS/Px8AgICeOGFF7j33nsbzyktLeWFF17gu+++o6SkhNDQUN5++20mTZrUrD5JQCuEUCqpKfqg9sfdJ/l2xwkqaxsa221UMLmXHfdp3sE55zfDBZ2668e5oddZoLdCtF9KqSfNDmg//vhjxo4dS8+ePVu7TxYnAa0QQqksUU/q1Ro2Hczhm+0Z5JVUGx0L93Vjekw4MZG+2FgiqK0t1W8gdvhTQ5udM8S8BlF/Bxvbtu+TEAphreOT1hjTrl69mrvuuotFixYRExPDxx9/zNKlS0lJSSEoKMjkNTfddBMFBQW8/vrrhIeHc+bMGdRqNSNHjgSgvr6emJgYvL29+ec//0lAQACnTp2ic+fODBgwoFn9koBWCKFUUlMMquoa+Gl3Ft/uyKSixhDUqtDxRNBuritbiE3DBZvl9rsXxrwDjl0s0Fsh2h+l1JPL3iTMmklAK4RQKkvWE41WS/zhXFZtyyC7qNLoWGA3V6bFhDO2X3fsbC1Q57I2wW8PQPlJQ5vvUJj4KXj2a/v+CKEAMj5pvmHDhhEVFcXixYsb2yIjI5kyZQrz589vcv6vv/7K9OnTyczMxMPD9OYuH330EW+99RZHjx7F3t7+svolAa0QQqmkpjRVXafmf3tOsjYpk/ILglovVSGvdv2YHrU7DCd3CtCPc0MmWKCnQrQvSqknEtCaIAGtEEKp2kM90ep0bD+az9eJ6aTnlxsd83F35raRYUwYEICDXRvPXq2vhMQXYN8HwLm/+mzsYfhcGPo82Dq0bX+EaOfaQz1Rgvr6elxcXFizZg0333xzY/vs2bPZv38/W7ZsaXLNo48+SlpaGoMHD+aLL77A1dWVG2+8kddeew1nZ2cAJk2ahIeHBy4uLvz44494eXkxY8YMnnvuOWxtTdfPuro66uoMS86Ul5cTGBhISUlJmwS0hYWFeHl5yfdFCHHFpKZcXE29mp+Ts1m7I5Py6vNBrY7rbDfwiNNnOOqqGs/V9bsfXdxb4Nj6uYYQ7VVb15PLfYadmfshhBCig7NRqYiN9COmty97Mgr5OjGdI6dKACgoreGD9Yf5cutxpo7oweSoIJwc2uivIodOMO496HUbbLgPSo6BtgG2vwRpa2HiMvAd3DZ9EUJYjaKiIjQaDT4+PkbtPj4+5Ofnm7wmMzOTxMREnJyc+P777ykqKuLRRx/l7NmzLFu2rPGczZs3c8cdd7B+/XqOHz/OY489hlqt5l//+pfJ+86fP59XXnmlSXthYSG1tbVX+EkvTavVUlZWhk6nkzBFCHHFpKZc2uiwTgwL6svmlELWHyygolbNL5prSa6O4mmH9xhkewAA1eGlaDN/oWzEu9T7XnxddCGsWVvXE19f38u6TmbQmiAzaIUQStVe68mh7LN8nZhOckahUbubsz1ThoZy09AQOjld3iu8l0VdC0mvwu43QafRt6lsYPCzMOJlsHduu74I0U6113rS3uTm5uLv78/27dsZMWJEY/u8efP44osvOHr0aJNrJkyYQEJCAvn5+XTpol8j8LvvvmPq1KlUVVXh7OxMz549qa2t5cSJE40zZt95553GjchMkRm0QghrITWl+Wrr1azbe4q1OzIpraoHdEy2+4UH7JfhrDL8ck531cPoRr2hn7QgRAciM2iFEEKIc/oHedB/xlDScktZlZjOtmMFAJTXNLBiSxprkzK5YXAwtwwPxd3VsfU7ZOcEo/4NPafqZ9MW7gedVh/Ypn8PEz6FAJllIIT4a56entja2jaZLXvmzJkms2rP8/Pzw9/fvzGcBf2atTqdjtOnTxMREYGfnx/29vZGyxlERkaSn59PfX09Dg5Nl2VxdHTE0bFpDbWxsWmTH0hUKlWbPUsIYf2kpjSPi5MDt44M44YhIaxPzmJNUibrKiexRxPFMw7vMcD2EACqgx+hOvkrXPsZBI6xbKeFaGNKqCftt2dCCCGsTs/u7vzrtsF8/FAc4/p1x0alb6+uV7N6ewZ3v7+ZxRuOUFhe0zYd8omCO3ZBzOuGNWhLjsPqOPj9caivaJt+CCEUy8HBgejoaDZu3GjUvnHjRkaOHGnympiYGHJzc6msNGyomJaWho2NDQEBAY3npKeno9Vqjc7x8/MzGc4KIYTo2JzsbblleA8+f3wsD0/oQ4NrMM/VzeO/9Q9Rqzv3y7vyk/DNWPj9CWiouuT9hBBtSwJaIYQQbS7EuzPP3TyITx8dw3WDArE7l9TWqbX8sOsksz74g3d/PkjO2TYYONraw/AX4K594Dfc0L7/v/B5Pzi5ofX7IIRQtKeffpqlS5eybNkyUlNTeeqpp8jOzubhhx8GYM6cOdx9992N58+YMYNu3bpxzz33kJKSwtatW/nHP/7Bvffe27hJ2COPPEJxcTGzZ88mLS2NdevW8e9//5vHHnvMIp9RCCGEMjja23LzsFB9UDuxH9ucp/Jw7Ycc0vQ1nLT/Q+qX9YPTCZbrqBDCiKxBa4KsQSuEUCql1pPC8hq+3XGC9clZ1KkNs8VsVDC6b3emx4QT4t259Tui1cC+DyDxBVBXG9r7zoTR74CzR+v3QYh2Qqn1xFIWLVrEm2++SV5eHv369ePdd98lLi4OgFmzZnHy5Eni4+Mbzz969ChPPPEE27Zto1u3btx22228/vrrjQEtQFJSEk899RT79+/H39+f++67j+eee85o2YNLacsxrXxfhBDmJDXFfOrVGn7Zd4o1iceJqV3DPfYrcFLp1yvXoqK018N4TFwA9i4W7qkQrUMp9UQCWhMkoBVCKJXS60lpVR3f7zzBT3uyqK5TGx0b0dOH20eF06u7ext0JBM2PgDZmw1trr5w9X8h4pbWf74Q7YDS64mQgFYIoVxSU8yvXq1hw/5T/JG4hfvq36CvbWrjsSLbQKrGLiF4wLUW7KEQrUMp9UQCWhMkoBVCKJW11JPK2gZ+2n2S73eeoLymwehYVA9Pbo8Np3+QByqVqvU6odPBoU9hyzNQX25o7zkVxn0IrqY3/xHCWlhLPenIJKAVQiiV1JTWU6/W8Nv+LMoS3uJWzac4qPRjba1OxbZOt+N57VtEhnS3cC+FMB+l1BMJaE2QgFYIoVTWVk9q69Ws35vN2h2ZFFfUGR3rG9iV22PDGRzm1bpBbcVp2PQIZP5saHPygLELIfJOaM1nC2FB1lZPOiIJaIUQSiU1pfXVqzVs3x5PwJ4nCNcZZtOe0gbwP8+XGT3+ZvoGyvJeQvmUUk8koDVBAlohhFJZaz2pV2vYdDCH1dvSyS+tMToW7uvG9NhwYnr7YtNaYalOB0dXweYnoLbY0B56HYz/GNwCW+e5QliQtdaTjkQCWiGEUklNaTsNDQ1k/PwSYZkLsEc/m1ajs2Gt+hYO+j/O9NH96R8kQa1QLqXUEwloTZCAVgihVNZeTzRaLfGHc1m1LYPsokqjY4HdXJkWE87Yft2xs22lz159BjbPhmOrDG0OnSHuTbjqQVBZ379z0XFZez3pCCSgFUIoldSUtqc+c5jKH+7EveJAY1uWNogF9X/HJWgEd8ZF0D+4mwV7KMTlUUo9kYDWBAlohRBK1VHqiVanY/vRfL5OTCc9v9zomI+7M7eNDGPCgAAc7Jq303mLpf8Emx6GqjxDW8BomLAUuoa3zjOFaGMdpZ5YMwlohRBKJTXFQrRqNDvfRJX0MjY6w2zab9RT+bLhdiKDfbgzricDQiSoFcqhlHoiAa0JEtAKIZSqo9UTnU7HnoxCvk5M58ipEqNjHp0cmTqiB5OjgnBysDP/w2tLYcuzcPhTQ5udM8S8BlF/B5tWCoeFaCMdrZ5YIwlohRBKJTXFwgoPoft1FqozexubTmiDWVD3FOk6/Wa9d46OYEBwt9bdC0IIM1BKPZGA1gQJaIUQStWR68mhrGK+3pZBckahUbubsz03DwvlxiEhdHKyN/+DszbBbw9A+UlDm+9QmPgpePYz//OEaCMduZ5YCwlohRBKJTWlHdA0wO430CW9ikprmE27Sn0bXzVMQ409/YI8uDMugoEhEtSK9ksp9UQCWhMkoBVCKJXUE0jLLWVVYjrbjhUYtbs42HHD4GBuGR6Ku6ujeR9aXwmJL8C+D4Bzf63a2MPwuTD0ebB1MO/zhGgDUk+UTwJaIYRSSU1pR84cgF9nQeH+xqYMbSgL6p4iU9cDgL6BXbkjLoKoUE8JakW7o5R6IgGtCRLQCiGUSuqJwckzFazelk78kVy0F/xN52hnw3VRQUwd0QMvN2fzPjRnG2y4D0qOGdo8+8PEZeA72LzPEqKVST1RPglohRBKJTWlndHUw85/w855oFUDoMaWr+qns0p9Kxr0y4lFBrhzZ1xPontIUCvaD6XUEwloTZCAVgihVFJPmso9W8U32zPYeOA06guSWjsbFeMHBDBtZBjdPVzN90B1LSS9CrvfBJ1G36aygehnYOQrYG/mUFiIViL1RPkkoBVCKJXUlHaqYK9+Nm3RocamLFUE/66ezUldSGNbb3937oyLYHCYlwS1wuKUUk8koDVBAlohhFJJPbm4wvIa1iZl8svebOrU2sZ2GxWM7tud6THhhHh3Nt8DC/bqZ9Ne8DoYXSNgwqcQMMp8zxGilUg9UT4JaIUQSiU1pR3T1MOO12Dn/MbJCFqVPT/a3c2SshvRYtgot1d3fVA7JFyCWmE5SqknEtCaIAGtEEKppJ78tdKqOr7beYL/7cmiuk5tdGxkLx9ujw2nZ3d38zxM0wB73oKkV/SD2fMGPApx/wEHMwbCQpiZ1BPlk4BWCKFUUlMUIH8P/DoTilMamyq6DODt+qdIKvY0OrWnXxfuiItgWIS3BLWizSmlnkhAa4IEtEIIpZJ60nyVtQ38tPsk3+88QXlNg9Gx6B6e3B4bTv/gbuZ5WHGqfjZtXpKhrXMQTFgCIRPN8wwhzEzqifJJQCuEUCqpKQqhroOkl88t7aV/Q01n68DJ8Gd56/TVZBTWGJ0e4deFO0ZFMLynBLWi7SilnkhAa4IEtEIIpZJ60nK19WrW781m7Y5MiivqjI71DezK7bHh5lk/S6uB/R9Cwj9BXX3BQ2bC6HfA2ePK7i+EmUk9UT4JaIUQSiU1RWHydurXpj17tLFJ5zuUfT3f4pN9KjILyo1OD/d14464CEb09JGgVrQ6pdQTCWhNkIBWCKFUUk8uX71aw8YDp/lmewb5pca/7Q/3dWN6bDgxvX2xudJBZGkmbHwAsjcb2lx8YPwiiLjlyu4thBlJPVE+CWiFEEolNUWB1LWw7V+wZwFwLmaydUQb8xo7Os3gy8RM0vONg9own3NBbS+fKx9jC3ERSqknEtCaIAGtEEKppJ5cOY1Wyx+Hc1m9LYPsokqjY0GenZgWE8bYft2xvZJ/vzodHPoUtjwD9RcMVHtOhXEfgqvP5d9bCDOReqJ8EtAKIZRKaoqC5WyHDfdASZqhzW8Eums/Y0ehOyu3pjUJakO9O3NHXIR5JkMI8SdKqScS0JogAa0QQqmknpiPVqdj29F8ViWmNxlE+ro7c9vIMK4ZEICDne1F7tAMFTmw6RHI/J+hzckDxi6EyDtBBqjCgqSeKJ8EtEIIpZKaonANNbBtLiS/S+NsWjsniP03uoFPsDOjmC+3Hictr8zoslDvzswYFUFspAS1wnyUUk8koDVBAlohhFJJPTE/nU7HnoxCvk5M58ipEqNj3To7MnV4DyZFBeHkYHe5D4Cjq+CPJ6GmyNAeeh2M/xjcAq+g90JcPqknyicBrRBCqaSmWInTifrZtKXphjb/WJj4GTr3MHanF/LF1jTSco2D2mCvTtwxKoJRffwkqBVXTCn1RAJaEySgFUIoldST1nUoq5ivE9NJziwyau/i4sCUoSHcOCSETk72l3fz6kLY/CQcW2Voc+gMcW/CVQ+CSv73FG1L6onySUArhFAqqSlWpKFKv0nuvvcNbXbOMOoNGPQYOlTsyShk5dbjHM0pNbo0yNMQ1NraSFArLo9S6okEtCZIQCuEUCqpJ23jWG4pqxLT2X6swKjdxdGOGwYHc8uwUNxdHS/v5uk/waaHoSrP0BYwGiYsha7hV9BrIVpG6onySUArhFAqqSlW6NQW2HAvlGUa2gJGw8Rl4N4DnU5HcmYRK7emkXq61OjSwG6uzBgVwei+3SWoFS2mlHoiAa0JEtAKIZRK6knbOnmmglXb0tlyJBftBX+bOtrZcF1UEFNH9MDLzbnlN64thS3PwuFPDW12TjDyNYh+CmyuYN1bIZpJ6onySUArhFAqqSlWqr4SEp6H/f81tNm76t8YG/AwqGzQ6XTsPVHEl1uPN1leLKCbKzNiwxlzpRv2ig5FKfVEAloTJKAVQiiV1BPLyDlbxTfbM9h04DTqC5JaOxsV1wwI4LaRYXT3cG35jbM2wW8PQPlJQ5vvEP1MA89+V95xIS5B6onySUArhFAqqSlWLnuzfjZteZahLWgcTPgUuoQA+n0g9p8s5ostaU2CWn8PV26PDWdcfwlqxV9TSj2RgNYECWiFEEol9cSyCstrWJuUyS97s6lTaxvbbVQwpm93psWEE+LduWU3ra/U74K7930ad8G1sYdhL8CwOWDrYL4PIMQFpJ4onwS0QgilkprSAdRXwNb/gwMfGdrsO8HoBef2X9AvZaDT6ThwspiVW49zKPus0S26e7gwIzZCglpxSUqpJxLQmiABrRBCqaSetA+lVXV8t/ME/9uTRXWd2uhYTC8fpseG07O7e8tumrNdP9Og5JihzbO/fjat7+Ar77QQfyL1RPkkoBVCKJXUlA7k5Eb47T6oOGVoC75Gv/+CW5DRqfqgNo2DWcZBrV9XF26PDefq/v7Y2cr3RRhTSj2RgNYECWiFEEol9aR9qaxt4KfdJ/l+5wnKaxqMjkX38OT22HD6B3dr/g3VtbDjNdj1Bug0+jaVDUQ/AyNfAfvLWO9WiIuQeqJ8EtAKIZRKakoHU1cOW56BQ0sNbQ6dYcy70O/extm05x3M0s+oPXCy2Kjd192Z22PDGX9VgAS1opFS6okEtCZIQCuEUCqpJ+1TTb2a9XuzWZuUydnKOqNjfQO7cntsOIPDvFCpmrkrbcE+/Wzawv2Gtq4R+nW7AkaZr+OiQ5N6onwS0AohlEpqSgd14lf47X6ozDG0hVwLEz6BzgFNTj+UfZaVW9PYf8I4qPVxd2Z6TDjXDAjAXoLaDk8p9cTiPVu0aBGhoaE4OTkRHR1NQkJCs67btm0bdnZ2DBw4sMmxhQsX0qtXL5ydnQkMDOSpp56itrbWzD0XQgghmsfZwY6/De/B8ifG8uSkfvi6G2a6HjlVwtyvd/PEp9tITM1D25zfm/oMgjt2Qew8wxq0JcdhdRxseky/ppcQQgghhBBKEnotzDwMfWcZ2k7+Csv7weHP4U/j5P5BHrxx53DemTWCqB6eje0FpTW8t+4Q9/03nvV7s2nQaBGivbPoDNrVq1dz1113sWjRImJiYvj4449ZunQpKSkpBAUFXfS6srIyoqKiCA8Pp6CggP379zce+/LLL7nvvvtYtmwZI0eOJC0tjVmzZjFt2jTefffdZvVLZtAKIZRK6okyaLRa/jicy+ptGWQXVRodC/LsxPSYMMb0a+ZmB8WpsOE+yEsytHUOgglLIGSimXsuOhKpJ8onM2iFEEolNUWQuQ5+ewCq8gxtPSbDNUugU3eTl6ScLmHl1uMkZxQatXt3cWZaTBgTBgTgYGfbmr0W7ZBS6olFA9phw4YRFRXF4sWLG9siIyOZMmUK8+fPv+h106dPJyIiAltbW3744QejgPbxxx8nNTWV33//vbHtmWeeYdeuXc2enSsBrRBCqaSeKItWp2Pb0XxWJaaTnl9udMzX3ZnbRoZxTXMGkloN7P8QEv4J6mpDe9+ZMPodcPZohd4Layf1RPkkoBVCKJXUFAFAbQn8MRtSvjC0ObrDuPch8s4ma9Oel3ouqN3zp6DW082J6TFhTBwYKEFtB6KUemKxntXX15OcnMyECROM2idMmMD27dsvet1nn31GRkYGL730ksnjsbGxJCcns2vXLgAyMzNZv349kydPNl/nhRBCCDOwUakYFenHh/fH8vrtQ+gb2LXxWH5pDe+vP8ysD//gux2Z1NarL3EjW4iaDTMPQdDVhvYjy+HzPnD8u1b8FEIIIYQQQrQCp65w3Qq46Udw8dG31ZXCL3fDj1OgKt/kZZEBXZk3Yyjv3RvD0HCvxvai8lo+/OUI93wYz4+7T1Kv1rT+ZxCimews9eCioiI0Gg0+Pj5G7T4+PuTnm/6P7Pjx4zz//PMkJCRgZ2e669OnT6ewsJDY2Fh0Oh1qtZpHHnmE559//qJ9qauro67OsGlLebl+FpNWq0Wrbf21SrRaLTqdrk2eJYSwblJPlCu6hydRod04lH2W1dsz2ZtZBEBxRR0fb0zl623pTBkSwg2Dg+nkZG/6Jm4hcMsGOPwpqq3/QFVfDtUF8NPf0EX8Dd3YD8DVx/S1QvyJJepJe57VIIQQQggLCb8R/GNg85Nw9Ct9W8ZPkJMI4z6E3tNNzqbt7e/Oa7cP5VhuKV9uPc7O42cAKKqoZdGvR1i9LZ1pI8O4LipIZtQKi7NYQHven3es1ul0Jnex1mg0zJgxg1deeYWePXte9H7x8fHMmzePRYsWMWzYMNLT05k9ezZ+fn68+OKLJq+ZP38+r7zySpP2wsLCNtlcTKvVUlZWhk6nkx9MhBBXROqJ8vk6w+yrg8m8ypP/7ctnb1YpAOXVDazYcpw12zMY39ebCf28cXO+SFDrcyM2k4fgtut5nHJ+A0B1/Ft0WZspj36F2tCpF30lTIjzLFFPfH192+Q5QgghhFAY524w+Uvo+TfY+DDUFELtWVg/A46vhfGLwcXb5KW9urvz6vQhHM8rY+XW4+xIKwD0EyEWbUhh1bYMbhsZxqSoIBztJagVlmGxNWjr6+txcXFhzZo13HzzzY3ts2fPZv/+/WzZssXo/NLSUrp27YqtreE/lvMzO2xtbfntt98YN24co0aNYvjw4bz11luN561cuZIHH3yQyspKkz9gmJpBGxgYSElJSZutQVtYWIiXl5cEKkKIKyL1xPqcPFPB6u0ZbE3JQ3vB39iOdjZcOyiQvw0PxcvN2fTFOh2krUb1x2xUNUWG5pBr0Y3/CDoHtnLvhZJZop5I3TIvWYNWCKFUUlPEJVUXwu+PQ9o3hjZnT7j6v9Drtr+8/HheGV9uPU7SuaD2PI9Ojtw6ogeTooNxkqDWaiilnlhsBq2DgwPR0dFs3LjRKKDduHEjN910U5Pz3dzcOHTokFHbokWL2Lx5M2vXriU0NBSA6urqJv/CbW1t0el0XCyLdnR0xNHRsUm7jY1Nm/2Pp1Kp2vR5QgjrJfXEuvTw7cKcW6K4e0wV32zPYNOB06i1OurUWn7cncW65GyuGRDAbSPD6O7h2vQGkTMg+Br9BgtHvwZAdfJXVCv6Q9ybcNWDoJLvijBN6okQQggh2h0XL7hhNRybCr8/CjVF+n9+ngZpa/VBrYvXRS+P8OvCy9MGk5GvD2q3HdMHtWcr9UuLfbM9k6kjenB9dBBODhZ/8Vx0EBabQQuwevVq7rrrLj766CNGjBjBkiVL+OSTTzhy5AjBwcHMmTOHnJwcVqxYYfL6l19+mR9++IH9+/cbtb3zzjssWbKkcYmDRx55hOjoaFavXt2sfrXlbANQTpovhGj/pJ5YvzNlNXy7I5Nf9mZTpzasDWqjgjF9uzMtJpwQ786mL07/CX5/BCpzDW0Bo2HCUuga3so9F0oj9UT5ZAatEEKppKaIZqs+A5sehePfGtqcvfRLHvT8W7NukZFfzlcJx0k8arwfkrurA1NH9OCG6GAJahVMKfXEot+wadOmUVxczKuvvkpeXh79+vVj/fr1BAcHA5CXl0d2dnaL7jl37lxUKhVz584lJycHLy8vbrjhBubNm9caH0EIIYRoU95dnHlkYl9ujw3nu50n+N/uLKrr1Wh1sPlwLpsP5xLTy4fbR0UQ4dfF+OLwGyEgDrb+Aw4t1bed3gIr+sPI1yD6KbCR17mEEEIIIYRCuHjDDWvg2Gr4/TH9urQ1hfC/qdD7dhj3gX792ksI83XjxVujOVFQzpcJ6SSm5qEDSqvqWbrpKGvOzai9YXAwzhLUilZi0Rm07ZXMoBVCKJXUk46nsraBn3af5PudJyivaTA6Fh3mxe2x4fQP8mh6YdbvsPEBKDthaPMdAhOXgWe/Vu61UAKpJ8onM2iFEEolNUVclqp8/QZiGT8a2lx84JqPIbzpUpoXc/JMBV8lHGdrij6oPa+LiwN/Gx7KDYNDcHGUoFYplFJPJKA1QQJaIYRSST3puGrq1azfm83apEzOVtYZHesb2JXbY8MZHOaFSqUyHGiogsQXYO/7cH74aWMPw16AYXPA1qHtPoBod6SeKJ8EtEIIpZKaIi6bTgdHv4LNT0BtiaE98k4Y+x44m5i4cBFZhRV8lZDOliO5RkGtm7M9twzvwY1DgnF1tDdf30WrUEo9kYDWBAlohRBKJfVE1Ks1/HbgNN9sz6CgtMboWIRfF6bHhDGyty82Fwa1Odvht/vg7FFDm2d/mPipflat6JCkniifBLRCCKWSmiKuWGUubHwIMn82tLn6wTVLIOz6Ft0qu7CCrxL1Qa32ggSts7M9twwL5aahIRLUtmNKqScS0JogAa0QQqmknojz1BotfxzOZfW2dE4VVxkdC/LsxPSYMMb0647t+e+JuhZ2vAa73gCdRt+msoHoZ2DkK2Dv3MafQFia1BPlk4BWCKFUUlOEWeh0kPIF/PEk1JUZ2vvOhDELwcm9Rbc7VVTJ14np/HE4xyio7eSkD2qnDA3B1UmC2vZGKfVEAloTJKAVQiiV1BPxZ1qdjm2p+azalk56frnRMb+uLtw2MozxV/njYHduc7CCfbDhXijcbzixawRMWKrfYEx0GFJPlE8CWiGEUklNEWZVkaPfe+HEL4a2Tv4w4RMIva7FtztdrA9qNx/6c1Brx81DQ5kyLJROEtS2G0qpJxLQmiABrRBCqaSeiIvR6XTsySjk68R0jpwqMTrm2dmJv43owaRBgTg52IGmAfa8BUmvgKbecOKARyHuP+DQuY17LyxB6onySUArhFAqqSnC7HQ6OPwZxD8F9RdMWuh3H4x5Gxy7tPiWOcVVfJ2Yzu+HctBeEK25OtoxZWgoNw8LpbOzBLWWppR6IgGtCRLQCiGUSuqJ+Cs6nY5D2Wf5OjGdvZlFRse6uDhw87BQbhwcrH89qzgVNtwHeUmGkzoHwYQlEDKxjXsu2prUE+WTgFYIoVRSU0SrKT8Fv90PWb8Z2joF6PdeCJlwWbfMPasPajcdNA5qXRztmDI0hJuHheLmLJvvWopS6okEtCZIQCuEUCqpJ6IljuWW8nVCOklpBUbtLo523Dg4mJuHheLubAf7P4SEf4K62nBS35kw+p0W7YQrlEXqifJJQCuEUCqpKaJV6XRwaCnEPw0NlYb2qx6E0Qsu+22xvJJqViWms/HgaTQXrH3g4mDHTUNDuGVYKG4uEtS2NaXUEwloTZCAVgihVFJPxOU4UVDOqm0ZbE0x3pnW0d6WSVFBTB3eA09tLmx8ELJ/N5zg4gPjF0HELW3fadHqpJ4onwS0Qgilkpoi2kR5lv5tsQvHt27BMOFTCL76sm+bX1LNqm3p/HbAOKh1drDlxiEh/G14D7pIUNtmlFJPJKA1QQJaIYRSST0RVyLnbBXfbM9g04HTqC8YTNrb2nDNgABuG9EDv9Nfw5ZnjNfu6jkVxn0Irj4W6LVoLVJPlE8CWiGEUklNEW1Gp4ODH8OWZ6GhytA+4FGIewMcOl32rfNLq1m9LYPf9p8yGls72Z8PakNxd3W8kt6LZlBKPZGA1gQJaIUQSiX1RJjDmbIavt2RyS97s6lTaxvbbVQqxvbrzoxBzgTs/Qdk/s9wkZMHjF0IkXeCStX2nRZmJ/VE+SSgFUIoldQU0ebKTsCGe+FUvKGtSyhMXAaBY67o1mfKali1LZ0N+5oGtTcMDmbqiB4S1LYipdST9tszIYQQQliEdxdnHpnYlxVPjmPayDBcHOwA0Op0/H4oh/tWpPNqw7/IG/kpOHvqL6o9C7/cDd9PhvJsC/ZeCMtYtGgRoaGhODk5ER0dTUJCwiXPr6ur44UXXiA4OBhHR0fCwsJYtmyZyXNXrVqFSqViypQprdBzIYQQQtAlFG79HcZ9AHYu+rayE/DNWNj8pPHs2hby7uLMk5P689njY7lhcDD2tvoorrZBw5qkTO7+4A8+2ZRKaVWdOT6JUCiZQWuCzKAVQiiV1BPRGipqGvhp90m+33WCipoGo2NxIXY85vgJ7qe+NTTad4K4N2HAQ6CS76FSST1pvtWrV3PXXXexaNEiYmJi+Pjjj1m6dCkpKSkEBQWZvOamm26ioKCA119/nfDwcM6cOYNarWbkyJFG52VlZRETE0OPHj3w8PDghx9+aHa/ZAatEEKppKYIiyrNgF/vgZwLftnqHgYTP4OAUVd8+8LyGlZvy+DXfado0BjeVnO0s2Hy4GBuHdEDj05OV/wcoaeUeiIBrQkS0AohlErqiWhNNfVq1u/NZm1SJmcrjX/Df5tPCnc1vINDbb6hMWA0TPgEuka0cU+FOUg9ab5hw4YRFRXF4sWLG9siIyOZMmUK8+fPb3L+r7/+yvTp08nMzMTDw+Oi99VoNIwePZp77rmHhIQESktLJaAVQnQIUlOExem0sO8DSJgD6ppzjSqImg2x88De5YofUVReyzfbM1i/N9soqHWws2FytD6o7dZZgtorpZR60n57JoQQQoh2xdnBjr8N78HyJ8byxKR++Lg7Nx77pqAP088uZJv99YYLTm+BFVfB7gWg1Vigx0K0vvr6epKTk5kwYYJR+4QJE9i+fbvJa3766ScGDx7Mm2++ib+/Pz179uTZZ5+lpqbG6LxXX30VLy8v7rvvvlbrvxBCCCFMUNnow9i79kP382+36GDvQvhiIOSY/ju+JTzdnHj02r4sf2IsU4aG4GCnj+jq1Vq+33mCWR/+weINRyiuqL3iZ4n2z87SHRBCCCGEsjjY2XJ9dDDXDgzkj8O5rN6WzqniKqroxKtlDzPQZjjPOv8XL10eqGth6z8g7Rv9Jgue/SzdfSHMqqioCI1Gg4+Pj1G7j48P+fn5Jq/JzMwkMTERJycnvv/+e4qKinj00Uc5e/Zs4zq027Zt49NPP2X//v3N7ktdXR11dYbZ7eXl5YB+5ohWq73YZWah1WrR6XSt/hwhRMcgNUW0G+7hcGs87HsP1ba5qDR1UHIc3apYiH4a3chXwM75L29zKV1dHXjomkhuHR7K2h0nWH9uo956tZYfdp1kXXI21w0K5NYRPfB0kxm1LdXW9eRyZ+lKQCuEEEKIy2Jna8M1AwIY19+f7Ufz+ToxnYyCcvZrB3Jf1QfcY7+Cm+z/hw06yN8NX0TBsBdg2BywdbB094UwK5VKZfRnnU7XpO08rVaLSqXiyy+/pEuXLgC88847TJ06lf/+97+o1WruvPNOPvnkEzw9PZvdh/nz5/PKK680aS8sLKS2tnVn32i1WsrKytDpdO369UEhhDJITRHtTuCd2F43jC5Jf8eheC8qdJD8NprjP1A24n0aPKPM8pgpA7oxJsKNXw7mszmlkHqNjgaNlp/2ZPHLvmzienly/QBfPDrJWLq52rqe+Pr6XtZ1sgatCbIGrRBCqaSeCEvS6XTsTi/k68R0Uk6XANDHJpWnHN4jyOa04UTP/jDxU/AdYqGeiuaQetI89fX1uLi4sGbNGm6++ebG9tmzZ7N//362bNnS5JqZM2eybds20tPTG9tSU1Pp06cPaWlpVFVVMWjQIGxtbRuPn5/1YWNjw7FjxwgLC2tyX1MzaAMDAykpKWmTNWgLCwvx8vKS74sQ4opJTRHtllYNye+iSvoXKk09ADqVDUQ/i27ES2BnvhmuJZV1fLvzBD8nZ1PXYFguzM5Wkqh2/AAAOwBJREFUxcQBgUyL6YGX25XN3u0I2rqeyAxaIYQQQliUSqViaIQ3Q8K9OJR9lq8T09mbGcmjte9zh/0qbrNbi61KC0WH0H01HFX0MzDyFbCXgaVQLgcHB6Kjo9m4caNRQLtx40Zuuukmk9fExMSwZs0aKisr6dSpEwBpaWnY2NgQEBCASqXi0KFDRtfMnTuXiooK3nvvPQIDA03e19HREUdHxybtNjY2bfIDiUqlarNnCSGsn9QU0S7ZOMCw5yD8BvhlJhTsQaXTwp43UZ34Ga793GyTELq5OfPgNX24bWQYa5My+d+eLGobNKg1OtbtzWbD/lNMHBTI9JhwvLvIePpSlFBPZAatCTKDVgihVFJPRHtzNKeUVYnpJKUVEKbK4GnH9wi3yWw8rukSju21n0JAnAV7KUyRetJ8q1ev5q677uKjjz5ixIgRLFmyhE8++YQjR44QHBzMnDlzyMnJYcWKFQBUVlYSGRnJ8OHDeeWVVygqKuL+++9n9OjRfPLJJyafMWvWLEpLS/nhhx+a3a+2HNPK90UIYU5SU4QiaNWw+03Y/jJoG/RtKlsY+hwM/xfYNf2l6ZUorarjux0n+GnPSWrqL5hRa6NiwsBApseE4ePuYtZnWgOl1JP22zMhhBBCKF5vf3denjaYjx4cRWCfUfy97h2W1d9NvU7/Eo9tWTqsHk3NLw9DfYWFeyvE5Zk2bRoLFy7k1VdfZeDAgWzdupX169cTHBwMQF5eHtnZ2Y3nd+rUiY0bN1JaWsrgwYO54447uOGGG3j//fct9RGEEEII0VI2djDsn3BnMnifW4NWp4Gd/4YvB0PBXrM+zt3VkXuv7s3yJ8YxLSYMZwf9UkhqrY71e7O557/xvPvzQfJLqs36XNE2ZAatCTKDVgihVFJPRHuXU1zFN9szOHooiSft3qOvbWrjsXI7PxrGLaZbf9OvhYu2JfVE+WQGrRBCqaSmCMXRNMCu/8COV/Uza0E/m3bYCzD8hVbZILe8up7vdp7gx10nqa5XN7bb2qgYf5U/t8dG4NdVZtQqpZ5IQGuCBLRCCKWSeiKU4kxZDd9uP47twUXcbfs5TirDxkaHOt+A+6QPCAwItmAPhdQT5ZOAVgihVFJThGKdOQC/zoTCA4Y2rwFw7XLwHtAqjyyvqef7nSf4YddJqusMQa2N6nxQG053D9dWebYSKKWetN+eCSGEEMJqeXdx5pHrruK2x9/jpz4/c0A7sPFY/4r/4bpqIN8sf5PjeWWW66QQQgghhBAt4T0A7tgFI17SL4EA+rD2y8GQ9Kp+pq2ZuTk7MHNML1Y8MY474yJwddQ/V6vT8duB09y3aAsLfjxATnGV2Z8tzEdm0JogM2iFEEol9UQoVUV1PUd+WUD/E//GVWUYPCaoR5LYfS7Xjx5G/yAPC/aw45F6onwyg1YIoVRSU4RVKNgLv86CokOGNu9B+tm0Xv1b7bGVtQ38sPME3+86QWXthTNqYWw/f2aMCiegW6dWe357o5R6IgGtCRLQCiGUSuqJULqas1mU/HA/3Us2NbZV6DrxUf0D5Hefyu2jIoju4YlKpbJgLzsGqSfKJwGtEEKppKYIq6Gugx2v6den1Wn0bTb2+hm2Q58zzLJtBVW1Dfyw6yTf7TxBZa1h5q6NCsb07c7toyII8rT+oFYp9UQCWhMkoBVCKJXUE2EVdDrUKV+j+f0JHBvONjbv0kTzfv1jdPWNYHpsOCN6+WAjQW2rkXqifBLQCiGUSmqKsDr5e/Rr0xanGNp8BsO1n4Nn31Z9dFVdAz+eC2oragxBrQoY0687M2LDCfLq3Kp9sCSl1JP22zMhhBBCdEwqFXZ9Z+B4/1G0vaY3Ng+1TWaJ02P0LPya19bs5uGPt7L5UA4ardaCnRVCCCGEEOIv+A6GO5Nh6POgOhfFFeyBlVGw6w3Qqi99/RVwdbRnxqgIVjwxjnvG9sLN2R4AHfDH4Vwe/Ggr87/bR1ZhRav1Qfw1mUFrgsygFUIoldQTYZUy/odu48OoqnIbmw5o+rGw/glydf74dXXhtpFhjL/KHwc7Wwt21LpIPVE+mUErhFAqqSnCquXt1K9Ne/aooc1vGEz8HLr1bvXHV9ep+d+ek6xNyqT8TzNqR/Xx445REYR4W8+MWqXUEwloTZCAVgihVFJPhNWqLYWt/4BDSxub6nQOrGi4k+/UN6HFFs/OTkwd0YProoJwspeg9kpJPVE+CWiFEEolNUVYvYYa2P4S7FmAfi4rYOsIMa9D9FNg0/pj2Zp6Nf/bk8XapEzKquuNjo2K9OWOURGE+rR+JtbalFJPJKA1QQJaIYRSST0RVi/rd9j4AJSdaGw6pong7frZZOlCAOji4sDNw0K5cXAwrk72Fuqo8kk9UT4JaIUQSiU1RXQYOdthwywoOW5o8xuhX5vWo2ebdKG2Xs3/kvVBbWmVcVAb29uXO+Ii6KHgoFYp9UQCWhMkoBVCKJXUE9EhNFRB4guw933OzzhQY8dX9bexWn0ravShrKujHTcOCeHmYaF0cXGwYIeVSeqJ8klAK4RQKqkpokNpqIZtcyF5IY2zae2cIHY+RD1pWLO2ldU2aFiXnMWa7ZmUVNUZHYvp5cMdcRGE+XZpk76Yk1LqiQS0JkhAK4RQKqknokPJ2Q6/3We0ftcZ+3DmVTzKUa1hxoGjvS2To4KYOqIH3To7WaKniiT1RPkkoBVCKJXUFNEhnU7Uz6YtzTC0+Y+Cicuga3ibdaO2QcP65CzWJGVyttI4qB3R04c74yII91NOUKuUeiIBrQkS0AohlErqiehw1LWw43XY9R/QaQDQqWxIdr+beXk3Uq01zJy1t7XhmgEBTBsZhm9XF0v1WDGkniifBLRCCKWSmiI6rIYqSPgn7Hvf0GbnDKPegEGPtdlsWoC6Bg3r92bzzfaMJkHt8Ahv7hzdkwgFBLVKqScS0JogAa0QQqmknogOq2AfbLgXCvc3Nqndwvifx4ssS/OmXq1tbLdRqRjbrzvTY8II8rKeHWrNTeqJ8klAK4RQKqkposM7tQU23GO07wIBo/Wzad17tGlX6ho0/Lovm9XbMyiuMA5qh0V4c2dcBD27u7dpn1pCKfVEAloTJKAVQiiV1BPRoWka9DvhJr0CGsPgsbbPQ3xj+wDf7yuiul7d2K4CYnr7Mj02XBG//W9rUk+UTwJaIYRSSU0RAqivhITnYf9/DW32rhD3Fgx4qE1n0wLUqzX8uu8Uq7dlUFRRa3RsaLgXd8T1pLe/e5v2qTmUUk8koDVBAlohhFJJPRECKD6qX5s2d7uhrXMg1aMX8V1BL37YdYKKmgajSwaHeXF7bDj9gjzauLPtl9QT5ZOAVgihVFJThLhA9mb9m2LlWYa2oHEw4VPoEtLm3alXa9iw/xSrtmVQVG4c1A4O8+LOuAgiA7q2eb8uRin1pP32TAghhBDicnTrDdO2wtj3wO7cWrMVp3D5+QburJ7HFw8O5IHxkXh0cmy8ZE9GIc8sT+LZ5UkkZxQiv78WQgghhBDtQtA4mHkIrnrI0Ja9GZb3h4NLoI3HrQ52ttwwOITPHhvDE5P64eVm2IR3T0Yhf/9sO//8cidHTp1t0341x/Hjxxk5ciQ9e/Zk6NChpKSkmDzv0KFDjBkzhsjISHr16sV3333X2B4XF0fv3r3p378/Dz74IHV1hjf3SkpKuOOOO4iIiCAyMpLnn3++2X2TGbQmyAxaIYRSST0R4k/KTsBvD0D274Y2Fx+4+r/U95jChv2nWbM9g4KyGqPLevp14fbYcIb38sFGpWrjTrcPUk+UT2bQCiGUSmqKEBdxcqP+TbGKU4a24GtgwlJwC7JIlxo0WjYeOM2qxPQmY+qoHp7cGRdB30DLvaV2YT0ZP348d999N7NmzWLt2rW8/fbbJCUlGZ1fXV1N//79Wb58ObGxsajVakpKSvDy8uL48ePU1NRw1VVXodFomDFjBgMGDOCf//wnADfffDMxMTE8++yzAOTl5eHn59esfkpAa4IEtEIIpZJ6IoQJOh0cXgZbnoG6MkN7xN/g6g9RO3nzx+FcVm1L53RxldGlwV6dmB4Tzui+fth2sP+mpJ4onwS0QgilkpoixCXUlcGWZ+HQUkObQ2cY8y70uxcsNLmgQaNl08HTfJ2YTkGpcVA7MLQbd8b1pL8FlhM7X08AevfuTVFREXZ2duh0Ovz8/NixYwchISGN5y9dupT4+HhWrlz5l/desGABR48eZenSpaSnp3P11Vdz4sSJy6pbUumEEEII8f/t3XtcVVX+//HXBhRUREUQEUFMJcEbIuYFTU3TstQs844yao1pM9OYNprVpF8nu5c1YWoXtWx0Upv8TY63SsVL3hI1ScULgooCitwMEM75/XH0IIGKcuCAvp+PB486a6+999pGHz58XHutO5thQKuxEBEDTfoXtMeugIVBOB36kgdb+zB/fDemPxHCPV4FhayTyZm88Z9oxkZuYvXP8eTm5dvhAURERERErnCuBb0XwOOrwdXH0pabAevGwcq+kHHKLsOq4ujAw239+GxCd/76aCvq165mPRZ94jyTF23nhS9+Yv/J83YZX0JCAg0aNMDJyQkAwzDw8/MjPj6+UL+YmBhcXFx49NFHCQ4OZtSoUSQnJxe5XlZWFp988gn9+vWznufr68v48eMJCQmhd+/e7N27t8TjU4FWRERE7g6uDWDAf+CRf0E1D0tbdiqsGQ0r++KYmcD9Qd5EPtWFmUNDCWxY23pqYuol5nx3gD/8cyPf7DhB9mUVakVERETEjho/DKN/gRYRBW1xa2BRSzi4qNzXpr3KydGBh9r68emE7kzq1xrvOtWtx/bFnWfK4p+Ysng7++LKv1Br/G52cXGLCly+fJm1a9cyb9489u7di6+vLxMnTizSZ8iQIfTu3ZsBAwZY27Zv386wYcP4+eefef755+nXrx95eXklGpsKtCIiInL3MAxoPtQym7b58IL2uDWwsAVEz8XATIdmXrwX0Zk3wzvStrGHtVtKRjYfr4th1Ac/sHTLUbKyL9vhIUREREREAJfa8NDnMPC/UOPKWqc5abAmAv7TDzLP2G1oTo4O9An25dMJ3Zjcvw0N3AsKtftPXuCFL35i8qLtRJ9IKZcNen19fTl16pS1YGo2m0lISMDPr/DavY0aNaJHjx74+PhgGAYjRoxg586d1uOXL19m8ODBeHt7M2fOnELn+fj40KNHDwD69OlDbm4up06VbEazCrQiIiJy96nuCY8sgcdWWWbWAlzOhO8nwL97QGoshmHQxr8ur4/swJwxnekY4GU9Pe1SLp//eJjwD35g0Y+HSbuUa6cHEREREZG73j2PQMRBCAovaDv+nWUCQsyXdptNC+Do4MCDbRryyTPdmDKgDT7uNazHDsRf4G9f7uD5Rdv5+XjZFmrr1atH27ZtrWvLrlixAn9//0LrzwIMHjyYXbt2kZ6eDsCaNWto06YNAHl5eQwdOhR3d3fmz59faEZuu3btcHNzY//+/QDs3r0bAB8fnxKNz+4F2sjISBo3boyLiwvt2rUjKiqqROdt3boVJycngoODixy7ePEiEydOxNvbGxcXFwIDA1m9erWNRy4iIiKVXpN+MPogtHqqoO3UZljcGna9DSbL37A396nDjCGhzH26K91bNMDhSi6WlZPHV1uOEv7BD8xbH8P5jGw7PISIiIiI3PVc6sDDiy1LelW/MrEg5yL8Lxy+HQhZZ+05OhwdHOjVuiELnrmfFwa0oWHdgkLtwYRUpi3ZwaSF29lzLLnMCrXz5s1j3rx5BAQE8Prrr/Ppp58CMG7cOFatWgWAn58f06ZNo1OnTrRp04YNGzbw0UcfAbBs2TJWrlzJ7t27adu2LcHBwdblDwzDYOHChYwbN47WrVszYcIEVqxYQZUqVUo0NsNcHvOIr2PZsmWEh4cTGRlJWFgY8+bN45NPPiEmJqbIFONrpaWlERISQtOmTTl37hzR0dHWY7m5uYSFhVGvXj1efPFFGjZsSEJCAjVr1rRWvG+mPHe8Be1QKSK2o3giUgrxP1g2V0g7UdBWvz30+Qw8Whbqevp8Fsu2HWXD/tPkmwpSqSqOlhkCQzo3of41621VRoonlV955rT6fhERW1JMESml387DD3+GQ18VtLm4wwP/tCz39bu1WO0h32Rm08EzfBUVS8L5rELHAn1qM7JbAO3u8SiybuytqizxxK4F2g4dOhASEsLcuXOtbYGBgTz22GPMnj37uucNHTqUZs2a4ejoyH/+859CBdqPP/6Yt956i0OHDpW4Sv17KtCKSGWleCJSSpezYMtL8PMc4EqK5FAFOkyHDtPAsWqh7klpv7F8+3H+tzee3DyTtd3BMOjRsgFDw5rg51mzHB/AdhRPKj8VaEWkslJMEbGR2JWwfjz8llzQ1uxx6DUXqtez37iukW8yExWTyJKoWOJTMgsda+5Tm5H3NyO0iedtF2orSzyxW4E2NzeX6tWr8/XXXzNw4EBr+1/+8heio6PZtGlTsed9/vnnREZGsn37dmbNmlWkQNu3b1/c3d2pXr063377LZ6engwfPpy//e1vODo6FnvNnJwccnJyrJ/T09Px9fUlNTW13Aq0ycnJeHp6VuhvFhGp+BRPRGzkzHaM9U9hXPjV2mT2aIX5wQWWWbW/k5qZwzc74/jvnpP8lptvbTeAzs29GBrWhKb1a5XHyG3GHvFEccu2VKAVkcpKMUXEhi4lw/fPwpF/F7RV84CekXDvk/Yb1++YzAWF2pPJhQu1AQ1qMfL+ZtzXtN4tF2orSzxxsteNU1JSyM/Px8vLq1C7l5cXZ88Wvy5GbGwsU6dOJSoqCien4od+/PhxfvjhB0aMGMHq1auJjY1l4sSJ5OXl8corrxR7zuzZs5kxY0aR9uTkZLKzy34tOZPJRFpaGmazuUJ/s4hIxad4ImIjTk2g92pcD7xPjZh/YpjzMVIOwNLOZDUfT2bryeBUrdApj7asQ49mNVl/MIl1vySRlZOPGdh66BxbD52jta8b/YK9Cajvap9nukX2iCf169cvl/uIiIiI3DWqe0K/ZXB4kGVD3N9SLF//HQxHnoSeH1n62JmDYdCtRQO6Bnmz9dezfLk5lrjkDACOnEnjlaW7CfCuxYj7m9Gh2a0Xais6u82gPXPmDD4+Pmzbto1OnTpZ2//xj3/wxRdfcOjQoUL98/Pz6dixI2PHjmX8+PEAvPrqq0Vm0AYEBJCdnc2JEyesM2bfffdd3nrrLRITE4sdi2bQisidQvFEpAwkRWOsH4eRtNfaZK7d1DKbtuH9xZ5yKSeP1XvjWflTHKlZOYWOtfSrw9CwJoQ0Lv2aWmVJM2grP82gFZHKSjFFpIxcSoINz1iWPriqmic8+LFl6YMKxGQ2s/XQWZZsjuVEUkahY03ruzHy/gA6Bty8UFtZ4ondZtB6eHjg6OhYZLZsUlJSkVm1ABkZGezevZu9e/fy7LPPApY/ZLPZjJOTE+vWreOBBx7A29ubKlWqFFrOIDAwkLNnz5Kbm0vVqlWLXNvZ2RlnZ+ci7Q4ODuX2H88wjHK9n4jcuRRPRGysfggM3wG734btMyA/B+PiUYyve0CbZ+D+N6Bq4XVmXatVZXDnpjx2X2PWRifw9bbjnEv7DYBf4lN5KX43AQ1qMSysKR3v9cKhghZqFU9ERERE7iDV60G/5XB4GXw/EbIvWNanXfUENB8GD3wI1erae5SAZUZt10BvwprXZ/vhcyzZHMuxc+kAHD2bzqv/3k3T+m6M6NqMTvd6VeiJDyVht2y7atWqtGvXjvXr1xdqX79+PZ07dy7S383NjQMHDhAdHW39Gj9+PPfeey/R0dF06NABgLCwMI4ePYrJVLBRx5EjR/D29i62OCsiIiJyU45VLJuEhUdDg2vylH1zYWELOLGm2NOqOjnSL9SfzyZ25/n+rWnoXsN67MiZNGZ8vYdn5kXxw4HT5F+Tu4iIiIiIlAnDgOZDIeIgNBlQ0H7oX5a89ui39htbMRwMg7Dm9fnoqS78fXA7mtYveCvo6Nl0Zny9hwkLtrDl10RMv1skIN9kZv/J82w/eoH9J8+Tb7LLIgIlYrclDgCWLVtGeHg4H3/8MZ06dWL+/PksWLCAgwcP0qhRI6ZNm8bp06dZvHhxsecXt8RBQkICQUFBRERE8Kc//YnY2FjGjBnDn//8Z6ZPn16icZXn62BQeaZbi0jFp3giUg5M+RD9EURNg7xLBe1Bo6D7e1DN/bqn5pssr2r9a8tRjl+ZAXCVd53qDAlrQq/WDaniaP//f6+NJ8eOHWP06NGkpKRQu3ZtFi5cSFBQULHnZWdnExISQvXq1dm9ezcAcXFxNG3alJYtW1r7rVixgiZNmgAwaNAgtm3bRmJiIhkZGbi6Vo51eis6LXEgIpWVYopIOTGb4dcl8OOfITu1oD0oHHrMAZc69hvbdZjNZnbEJvHFpiMcPVs4n25cryYjujYjLLA+2w6dZe7aGFIyCvaW8qjpwjN9gugS6F3ew74puxZoASIjI3nzzTdJTEykZcuWvPfee9x/v2U9t4iICOLi4ti4cWOx5xZXoAXYvn07f/3rX4mOjsbHx4exY8fyt7/9rdCyBzeiAq2IVFaKJyLlKO0ErHsa4jcUtFX3smy0EPDEDU81m83sPJrEv7Yc5ddTFwsd83Bz4clO9/BQWz9cqpQsdykL18aTXr16MWrUKCIiIli+fDnvvPMO27dvL/a8559/nosXL7Jv375CBdrQ0FBSUlKKPWfDhg20bt0aLy8vFWhtSAVaEamsFFNEylnmGVj/Rzj+34K2Gt7w4Hxo8qj9xnUDVwu1SzbHciQxrdAxTzcXktOzr3MmvDwopMIVae1eoK2IVKAVkcpK8USknJnN8MtnsOl5yLkmMWz2BPT8J9Sof5PTzew7eZ5/bTlK9InzhY7Vql6Vxzs0pl/7RtRwrlIWo7+hq/EEoHnz5qSkpODk5ITZbMbb25uffvoJf3//QudERUXx1ltvMWnSJCZPnlziAu1VhmGoQGtDKtCKSGWlmCJiB2YzxCyGH/9SOK9tEWF5S8yltr1GdkNms5ldR5P5cnMsh89cLNE5nm4uLPrTAzg6VJx1axXpRERERG6XYUCrsRARA036F7THroCFQXBwsSXZve7pBsH+HrwxsiNzxnSmY7N61mNpl3L5/MfDhM/5gUU/HibtUm5ZPsl1JSQk0KBBA5ycnKxj9vPzIz4+vlC/rKwsnnvuOebOnVvsddLT02nfvj0hISHMnDmT/Pz8Mh+7iIiIiJSQYUCL0TD6IDR+uKD94EJY1PK6ey7Ym2EY3NesHnPGdGbWsPb4edS46TnJ6dn8En+hHEZXcirQioiIiJSWawMY8B94ZClU87S0ZafCmtGwsi+kx9/wdIDmPnWYMbQ9c5/uSrcgb67+fX5WTh5fbTnKqA9+YN76GM5nXP91rbLy+11xi3sBa8qUKUycOBEfH58ix7y9vTl16hS7du1iw4YNREVF8c4775TZeEVERETkNtX0gYHfQe9PoeqVN3AyT8PKh2HtuMKzaysQwzBo37Qew7o0K1H/C5nln1PfiAq0IiIiIrZgGNB8iGU2bfPhBe1xayw74kbPBbPpppe5x8uNF58I4ZMJ3egT3ND66lX25XxW/nSC0R/+yAerD3A29dJNrmQbvr6+nDp1iry8PMBSnE1ISMDPz69Qvy1btjBz5kz8/f0ZOnQoBw4coEWLFgA4OztTr55ldrC7uztjxowhKiqqXMYvIiIiIrfIMKDVGBh9ABo9WND+y6ewqBXErbff2G6ibk2XEvVzdy1Zv/KiAq2IiIiILVX3gEeWwGOrwPXKbNLLmfD9BPh3D0iNLdFlGtZ1ZVK/Nix8tgf92zeiqpMlbbucb+K7PfH84aONvPVtNPEpmWX1JADUq1ePtm3b8uWXXwKwYsUK/P39i6w/u3//fuLi4oiLi2Pp0qW0atWKgwcPApCUlMTly5cByMnJYeXKlbRt27ZMxy0iIiIipeTmB0+shQfnQZUrewRkJMCK3rB+PORm2Hd8xWjp547HTYq0nm4utPRzL6cRlYwKtCIiIiJloUk/iDgIrZ4qaDu1GRa3hl1vgymvRJepV6saEx9qyeI/PcCTne6hWlVHAExmMxv2n+bpuZuYtXwPRxPL7nWzefPmMW/ePAICAnj99df59NNPARg3bhyrVq266flbtmyhbdu2tGnThpCQEOrXr8/06dOtx/v370/Dhg0BuPfee+nevXuZPIeIiIiI3CLDgNZPQ8Qv4PdAQfv+eZbZtCe/t9/YiuHoYPBMn6Ab9hnfO6hCbRAGYJiLW0TsLleeO96CdqgUEdtRPBGpoOJ/gHXjIO1EQVv99pa1vTxb3dKl0n/LZdXOOL7ZGUdm9uVCx9o39WRYl6a08C39jADFk8qvPHNafb+IiC0ppohUUGYT7JsHm6fA5ayC9jYT4P43oKqr/cb2O1t+TWTu2hhSrtm/wdPNhfG9g+gS6G3HkRVPBdpiqEArIpWV4olIBXY5C7a8BD/PAa6kXw5VoMOLli/Hqrd0uUs5eXz380lW/nSCC5k5hY61buTO0C5NCWnsUWSDr5JSPKn8VKAVkcpKMUWkgks7AWvHQMLGgrZajaHP5+DbzV6jKiLfZObAyRROnE6msY8nrRp5VLiZs1epQFsMFWhFpLJSPBGpBM5sh7Vj4cKvBW0eLaHPZ5ZZtbcoNy+ftdEJ/HvbcZLSfit0LKBBLYZ1aUrHAC8cbrFQq3hS+alAKyKVlWKKSCVgNkF0JGz+G+Rds3lt2z9B19lQpYb9xnaNyhJPKu7IRERERO5EDTpB+F7oMB0My3qypPwCX3WETVPg8m83Pv93qjo50i/Un88nduf5/q1p6F6QDB85k8aMf+/hmXlR/PjLafJN+nt5EREREbEBwwHaPguj9oFPl4L2vR/C4jZwKsp+Y6uEVKAVERERKW9OztBlFozcDfXaWtrMJtj9tmUTsVObb/2Sjg70buPL/Ge68eLjbbnHq2DGZFxyBq9/E824uRv53954LuebbPUkIiIiInI3q9MUhmyC7u+Bk4ul7eIxWNYNNk6Cy5dufL4AKtCKiIiI2E+9YBi+A7rMBkdnS9vFo5aEdsMEyM245Us6Ohh0a9GAyKe6MGNIKIE+ta3Hzly4xPv/PUDEP3/kPztPkH053zbPISIiIiJ3L8MB2j0H4fugQecrjWbY8x58EQynt9lxcJWDCrQiIiIi9uRYBTpMhfDoaxJaYN9cWNgCTqy5rcsahkHHAC/e+0Nn3gjvQHDjutZjKenZzF0bw6gPfmDZ1qNk5VwudG6+ycz+k+fZfvQC+0+e19IIIiIiInJz7gEwZDN0e7tg8kFqLCztcltLed1NtElYMbRJmIhUVoonIpWcKd+y2cKWaXA5q6A9aJTltbFq7qW6/K+nUlm65Sg/xSYVand1caJ/e38G3teY/SfPM3dtDCkZ2dbjHjVdeKZPEF0CvUt1fylf2iRMRCorxRSRO8D5Q7A2AhJ3FLS5N4eHFoJ3h3IbRmWJJyrQFkMFWhGprBRPRO4QaXGw7imI31DQVt0Len4EAU+U+vLHz6WzdMtRNsckcm0iWMXR4Ybr0748KERF2kpEBVoRqawUU0TuEKY82P0ubHsZ8nMtbYYDhE6Bzq8WrFlblkOoJPGk4o5MRERE5G5Vyx8GrYPen4JzLUvbpXPw/wbBqkGQdbZUl7/Hy40Xnwjhkwnd6N2mIY4OBsB1i7NZ50+zY8Fk+nZrT/v77iMmJua6187OziYoKIjQ0NAix8xmMz179sTDw6NQu2EYtG7dmuDgYIKDg4mKqny7/kZGRtK4cWNcXFxo167dTZ8hJyeH6dOn06hRI5ydnWnSpAmfffaZ9fiCBQvo2rUrderUoU6dOvTq1YudO3eW9WOIiIiI2I6DE9z3Aoz8Gbyu5IZmE+x6A75sB2d3letwYmNj6dy5MwEBAdx3g5z2wIEDdO/encDAQO69915WrlwJQGZmJn369MHDw6NIPguly2k1g7YYmkErIpWV4onIHSjzjGXDsGPfFrS51IHu70NQOBhGqW+RlPYbc9ceZNvhc8Ue3/X5izQIfgCftr14sG4SK76Yz/bt24vt+/zzz3Px4kX27dvH7t27Cx378MMPiY6O5ttvvyUlJcXabhgGGRkZuLq6lvpZ7GHZsmWEh4cTGRlJWFgY8+bN45NPPiEmJgY/P79izxkwYADnzp1j1qxZNG3alKSkJPLy8ujc2bIO8YgRIwgLC6Nz5864uLjw5ptvsnLlSg4ePIiPj0+JxqUZtCJSWSmmiNyBTHmw603Y9iqYrux/YDjCfVOh48vg5Fw2t70mnvTq1YtRo0YRERHB8uXLeeedd4rktJcuXaJVq1YsWrSILl26kJeXR2pqKp6enuTk5LBlyxbq1q1Lr169CuWzULqcVpFOREREpCJzbQADvoFHlkI1T0tbdiqsGQ0r+0J6fKlvUa9WNe4PKn7pgpzMi2QkHsO7dQ8AQro+yIkTJ4iLiyvSNyoqitjYWMLDw4sci42NZenSpUydOrXU461o3n33XcaOHcu4ceMIDAzk/fffx9fXl7lz5xbbf82aNWzatInVq1fTq1cv/P39ue+++6zFWYAlS5YwYcIEgoODad68OQsWLMBkMvH999+X12OJiIiI2I6DE3R4EUbugXohljZzPuz4BywJhXM/l+ntk5KS+Pnnnxk5ciQATzzxRLE57VdffUWnTp3o0qULAE5OTnh6WnJwZ2dnevbsSe3atW0+PhVoRURERCo6w4DmQyAiBpoPL2iPWwMLW0D0XMvrYqXg7lr8GmA56Sk413THwdERgLo1q+Hn50d8fOHCcFZWFs8991yxRUmTycRTTz3FRx99RJUqVYq9T/fu3WnTpg2TJk0iKyur2D4VUW5uLnv27KF3796F2nv37s22bduKPWfVqlWEhoby5ptv4uPjQ0BAAJMnT+a3366/s/GlS5e4fPky7u6l2yhORERExK48W8Hwn6DzTEvRFiDlF1hyH2z9e8FatTaWkJBAgwYNcHKy3NMwjGJz2piYGFxcXHj00UcJDg5m1KhRJCcnl/g+t5vTOpW4p4iIiIjYV3UPeGQJNB8GG8ZD5mm4nAnfT4DDS6H3J1Cn2W1duqWfOx41XUjJyC7mqGUZBU83F1r6uVPcCllTpkxh4sSJ+Pj4EBsbW+jY22+/zf33309wcHCxM29PnjyJn58fWVlZjB8/nilTphAZGXlbz1HeUlJSyM/Px8vLq1C7l5cXZ88Wv1bw8ePH2bJlCy4uLnzzzTekpKQwYcIELly4UGgd2mtNnToVHx8fevXqdd2x5OTkkJOTY/2cnp4OWArkJlPpCvg3YzKZMJvNZX4fEbk7KKaI3OEMR+gwHRo/grFuDEbyPsts2p9mYj72LeY+n4NnG5vc6tp4YhhGobhytf3attzcXNauXcu2bdto0KABL7/8MhMmTGDZsmWFrnntP686ceIE/v7+t5XTqkArIiIiUtk0eRQaHoRNU+DAAkvbqc2wuDV0/j9o91zBjIQScnQweKZPEP+3vPDrZc5uHuSkp2DKz2d87yAcDMsMhN+vrbplyxZWr17NzJkzyc7OJjU1lRYtWnDw4EE2b97M/v37Wbx4sXUdL39/f/bu3UudOnWs16pRowYTJkzg6aefvu0/GnsxfrcWsNlsLtJ21dVfEJYsWUKtWpZN4N59910GDRrERx99RLVq1Qr1f/PNN/nXv/7Fxo0bcXG5/m7Hs2fPZsaMGUXak5OTyc4urvBuOyaTibS0NMxms9aLFJFSU0wRuVs0gJ6rcD04hxq/zMEw51uKtUvuI7PVX8lq8SdwKP7tq5K6Gk+qVatGQkICZ86cwcnJCbPZzMmTJ6lRowZJSUnW/nXr1qVjx45UqVKF5ORk+vTpwxdffFGoz/nz561r217rap52OzmtCrQiIiIilZFzLeg9H5oPhXXjIO0E5GXD5ilw5N/Q+1PLK2S3oEugNy8PCmHu2hjrTFpn19q4N2xK+6rH6RLYn+XLl+Pv74+/v3+hc/fv32/9940bNzJ58mTrJmH//e9/rcfi4uIIDQ21zqRNTU3F2dmZ6tWrYzKZWLZsGW3btr2NPxD78PDwwNHRschs2aSkpCKzaq/y9vbGx8fHWpwFCAwMxGw2c+rUKZo1K5gF/fbbb/Paa6+xYcMGWrdufcOxTJs2jUmTJlk/p6en4+vri6enZ7lsEmYYBp6eniqmiEipKaaI3GW838LcahisG4ORcgDDnEfN/W/hevZ7y2xaj5a3felr40lISAjr1q2zbhJ2zz330K5du0L9//CHP/Dwww/j4uKCm5sbS5YsoW3bttSrV8/a59KlSzg4OBRqu5rTXr3nrea0KtCKiIiIVGZ+D8DoA7DlJfh5DmCGs7vgy3aWjRg6vAiOVUt8uS6B3nS6tz4HTqZw4nQyjX08qTpoGWPH/IGAhZG4ubmxaNEiAMaNG0f//v3p37//bQ//0KFD/PGPf8QwDPLy8ggJCWHOnDm3fb3yVrVqVdq1a8f69esZOHCgtX39+vUMGDCg2HPCwsL4+uuvyczMtO7ye+TIERwcHGjYsKG131tvvcWsWbNYu3YtoaGhNx2Ls7Oz9ReDazk4OJRLgcMwjHK7l4jc+RRTRO4y3qEwYhf89H+w83Uw52Mk/YyxJBQ6vwrtX7jlN8SuuhpP5s2bR0REBK+//ro1p3VwcCiU0/r7+zNt2jTCwsJwcnLCx8eH+fPnW2NRSEgIiYmJpKam4ufnR48ePfjiiy84cuRIqXJaw1zcImJ3ufT0dGrVqkVaWlqZzzYArNOi69Wrpx8+IlIqiicid7kz22HtWLjwa0GbR0vo8xnUb39Ll1I8Kblly5YRHh7Oxx9/TKdOnZg/fz4LFizg4MGDNGrUiGnTpnH69GkWL14MQGZmJoGBgXTs2JEZM2aQkpLCuHHj6NatGwsWWJasePPNN3n55Zf56quvCAsLs97L1dXVWtS9mfLMafX9IiK2pJgicpc7uwvWRMD5mII2r1B4eBHUDbqlS1WWeFJxRyYiIiIit6ZBJwjfCx1fKrwr7lcdLevVXr5k3/HdoYYMGcL777/PzJkzCQ4OZvPmzaxevZpGjRoBkJiYWGiHYFdXV9avX8/FixcJDQ1lxIgR9OvXjw8++MDaJzIyktzcXAYNGoS3t7f16+233y735xMREREpV/Xbw8g9cN9UMK6ULs/thi/aws43wJRn3/GVAc2gLYZm0IpIZaV4IiJWSdGW2bRJ12z6Vbsp9PkUGt5/09MVTyo/zaAVkcpKMUVErBJ3WGbTXjhU0ObdAfoshLrNb3p6ZYknFXdkIiIiInL76gXDiB3QZTY4XlmX9OJRWNYNNkyAnHS7Dk9ERERE5Ka8O8DInyF0MmBY2hJ3wBfBsPsdMOXbc3Q2owKtiIiIyJ3KwQk6TIXwaGhQsI4p++bCopZwYo3dhiYiIiIiUiJVqkG3t2DoFqjTzNKWnwObJsOy++HCEfuOzwZUoBURERG509VtDkM3Q48PoEoNS1tGAqx8GP43Gn67YN/xiYiIiIjcjE9ny8SDdn/FOpv2zDb4og3seR/MJjsOrnRUoBURERG5GxgOEPInGP0L+PUqaI9ZDAuD4MiKgjZTPiRsxCXuG0jYeMe8OiYiIiIilVyV6tD9XRiyCWo3sbTlZcPGv8Ky7pB6tKBvJcppnew9ABEREREpR7X8YdA6+OVz2DQJctLg0jn4f4Og2RPQ+GHY9ioOmaeoffUc14bwwBxo9rj9xi0iIiIiclXDrjBqH0S9CHs/sLSdjoLFbaDr6+DqDT/+tdLktIbZbDbbexAVTXnueAuVZ0c5Ean4FE9E5JZknrFsGHbs25t0vPIKWf/lFTKhleKVZ06rnz8iYkuKKSJySxI2wtoxkHbiJh0rbk6rSCciIiJyt3JtAAO+gUeWgovHDTpe+fv8H5+r0K+GiYiIiMhdyLc7jNoPbSbcpGPFzWlVoBURERG5mxkGNB8CvT+5SUezZWOx01HlMiwRERERkRKr6gq9PoJu79ykY8XMaVWgFRERERHIu1SyfpmJZTsOEREREZHbVcO7ZP0qWE6rAq2IiIiIWDZSsGU/EREREZHyVklzWhVoRURERAR8ulp2tr26eUIRBtT0tfQTEREREamIKmlOqwKtiIiIiICDIzww58qH3ye0Vz73eN/ST0RERESkIqqkOa0KtCIiIiJi0exx6L8cXH0Kt9dsaGlv9rh9xiUiIiIiUlKVMKd1svcARERERKQCafY4NBmAKWET6YmHcfO+FwffbhVuloGIiIiIyHVVspxWBVoRERERKczBEXy7k+0chFu9euCgl65EREREpJKpRDltxR2ZiIiIiIiIiIiIyB1OBVoRERERERERERERO1GBVkRERERERERERMRO7F6gjYyMpHHjxri4uNCuXTuioqJKdN7WrVtxcnIiODj4un2WLl2KYRg89thjthmsiIiIiIiIiIiIiA3ZtUC7bNkynnvuOaZPn87evXvp2rUrDz/8MPHx8Tc8Ly0tjVGjRtGzZ8/r9jl58iSTJ0+ma9euth62iIiIiIiIiIiIiE3YtUD77rvvMnbsWMaNG0dgYCDvv/8+vr6+zJ0794bn/fGPf2T48OF06tSp2OP5+fmMGDGCGTNmcM8995TF0EVERERERERERERKzcleN87NzWXPnj1MnTq1UHvv3r3Ztm3bdc/7/PPPOXbsGF9++SWzZs0qts/MmTPx9PRk7NixJVoyIScnh5ycHOvn9PR0AEwmEyaTqSSPUyomkwmz2Vwu9xKRO5viiYjYij3iiYOD3VffEhEREREpd3Yr0KakpJCfn4+Xl1ehdi8vL86ePVvsObGxsUydOpWoqCicnIof+tatW/n000+Jjo4u8Vhmz57NjBkzirQnJyeTnZ1d4uvcLpPJRFpaGmazWb+YiEipKJ6IiK3YI57Ur1+/XO4jIiIiIlKR2K1Ae5VhGIU+m83mIm1gWbZg+PDhzJgxg4CAgGKvlZGRwciRI1mwYAEeHh4lHsO0adOYNGmS9XN6ejq+vr54enri5uZW4uvcLpPJhGEYeHp6qqAiIqWieCIitqJ4IiIiIiJSPuxWoPXw8MDR0bHIbNmkpKQis2rBUnzdvXs3e/fu5dlnnwUKXr1zcnJi3bp1uLu7ExcXR79+/aznXX0tz8nJicOHD9OkSZMi13Z2dsbZ2blIu4ODQ7n9QmIYRrneT0TuXIonImIriiciIiIiImXPbgXaqlWr0q5dO9avX8/AgQOt7evXr2fAgAFF+ru5uXHgwIFCbZGRkfzwww8sX76cxo0b4+joWKTPSy+9REZGBnPmzMHX17dEYzObzUDBWrRlzWQykZGRgYuLi34BEpFSUTwREVuxVzypWbNmsW9Tya0rz5xWP39ExJYUU0TEVuwRT24nn7XrEgeTJk0iPDyc0NBQOnXqxPz584mPj2f8+PGAZemB06dPs3jxYhwcHGjZsmWh8+vVq4eLi0uh9t/3qV27drHtN5KRkQFQ4oKuiIiIiNhGWlpauSwxdTdQTisiIiJS/m4nn7VrgXbIkCGcP3+emTNnkpiYSMuWLVm9ejWNGjUCIDExkfj4+HIfV4MGDUhISCi3GRxX17xNSEjQLyQiUiqKJyJiK/aKJzVr1iy3e93pyjOn1c8fEbElxRQRsRV7xJPbyWcN89V3n8Ru0tPTqVWrlmaMiEipKZ6IiK0onsit0PeLiNiSYoqI2EpliSdazEVERERERERERETETlSgFREREREREREREbETFWgrAGdnZ/7+97/j7Oxs76GISCWneCIitqJ4IrdC3y8iYkuKKSJiK5UlnmgNWhERERERERERERE70QxaERERERERERERETtRgVZERERERERERETETlSgFREREREREREREbETFWgrKH9/f95//317D0NE7jCKLSIiUp70c0dEyoJii4jcaVSgtaHu3bvz3HPP2eRau3bt4umnn7bJtURERETAtrkKQEREBI899pjNricVg3JaERERqcjuxJzWya53v8uYzWby8/Nxcrr5H7unp2c5jEhERERE5NYopxURERGxLc2gtZGIiAg2bdrEnDlzMAwDwzBYuHAhhmGwdu1aQkNDcXZ2JioqimPHjjFgwAC8vLxwdXWlffv2bNiwodD1fv/KhmEYfPLJJwwcOJDq1avTrFkzVq1aVc5PKSL2NG/ePHx8fDCZTIXa+/fvz+jRo0sUW0Tk7lVcrhIXF0dMTAx9+/bF1dUVLy8vwsPDSUlJsZ63fPlyWrVqRbVq1ahbty69evUiKyuLV199lUWLFvHtt99ar7dx40b7PaDYhHJaESlrymlFpDTu1JxWBVobmTNnDp06deKpp54iMTGRxMREfH19AXjhhReYPXs2v/76K61btyYzM5O+ffuyYcMG9u7dS58+fejXrx/x8fE3vMeMGTMYPHgw+/fvp2/fvowYMYILFy6Ux+OJSAXw5JNPkpKSwo8//mhtS01NZe3atYwYMeK2Y4uI3B2Ky1WqVKlCt27dCA4OZvfu3axZs4Zz584xePBgABITExk2bBhjxozh119/ZePGjTz++OOYzWYmT57M4MGDeeihh6zX69y5s52fUkpLOa2IlDXltCJSGndqTqslDmykVq1aVK1alerVq1O/fn0ADh06BMDMmTN58MEHrX3r1q1LmzZtrJ9nzZrFN998w6pVq3j22Weve4+IiAiGDRsGwGuvvcaHH37Izp07eeihh8rikUSkgnF3d+ehhx7iq6++omfPngB8/fXXuLu707NnTxwdHW8rtojI3aG4XOWVV14hJCSE1157zdrvs88+w9fXlyNHjpCZmUleXh6PP/44jRo1AqBVq1bWvtWqVSMnJ8d6Pan8lNOKSFlTTisipXGn5rSaQVsOQkNDC33OysrihRdeICgoiNq1a+Pq6sqhQ4du+jeCrVu3tv57jRo1qFmzJklJSWUyZhGpmEaMGMGKFSvIyckBYMmSJQwdOhRHR8fbji0icvfas2cPP/74I66urtav5s2bA3Ds2DHatGlDz549adWqFU8++SQLFiwgNTXVzqMWe1FOKyK2opxWRGzpTshpNYO2HNSoUaPQ5ylTprB27VrefvttmjZtSrVq1Rg0aBC5ubk3vE6VKlUKfTYMo8i6PSJyZ+vXrx8mk4nvvvuO9u3bExUVxbvvvgvcfmwRkbuXyWSiX79+vPHGG0WOeXt74+joyPr169m2bRvr1q3jww8/ZPr06ezYsYPGjRvbYcRiT8ppRcRWlNOKiC3dCTmtCrQ2VLVqVfLz82/aLyoqioiICAYOHAhAZmYmcXFxZTw6EbkTVKtWjccff5wlS5Zw9OhRAgICaNeuHaDYIiI39/tcJSQkhBUrVuDv74+TU/FpoWEYhIWFERYWxiuvvEKjRo345ptvmDRpUolzH6lclNOKSFlTTisipXEn5rRa4sCG/P392bFjB3FxcaSkpFx3JkDTpk1ZuXIl0dHR7Nu3j+HDh2vWgIiU2IgRI/juu+/47LPPGDlypLVdsUVEbub3ucrEiRO5cOECw4YNY+fOnRw/fpx169YxZswY8vPz2bFjB6+99hq7d+8mPj6elStXkpycTGBgoPV6+/fv5/Dhw6SkpHD58mU7P6HYgnJaESkPymlF5HbdiTmtCrQ2NHnyZBwdHQkKCsLT0/O6a+S899571KlTh86dO9OvXz/69OlDSEhIOY9WRCqrBx54AHd3dw4fPszw4cOt7YotInIzv89VcnNz2bp1K/n5+fTp04eWLVvyl7/8hVq1auHg4ICbmxubN2+mb9++BAQE8NJLL/HOO+/w8MMPA/DUU09x7733EhoaiqenJ1u3brXzE4otKKcVkfKgnFZEbtedmNMaZrPZXO53FRERERERERERERHNoBURERERERERERGxFxVoRUREREREREREROxEBVoRERERERERERERO1GBVkRERERERERERMROVKAVERERERERERERsRMVaEVERERERERERETsRAVaERERERERERERETtRgVZERERERERERETETlSgFREREREREREREbETFWhFRERERERERERE7EQFWhERERERERERERE7UYFWRERERERERERExE7+P6X15i5ViQTsAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1400x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved fitting analysis plot.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── FITTING ANALYSIS PLOT (reads the persisted eval JSON) ────────────────────\n",
+    "import json, matplotlib.pyplot as plt\n",
+    "\n",
+    "with open(\"../outputs/xgboost_v2_evaluation_results.json\") as f:\n",
+    "    R = json.load(f)\n",
+    "\n",
+    "splits = [\"train\", \"val\", \"test\"]\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(14, 5))\n",
+    "for ax, (task, keys) in zip(axes, [(\"4-Class\", [\"4class_A\", \"4class_B\"]),\n",
+    "                                    (\"Binary\", [\"binary_A\", \"binary_B\"])]):\n",
+    "    for key, label, color in zip(keys, [\"Config A\", \"Config B\"], [\"steelblue\", \"darkorange\"]):\n",
+    "        if key in R:\n",
+    "            y = [R[key][s][\"overall\"][\"f1\"] for s in splits]\n",
+    "            ax.plot(splits, y, marker=\"o\", label=label, color=color, linewidth=2)\n",
+    "            for s, v in zip(splits, y):\n",
+    "                ax.annotate(f\"{v:.3f}\", (s, v), textcoords=\"offset points\", xytext=(0, 8), fontsize=8)\n",
+    "    ax.set_title(f\"{task} — Weighted F1 by Split\", fontsize=12, fontweight=\"bold\")\n",
+    "    ax.set_ylabel(\"Weighted F1\"); ax.legend(); ax.grid(alpha=0.3)\n",
+    "    ax.spines[\"top\"].set_visible(False); ax.spines[\"right\"].set_visible(False)\n",
+    "plt.suptitle(\"Fitting Analysis (Leakage-Corrected)\", fontsize=14, fontweight=\"bold\", y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(\"../outputs/figures/xgb_v2_fitting_analysis.png\", dpi=150, bbox_inches=\"tight\")\n",
+    "plt.show()\n",
+    "print(\"Saved fitting analysis plot.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac4ac408-742f-4640-9d28-09ca45c73c3c",
+   "metadata": {},
+   "source": [
+    "### Leakage-Corrected Baseline Results\n",
+    "\n",
+    "The corrected XGBoost models reveal that temporal aggregate leakage was responsible for a substantial fraction of Milestone 3's reported performance:\n",
+    "\n",
+    "| Task | v1 Test WF1 (leaky) | v2 Test WF1 (corrected) | Δ |\n",
+    "|---|---|---|---|\n",
+    "| 4-class Config A | 0.5689 | 0.4514 | **−0.118** |\n",
+    "| 4-class Config B | 0.5866 | 0.4451 | **−0.142** |\n",
+    "| Binary Config A   | 0.7280 | 0.6260 | **−0.102** |\n",
+    "| Binary Config B   | 0.7440 | 0.6149 | **−0.129** |\n",
+    "\n",
+    "Roughly 10–14 weighted-F1 points of v1's reported test performance were attributable to temporal aggregate leakage rather than genuine pre-publication signal. The leakage arose from computing author and subreddit aggregates (`author_mean_score`, `subreddit_median_score`, etc.) over the full 2012–2018 dataset before the temporal split, allowing each validation and test row to access summary statistics that included information from its own period.\n",
+    "\n",
+    "**Configuration ranking reverses on test.** In v1, the aggressive Config B outperformed the conservative Config A across all splits. With the leakage removed, Config A now achieves higher test weighted F1 than Config B for both tasks (4-class: 0.4514 vs 0.4451; binary: 0.6260 vs 0.6149), even as Config B retains the higher train weighted F1. This indicates that v1's Config B was effectively overfitting to the leaked aggregate signal: with deeper trees and lighter regularization, it absorbed more of the spurious information that did not generalize to the held-out periods. The conservative Config A, which placed less weight on these features under v1, generalizes better once the signal is honest.\n",
+    "\n",
+    "**The train→test gap tracks cold-start prevalence.** All four models show a substantial monotonic decline from train to validation to test (Config B 4-class: 0.578 → 0.512 → 0.445; binary: 0.738 → 0.679 → 0.615). The training split has 0% cold-start by construction, the validation split has 28.8% cold-start authors, and the test split has 48.6%. The performance degradation tracks this prevalence almost linearly, indicating that the test underperformance is not classical overfitting but a structural consequence of forward-in-time prediction on a growing platform: roughly half of the test set consists of authors with no training-period history available, and the model has no historical basis to ground predictions for them. This finding directly motivates the dimensionality-reduced NLP feature enrichment in Milestone 4, since content-derived features (TF-IDF, SVD components, embeddings) carry signal independent of author history and are the principal recourse for the cold-start population.\n",
+    "\n",
+    "**Feature importance is dominated by subreddit and author aggregates.** As in v1, `subreddit_post_count`, `author_post_count`, `author_mean_score`, and `subreddit_median_score` are the top features across all four models, with title-structural features (`title_len`, `selftext_len`) and sentiment (`title_sentiment`, `selftext_sentiment`) forming the second tier. The cold-start flags `is_new_author` and `is_new_subreddit` show zero importance — by design, both are identically zero on the training data (every train author/subreddit is in the train aggregate by construction), giving XGBoost no variance to split on at training time. XGBoost's native missing-value default-direction handling carries the actual cold-start routing through its built-in NaN logic, rendering the explicit flags structurally redundant. The flags are retained in the feature set for transparency and would become informative under a different split structure (e.g. k-fold cross-validation) where cold-start status varies within training data.\n",
+    "\n",
+    "Several low-information features show zero importance across all models: `has_title`, `title_is_allcaps`, `has_exclamation`, and `has_question`. These are candidates for removal in subsequent modeling stages."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fb13fbf-1e3b-409e-871e-a78c579c1b9f",
+   "metadata": {},
+   "source": [
+    "### Sanity Check: Verify Low-Information Features Before NLP Augmentation\n",
+    "\n",
+    "Four structural features show zero importance across all four models (`has_title`, `title_is_allcaps`, `has_exclamation`, `has_question`). Before committing to the augmented feature set for the NLP-enriched models, we verify this is consistent rather than a single-model artifact by examining the importance across all four models simultaneously. Features with zero importance in every model are candidates for removal: keeping them adds vector dimensionality without information, and (depending on `colsample_bytree`) can mildly degrade training by occupying sampled-feature slots with noise.\n",
+    "\n",
+    "The cold-start flags `is_new_author` and `is_new_subreddit` also show zero importance, but for a structurally different reason: they are identically zero on the training data (every train author and subreddit is in the train aggregate by construction), so XGBoost has no variance to split on. They are retained to document the cold-start methodology in the assembler and to remain available under any future modeling structure where cold-start status varies within training data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "164eafbc-5a88-4fbe-8f0b-74600d05a3cb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feature importance across all four models (sorted ascending by max):\n",
+      "                           4class_A  4class_B  binary_A  binary_B    min      max\n",
+      "has_question                    0.0       0.0       0.0       0.0    0.0      0.0\n",
+      "has_exclamation                 0.0       0.0       0.0       0.0    0.0      0.0\n",
+      "title_is_allcaps                0.0       0.0       0.0       0.0    0.0      0.0\n",
+      "is_new_subreddit                0.0       0.0       0.0       0.0    0.0      0.0\n",
+      "is_new_author                   0.0       0.0       0.0       0.0    0.0      0.0\n",
+      "has_title                       0.0     578.0       0.0     122.0    0.0    578.0\n",
+      "is_known_bot                  177.0    1323.0      18.0     340.0   18.0   1323.0\n",
+      "is_anonymous_author           195.0    2680.0      90.0     785.0   90.0   2680.0\n",
+      "day_of_week                    12.0    5723.0       0.0    1709.0    0.0   5723.0\n",
+      "title_has_number              172.0    6050.0      44.0    1606.0   44.0   6050.0\n",
+      "is_text_post                  475.0    6273.0     137.0    1596.0  137.0   6273.0\n",
+      "selftext_sentiment             73.0    9532.0       7.0    2391.0    7.0   9532.0\n",
+      "hour_of_day                   133.0   12745.0      64.0    3371.0   64.0  12745.0\n",
+      "title_sentiment                95.0   15264.0      11.0    4051.0   11.0  15264.0\n",
+      "selftext_len                  763.0   21018.0     183.0    5795.0  183.0  21018.0\n",
+      "subreddit_median_comments    1181.0   23213.0     256.0    6936.0  256.0  23213.0\n",
+      "title_len                     319.0   24405.0      91.0    6418.0   91.0  24405.0\n",
+      "subreddit_median_score       1424.0   24476.0     337.0    5823.0  337.0  24476.0\n",
+      "author_mean_score            2278.0   33730.0     566.0    8865.0  566.0  33730.0\n",
+      "author_post_count            1422.0   36654.0     368.0    8795.0  368.0  36654.0\n",
+      "subreddit_post_count         3062.0   53356.0     820.0   12521.0  820.0  53356.0\n",
+      "\n",
+      "Features with zero importance in EVERY model (5):\n",
+      "  - has_question\n",
+      "  - has_exclamation\n",
+      "  - title_is_allcaps\n",
+      "  - is_new_subreddit\n",
+      "  - is_new_author\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── SANITY CHECK: ZERO-IMPORTANCE FEATURES ACROSS ALL FOUR MODELS ────────────\n",
+    "# Confirm the candidates for removal are zero (or near-zero) in EVERY model,\n",
+    "# not just dominant ones, before deciding to drop them.\n",
+    "\n",
+    "import pandas as pd\n",
+    "from xgboost.spark import SparkXGBClassifierModel\n",
+    "\n",
+    "MODELS_FOR_AUDIT = {\n",
+    "    \"4class_A\": \"../models/xgb_4class_configA_v2/\",\n",
+    "    \"4class_B\": \"../models/xgb_4class_configB_v2/\",\n",
+    "    \"binary_A\": \"../models/xgb_binary_configA_v2/\",\n",
+    "    \"binary_B\": \"../models/xgb_binary_configB_v2/\",\n",
+    "}\n",
+    "\n",
+    "def importance_dict(model, names):\n",
+    "    scores = model.get_booster().get_score(importance_type=\"weight\")\n",
+    "    imp = {names[int(k[1:])]: v for k, v in scores.items()}\n",
+    "    return {n: imp.get(n, 0) for n in names}\n",
+    "\n",
+    "# Already-defined FEATURE_NAMES from the importance-plot cell; redefining for safety\n",
+    "FEATURE_NAMES = [\n",
+    "    \"title_len\", \"has_question\", \"has_exclamation\", \"title_has_number\", \"title_is_allcaps\",\n",
+    "    \"has_title\", \"is_text_post\", \"selftext_len\",\n",
+    "    \"hour_of_day\", \"day_of_week\",\n",
+    "    \"is_known_bot\", \"is_anonymous_author\",\n",
+    "    \"is_new_author\", \"is_new_subreddit\",\n",
+    "    \"author_post_count\", \"author_mean_score\",\n",
+    "    \"subreddit_post_count\", \"subreddit_median_score\", \"subreddit_median_comments\",\n",
+    "    \"title_sentiment\", \"selftext_sentiment\",\n",
+    "]\n",
+    "\n",
+    "rows = {}\n",
+    "for key, path in MODELS_FOR_AUDIT.items():\n",
+    "    m = SparkXGBClassifierModel.load(path)\n",
+    "    rows[key] = importance_dict(m, FEATURE_NAMES)\n",
+    "\n",
+    "df_imp = pd.DataFrame(rows).fillna(0)\n",
+    "df_imp[\"min\"] = df_imp.min(axis=1)\n",
+    "df_imp[\"max\"] = df_imp.max(axis=1)\n",
+    "df_imp = df_imp.sort_values(\"max\")\n",
+    "\n",
+    "print(\"Feature importance across all four models (sorted ascending by max):\")\n",
+    "print(df_imp.to_string())\n",
+    "\n",
+    "zero_in_all = df_imp[df_imp[\"max\"] == 0].index.tolist()\n",
+    "print(f\"\\nFeatures with zero importance in EVERY model ({len(zero_in_all)}):\")\n",
+    "for f in zero_in_all:\n",
+    "    print(f\"  - {f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d0f4891-2418-42a5-84f3-c195221a4876",
+   "metadata": {},
+   "source": [
+    "**Feature importance audit complete.** Examining feature importance across all four trained models simultaneously confirms five features with zero importance in every model: three title-structural features (`has_question`, `has_exclamation`, `title_is_allcaps`) and the two cold-start flags (`is_new_author`, `is_new_subreddit`). A fourth title-structural feature, `has_title`, is zero-importance in both Config A models but receives marginal weight in Config B (578 and 122 splits, ~1% of the top feature's count), exclusively in the more aggressive configuration — the regime most prone to finding spurious splits on near-constant features. Because `has_title = 1` for the overwhelming majority of rows and the rare zero-title cases are already captured by `title_len = 0`, this signal is redundant with `title_len` and is also removed.\n",
+    "\n",
+    "The cold-start flags are retained despite zero importance: they encode no information during training (every train row by construction has `is_new_author = 0`), so XGBoost cannot split on them, but their presence in the feature vector documents the cold-start methodology and they would become informative under any modeling structure where cold-start status varies within the training data. XGBoost's native missing-value default-direction handling provides the actual cold-start routing through its built-in NaN logic.\n",
+    "\n",
+    "Final structured feature set for the NLP-enriched pipeline: **17 features**, removing `has_title`, `has_question`, `has_exclamation`, and `title_is_allcaps` from the original 21. The reduced vector will be concatenated with SVD components from TF-IDF dimensionality reduction in Milestone 4."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da7cb820-4bfb-4df4-bfdf-4d91f557c126",
+   "metadata": {},
+   "source": [
+    "## Milestone 3 Conclusion\n",
+    "\n",
+    "The headline result of Milestone 3 is methodological: a temporal aggregate leakage bug in the original pipeline was responsible for roughly 10–14 weighted-F1 points of reported test performance across all four model configurations. Computing author and subreddit aggregates (`author_mean_score`, `subreddit_median_score`, etc.) over the full 2012–2018 dataset before the temporal split allowed each validation and test row to access summary statistics that included information from its own period. Correcting this by computing aggregates strictly on training-period data — and explicitly handling the resulting cold-start cases via XGBoost's native missing-value mechanism — produced a corrected baseline that is meaningfully lower than the original numbers but is, for the first time, an honest measurement of forward-in-time generalization.\n",
+    "\n",
+    "Three findings emerged from the corrected pipeline:\n",
+    "\n",
+    "**The leakage was severe and uniform.** Test weighted F1 dropped 0.10–0.14 across all four model configurations, with the heaviest impact on the more aggressive Config B. The four trained XGBoost models now report test weighted F1 of 0.4514 (4-class A), 0.4451 (4-class B), 0.6260 (binary A), and 0.6149 (binary B), versus v1's 0.5689 / 0.5866 / 0.7280 / 0.7440. The proportional reduction is consistent across tasks, which is what we would expect from a leakage source affecting all models equally rather than a model-specific issue.\n",
+    "\n",
+    "**Configuration ranking inverts on test.** In v1, the aggressive Config B outperformed the conservative Config A across the board. With the leakage removed, Config A now achieves the higher test weighted F1 in both tasks, even as Config B retains the higher train weighted F1. This is a textbook signature of overfitting to a spurious feature: with deeper trees and lighter regularization, Config B absorbed more of the leaked aggregate signal — signal that did not generalize once removed. The conservative configuration, which under-relied on the leaky features by virtue of its regularization, generalizes better when the signal is honest.\n",
+    "\n",
+    "**The train→test gap reflects cold-start prevalence, not classical overfitting.** Performance declines monotonically from train (0% cold-start by construction) to validation (28.8% cold-start authors) to test (48.6%), tracking the cold-start rate almost linearly. Roughly half of the 2018 test set consists of authors with no training-period history, and the model has no historical basis to ground predictions for them. This is not a model failure but a structural property of forward-in-time prediction on a growing platform — and it is the result that directly motivates Milestone 4's content-based feature enrichment, since text features (TF-IDF components, embeddings) carry signal that does not depend on author history.\n",
+    "\n",
+    "**On the implementation side**, the corrected pipeline required several non-obvious engineering changes. The aggregate join had to be lineage-broken via disk round-trip to avoid Spark's shared-plan resolution silently returning nulls for valid keys (the first attempt produced an impossible 86% cold-start rate on training data). The sentiment lookup had to be deduplicated to handle the dataset's single known duplicate post id, which would otherwise have fanned out test rows on a left join. The XGBoost training step OOM'd in `local[*]` mode on the full 276M-row training set, requiring a stratified 30% sample (82.9M rows) for model fitting; the sample preserves class proportions to four decimals so reported metrics are not biased by sampling variance. The feature assembler was set to `handleInvalid=\"keep\"` so cold-start rows (up to 48.6% of test) are preserved in the output with their missing aggregates represented as NaN, which XGBoost handles natively via its learned default-direction mechanism — a critical detail since the alternative (`handleInvalid=\"skip\"`) would have silently dropped nearly half the test set.\n",
+    "\n",
+    "**What's next.** Milestone 4 introduces dimensionality reduction on a content-derived feature space, with the M4 model trained on the reduced features. As preparation, the present notebook is extended below with TF-IDF feature engineering and (time permitting) truncated SVD, producing an enriched feature artifact that M4 will both *use* and *analyze* in the formal dimensionality-reduction framing required by the rubric. The structural-feature-only baseline established above remains the reference against which the NLP-enriched model is measured: any test weighted F1 gain in the NLP arm is, by construction, attributable to content features rather than feature engineering of the existing structured set."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8e818fd-b63c-4ab4-9fc3-952150204e2b",
+   "metadata": {},
+   "source": [
+    "## Extension: TF-IDF Feature Engineering for the NLP Arm\n",
+    "\n",
+    "The Milestone 3 deliverable is complete above. The remainder of this notebook extends the pipeline with TF-IDF feature engineering and, time permitting, truncated SVD dimensionality reduction. The motivation is structural: roughly half the test set consists of cold-start authors for whom the historical aggregate features carry no information, so content-derived features are the principal lever for further improvement. The TF-IDF artifact persisted below is the input to Milestone 4's dimensionality reduction analysis and supervised model on reduced features.\n",
+    "\n",
+    "Four zero-importance structural features (`has_title`, `has_question`, `has_exclamation`, `title_is_allcaps`) identified in the importance audit above are excluded from the NLP-enriched feature set. The cold-start flags (`is_new_author`, `is_new_subreddit`) are retained despite zero importance, since they document the cold-start methodology and may become informative under different modeling structures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f4b7db4-4f42-4388-89d7-3da25d4033c7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b000c1d-2887-4058-abed-50c8538fde79",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b90e501d-098e-4e84-a677-936653adec9e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd87d10b-12dd-41f7-8fa2-829ba13d04dd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "717e3fe8-52d3-4bf0-9797-6b1aa19db276",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fcdf4e4-5a8b-4c8a-9f39-3c276c6f7ff9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "918f1e9f-1c93-4793-9935-ce824902d3f8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42acccf0-e95e-4e86-af53-024a51e013a0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e110b90-16b7-42e4-8242-f6a3ea8a7d9d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c13bae9-8506-4836-8c5b-e817ac305a42",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10ecb40b-5c74-47d8-810a-91c47be9a11b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de6dac76-ed1a-4ef3-8e91-3444774e5af6",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "# V1 PIPELINE -- ALL CODE BELOW IS STALE -- PIPELINE CURRENTLY BEING RESTRUCTURED -- DISREGARD ALL BELOW\n",
+    "\n",
+    "# --------------------------------------------------------------------------------------------------\n",
+    "\n",
+    "## Feature Engineering\n",
+    "\n",
+    "All features are derived from pre-publication information only to prevent data leakage and no features use `score`, `num_comments`, or the derived label columns.\n",
+    "\n",
+    "### Title and Post Type Features\n",
+    "\n",
+    "Simple structural features extracted from the `title` and `selftext` columns using PySpark string functions. These require no aggregations or UDFs and are computed directly as column transformations. Both text length features use character count for consistency.\n",
+    "\n",
+    "- `title_len`: character count of the post title\n",
+    "- `has_question`: binary flag indicating the presence of `?` in the title\n",
+    "- `has_exclamation`: binary flag indicating the presence of `!` in the title\n",
+    "- `title_has_number`: binary flag indicating the presence of a digit in the title, captures listicle-style titles (\"10 things...\") which are a known Reddit engagement pattern\n",
+    "- `title_is_allcaps`: binary flag indicating the entire title is uppercase, captures high emotional register posts\n",
+    "- `is_text_post`: binary flag, 1 if the post has a non-empty selftext body\n",
+    "- `selftext_len`: character length of selftext (0 for link posts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12dffeac-daaa-4612-a9c8-b7793cc51ccc",
+   "metadata": {},
+   "source": [
+    "## Model Preparation\n",
+    "\n",
+    "With all non-NLP features engineered, we now prepare the DataFrame for MLlib model training. This involves four steps:\n",
+    "\n",
+    "1. **Null imputation** — check for and impute any nulls in numeric feature columns\n",
+    "2. **Label encoding** — convert string labels to numeric indices using `StringIndexer`\n",
+    "3. **Feature assembly** — combine all numeric features into a single vector using `VectorAssembler`\n",
+    "4. **Feature scaling** — standardize the feature vector using `StandardScaler`\n",
+    "\n",
+    "These steps follow feature engineering as they operate on the finalized feature set rather than raw data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07f618d7-83c2-47d6-8041-561af33c05a8",
+   "metadata": {},
+   "source": [
+    "### Step 1 — Null Check on Feature Columns\n",
+    "\n",
+    "Before assembling the feature vector, we check for nulls across all numeric feature columns. Nulls will cause `VectorAssembler` to fail unless handled explicitly via imputation or by setting `handleInvalid=\"skip\"`. We use `Imputer` for numeric nulls rather than dropping rows, preserving as much data as possible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "523ca0e3-ec11-4ae5-aa5a-e8e03215ca76",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-RECORD 0------------------------------\n",
+      " title_len                 | 0         \n",
+      " has_question              | 0         \n",
+      " has_exclamation           | 0         \n",
+      " title_has_number          | 0         \n",
+      " title_is_allcaps          | 0         \n",
+      " is_text_post              | 0         \n",
+      " selftext_len              | 0         \n",
+      " hour_of_day               | 0         \n",
+      " day_of_week               | 0         \n",
+      " subreddit_post_count      | 0         \n",
+      " subreddit_median_score    | 0         \n",
+      " subreddit_median_comments | 0         \n",
+      " author_post_count         | 0         \n",
+      " author_mean_score         | 0         \n",
+      " has_title                 | 0         \n",
+      " is_known_bot              | 0         \n",
+      " is_anonymous_author       | 0         \n",
+      " title_sentiment           | 0         \n",
+      " selftext_sentiment        | 388899527 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── NULL CHECK ON FEATURE COLUMNS ────────────────────────────────────────────\n",
+    "\n",
+    "feature_cols = [\n",
+    "    \"title_len\", \"has_question\", \"has_exclamation\",\n",
+    "    \"title_has_number\", \"title_is_allcaps\",\n",
+    "    \"is_text_post\", \"selftext_len\", \"hour_of_day\", \"day_of_week\",\n",
+    "    \"subreddit_post_count\", \"subreddit_median_score\", \"subreddit_median_comments\",\n",
+    "    \"author_post_count\", \"author_mean_score\",\n",
+    "    \"has_title\", \"is_known_bot\", \"is_anonymous_author\",\n",
+    "    \"title_sentiment\", \"selftext_sentiment\"\n",
+    "]\n",
+    "\n",
+    "# Count nulls per feature column\n",
+    "null_counts = df_features.select([\n",
+    "    F.count(F.when(F.col(c).isNull(), c)).alias(c)\n",
+    "    for c in feature_cols\n",
+    "])\n",
+    "\n",
+    "null_counts.show(vertical=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2de7de10-b1e4-452a-93a8-ef025143842d",
+   "metadata": {},
+   "source": [
+    "### Null Check Results\n",
+    "\n",
+    "All feature columns are null-free except `selftext_sentiment` which has 388,899,527 nulls which is exactly as expected. This represents the 72.8% of posts that are link posts with empty selftext, for which sentiment is intentionally undefined rather than neutral. The `is_text_post` flag already captures this distinction so the model has the context to interpret imputed selftext sentiment values correctly.\n",
+    "\n",
+    "Only `selftext_sentiment` requires imputation before feature assembly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "063d144e-5215-4c15-8074-95c78687fc85",
+   "metadata": {},
+   "source": [
+    "### Step 2 — Imputation\n",
+    "\n",
+    "Only `selftext_sentiment` requires imputation — 388,899,527 nulls representing link posts with no body text. All other feature columns are null-free. We impute with the mean strategy, replacing nulls with the mean sentiment score of text posts. The `is_text_post` flag remains in the feature set so the model retains the ability to distinguish imputed values (link posts) from genuine neutral"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "08f071c7-0603-41e9-8f1c-cb50e1afeee7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Null counts after imputation:\n",
+      "-RECORD 0------------------------\n",
+      " title_len                 | 0   \n",
+      " has_question              | 0   \n",
+      " has_exclamation           | 0   \n",
+      " title_has_number          | 0   \n",
+      " title_is_allcaps          | 0   \n",
+      " is_text_post              | 0   \n",
+      " selftext_len              | 0   \n",
+      " hour_of_day               | 0   \n",
+      " day_of_week               | 0   \n",
+      " subreddit_post_count      | 0   \n",
+      " subreddit_median_score    | 0   \n",
+      " subreddit_median_comments | 0   \n",
+      " author_post_count         | 0   \n",
+      " author_mean_score         | 0   \n",
+      " has_title                 | 0   \n",
+      " is_known_bot              | 0   \n",
+      " is_anonymous_author       | 0   \n",
+      " title_sentiment           | 0   \n",
+      " selftext_sentiment        | 0   \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── IMPUTATION ────────────────────────────────────────────────────────────────\n",
+    "from pyspark.ml.feature import Imputer\n",
+    "\n",
+    "# Only selftext_sentiment has nulls — impute with mean of non-null values\n",
+    "imputer = Imputer(\n",
+    "    inputCols=[\"selftext_sentiment\"],\n",
+    "    outputCols=[\"selftext_sentiment\"],\n",
+    "    strategy=\"mean\"\n",
+    ")\n",
+    "\n",
+    "# Fit computes mean from non-null rows, transform fills nulls\n",
+    "imputer_model = imputer.fit(df_features)\n",
+    "df_features = imputer_model.transform(df_features)\n",
+    "\n",
+    "# Verify no nulls remain\n",
+    "null_check = df_features.select([\n",
+    "    F.count(F.when(F.col(c).isNull(), c)).alias(c)\n",
+    "    for c in feature_cols\n",
+    "])\n",
+    "print(\"Null counts after imputation:\")\n",
+    "null_check.show(vertical=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aabfbca0-b507-4d95-88bb-dec29d4d32e5",
+   "metadata": {},
+   "source": [
+    "### Step 3 — Label Encoding\n",
+    "\n",
+    "MLlib classifiers require numeric labels. `StringIndexer` converts `label_4class` and `label_binary` string labels to numeric indices ordered by frequency. The most frequent label receives index 0. Given `low-engagement` is the plurality class at 44.3%, it is expected to receive index 0 in the 4-class encoding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "3041001f-8a19-4f36-9dfb-007ade252b3b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4-class label index mapping:\n",
+      "+--------------+----------------+---------+\n",
+      "|  label_4class|label_4class_idx|    count|\n",
+      "+--------------+----------------+---------+\n",
+      "|low-engagement|             0.0|236954268|\n",
+      "|         viral|             1.0|160168118|\n",
+      "| crowd-pleaser|             2.0| 74916114|\n",
+      "|debate-starter|             3.0| 63442318|\n",
+      "+--------------+----------------+---------+\n",
+      "\n",
+      "Binary label index mapping:\n",
+      "+---------------+----------------+---------+\n",
+      "|   label_binary|label_binary_idx|    count|\n",
+      "+---------------+----------------+---------+\n",
+      "|high-engagement|             0.0|298526550|\n",
+      "| low-engagement|             1.0|236954268|\n",
+      "+---------------+----------------+---------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── LABEL ENCODING ───────────────────────────────────────────────────────────\n",
+    "from pyspark.ml.feature import StringIndexer\n",
+    "\n",
+    "# Index 4-class label\n",
+    "indexer_4class = StringIndexer(\n",
+    "    inputCol=\"label_4class\",\n",
+    "    outputCol=\"label_4class_idx\",\n",
+    "    handleInvalid=\"keep\"\n",
+    ")\n",
+    "\n",
+    "# Index binary label\n",
+    "indexer_binary = StringIndexer(\n",
+    "    inputCol=\"label_binary\",\n",
+    "    outputCol=\"label_binary_idx\",\n",
+    "    handleInvalid=\"keep\"\n",
+    ")\n",
+    "\n",
+    "# Fit and transform\n",
+    "df_features = indexer_4class.fit(df_features).transform(df_features)\n",
+    "df_features = indexer_binary.fit(df_features).transform(df_features)\n",
+    "\n",
+    "# Verify label index mapping\n",
+    "print(\"4-class label index mapping:\")\n",
+    "df_features.groupBy(\"label_4class\", \"label_4class_idx\") \\\n",
+    "    .count() \\\n",
+    "    .orderBy(\"label_4class_idx\") \\\n",
+    "    .show()\n",
+    "\n",
+    "print(\"Binary label index mapping:\")\n",
+    "df_features.groupBy(\"label_binary\", \"label_binary_idx\") \\\n",
+    "    .count() \\\n",
+    "    .orderBy(\"label_binary_idx\") \\\n",
+    "    .show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "804ef2d4-5699-419b-828e-c471d405fe34",
+   "metadata": {},
+   "source": [
+    "### Label Encoding Results\n",
+    "\n",
+    "Label indices assigned by frequency as expected:\n",
+    "\n",
+    "**4-class:**\n",
+    "| Label | Index | Count |\n",
+    "|---|---|---|\n",
+    "| low-engagement | 0 | 236,954,268 |\n",
+    "| viral | 1 | 160,168,118 |\n",
+    "| crowd-pleaser | 2 | 74,916,114 |\n",
+    "| debate-starter | 3 | 63,442,318 |\n",
+    "\n",
+    "**Binary:**\n",
+    "| Label | Index | Count |\n",
+    "|---|---|---|\n",
+    "| high-engagement | 0 | 298,526,550 |\n",
+    "| low-engagement | 1 | 236,954,268 |\n",
+    "\n",
+    "`low-engagement` received index 0 in the 4-class encoding as predicted. Notably in the binary encoding, `high-engagement` is the majority class at 55.7% and receives index 0. Both encodings confirm the label distributions from the threshold analysis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22c03a6c-fa09-4c3c-aaa1-6307b93798a2",
+   "metadata": {},
+   "source": [
+    "### Step 4 — Feature Assembly\n",
+    "\n",
+    "`VectorAssembler` combines all 19 numeric feature columns into a single dense vector column required by MLlib models. Raw text columns (`title`, `selftext`), identifier columns (`id`, `author`, `subreddit`, `subreddit_id`), timestamp (`created_utc`), raw engagement columns (`score`, `num_comments`), and string label columns are excluded. Only engineered numeric features enter the vector. `handleInvalid=\"skip\"` is set as a safety net though imputation above eliminated all nulls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "39bcb216-53d0-4773-8fe8-857bb0081adc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feature vector assembled with 19 features.\n",
+      "+--------------------------------------------------------------------------------+\n",
+      "|                                                                    features_raw|\n",
+      "+--------------------------------------------------------------------------------+\n",
+      "|(19,[0,3,5,8,9,12,13,14,15,18],[36.0,1.0,1.0,11.0,3.0,30.0,3.4,2473.0,1.0,0.2...|\n",
+      "|(19,[0,5,8,9,12,13,14,15,18],[36.0,1.0,20.0,6.0,30.0,3.4,2473.0,1.0,0.2330756...|\n",
+      "|(19,[0,5,8,9,12,13,14,15,16,18],[50.0,1.0,9.0,7.0,30.0,3.4,175729.0,3.0,3.0,0...|\n",
+      "+--------------------------------------------------------------------------------+\n",
+      "only showing top 3 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── FEATURE ASSEMBLY ──────────────────────────────────────────────────────────\n",
+    "from pyspark.ml.feature import VectorAssembler\n",
+    "\n",
+    "assembler_cols = [\n",
+    "    # Title structural features\n",
+    "    \"title_len\", \"has_question\", \"has_exclamation\",\n",
+    "    \"title_has_number\", \"title_is_allcaps\",\n",
+    "    # Post type features\n",
+    "    \"has_title\", \"is_text_post\", \"selftext_len\",\n",
+    "    # Temporal features\n",
+    "    \"hour_of_day\", \"day_of_week\",\n",
+    "    # Author type flags\n",
+    "    \"is_known_bot\", \"is_anonymous_author\",\n",
+    "    # Author history aggregations\n",
+    "    \"author_post_count\", \"author_mean_score\",\n",
+    "    # Subreddit context aggregations\n",
+    "    \"subreddit_post_count\", \"subreddit_median_score\", \"subreddit_median_comments\",\n",
+    "    # NLP sentiment features\n",
+    "    \"title_sentiment\", \"selftext_sentiment\"\n",
+    "]\n",
+    "\n",
+    "assembler = VectorAssembler(\n",
+    "    inputCols=assembler_cols,\n",
+    "    outputCol=\"features_raw\",\n",
+    "    handleInvalid=\"skip\"\n",
+    ")\n",
+    "\n",
+    "df_features = assembler.transform(df_features)\n",
+    "print(f\"Feature vector assembled with {len(assembler_cols)} features.\")\n",
+    "df_features.select(\"features_raw\").show(3, truncate=80)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9d4cee8-650b-4333-9056-a3937ad2729a",
+   "metadata": {},
+   "source": [
+    "### Step 5 — Feature Scaling\n",
+    "\n",
+    "`StandardScaler` standardizes the assembled feature vector to zero mean and unit variance. Features with large ranges (`author_post_count` can reach millions, `selftext_len` can reach thousands) would otherwise dominate binary features like `has_question` and `is_known_bot` which only take values 0 or 1. Scaling ensures all features contribute proportionally to the model.\n",
+    "\n",
+    "The scaler is fit on training data only and applied to all three splits. Fitting on the full dataset would leak validation and test set statistics into training. We therefore perform the train/test split before fitting the scaler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "efb91f6f-3d34-4e02-9d75-334f3307becb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train rows: 276,442,594\n",
+      "Val rows:   114,089,205\n",
+      "Test rows:  144,949,019\n",
+      "\n",
+      "Scaling complete.\n",
+      "Train rows: 276,442,594\n",
+      "Val rows:   114,089,205\n",
+      "Test rows:  144,949,019\n",
+      "+--------------------------------------------------------------------------------+\n",
+      "|                                                                        features|\n",
+      "+--------------------------------------------------------------------------------+\n",
+      "|[-0.3794727388086728,0.0,0.0,1.8308506054916096,-0.07351652556800245,0.046569...|\n",
+      "|[-0.3794727388086728,0.0,0.0,-0.5461942079725822,-0.07351652556800245,0.04656...|\n",
+      "|[0.01009276171008487,0.0,0.0,-0.5461942079725822,-0.07351652556800245,0.04656...|\n",
+      "+--------------------------------------------------------------------------------+\n",
+      "only showing top 3 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── TRAIN/VAL/TEST SPLIT ──────────────────────────────────────────────────────\n",
+    "from pyspark.ml.feature import StandardScaler\n",
+    "\n",
+    "# Time-based split boundaries as Unix timestamps\n",
+    "TRAIN_END = 1483228800  # 2017-01-01 00:00:00 UTC\n",
+    "VAL_END   = 1514764800  # 2018-01-01 00:00:00 UTC\n",
+    "\n",
+    "train_df = df_features.filter(F.col(\"created_utc\") < TRAIN_END)\n",
+    "val_df   = df_features.filter(\n",
+    "    (F.col(\"created_utc\") >= TRAIN_END) &\n",
+    "    (F.col(\"created_utc\") < VAL_END)\n",
+    ")\n",
+    "test_df  = df_features.filter(F.col(\"created_utc\") >= VAL_END)\n",
+    "\n",
+    "print(f\"Train rows: {train_df.count():,}\")\n",
+    "print(f\"Val rows:   {val_df.count():,}\")\n",
+    "print(f\"Test rows:  {test_df.count():,}\")\n",
+    "\n",
+    "# Fit scaler on training data only — prevents leakage from val/test sets\n",
+    "scaler = StandardScaler(\n",
+    "    inputCol=\"features_raw\",\n",
+    "    outputCol=\"features\",\n",
+    "    withMean=True,\n",
+    "    withStd=True\n",
+    ")\n",
+    "\n",
+    "scaler_model = scaler.fit(train_df)\n",
+    "\n",
+    "# Apply fitted scaler to all three splits\n",
+    "train_df = scaler_model.transform(train_df)\n",
+    "val_df   = scaler_model.transform(val_df)\n",
+    "test_df  = scaler_model.transform(test_df)\n",
+    "\n",
+    "print(\"\\nScaling complete.\")\n",
+    "print(f\"Train rows: {train_df.count():,}\")\n",
+    "print(f\"Val rows:   {val_df.count():,}\")\n",
+    "print(f\"Test rows:  {test_df.count():,}\")\n",
+    "train_df.select(\"features\").show(3, truncate=80)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4254558-2ccf-4696-b376-a838b1e5762a",
+   "metadata": {},
+   "source": [
+    "### Scaling and Split Results\n",
+    "\n",
+    "Time-based train/val/test split:\n",
+    "\n",
+    "| Split | Rows | % of Total |\n",
+    "|---|---|---|\n",
+    "| Train (2012–2016) | 276,442,594 | 51.6% |\n",
+    "| Validation (2017) | 114,089,205 | 21.3% |\n",
+    "| Test (2018) | 144,949,019 | 27.1% |\n",
+    "\n",
+    "The scaled feature vectors show standardized values centered around 0 with values both positive and negative, confirming `StandardScaler` is working correctly. The split proportions are reasonable with over half the data in training, with a full year each for validation and test."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d2ced19-3a7f-4581-8b86-55e08cf612f2",
+   "metadata": {},
+   "source": [
+    "### Persist Train/Val/Test Splits\n",
+    "\n",
+    "We persist the three splits to disk before model training to break the lineage chain (features_nlp → imputer → StringIndexer → VectorAssembler → StandardScaler → time filter). Without persistence, every action during model training would re-execute this entire chain. Reading from persisted Parquet eliminates this overhead and significantly reduces training time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "01cef4c0-3da2-4a06-9561-ad3d23716d17",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing train split...\n",
+      "Writing val split...\n",
+      "Writing test split...\n",
+      "\n",
+      "Reloading splits from disk...\n",
+      "Train rows: 276,442,594\n",
+      "Val rows:   114,089,205\n",
+      "Test rows:  144,949,019\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ── PERSIST TRAIN/VAL/TEST SPLITS ────────────────────────────────────────────\n",
+    "\n",
+    "TRAIN_DIR = \"../data/processed/train\"\n",
+    "VAL_DIR   = \"../data/processed/val\"\n",
+    "TEST_DIR  = \"../data/processed/test\"\n",
+    "\n",
+    "print(\"Writing train split...\")\n",
+    "train_df.write.mode(\"overwrite\").parquet(TRAIN_DIR)\n",
+    "print(\"Writing val split...\")\n",
+    "val_df.write.mode(\"overwrite\").parquet(VAL_DIR)\n",
+    "print(\"Writing test split...\")\n",
+    "test_df.write.mode(\"overwrite\").parquet(TEST_DIR)\n",
+    "\n",
+    "print(\"\\nReloading splits from disk...\")\n",
+    "train_df = spark.read.parquet(TRAIN_DIR)\n",
+    "val_df   = spark.read.parquet(VAL_DIR)\n",
+    "test_df  = spark.read.parquet(TEST_DIR)\n",
+    "\n",
+    "print(f\"Train rows: {train_df.count():,}\")\n",
+    "print(f\"Val rows:   {val_df.count():,}\")\n",
+    "print(f\"Test rows:  {test_df.count():,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6e76885c-5411-49d2-a332-cbeaa34f3451",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Reloading splits from disk...\n",
+      "Train rows: 276,442,594\n",
+      "Val rows:   114,089,205\n",
+      "Test rows:  144,949,019\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reloading train val and test dfs\n",
+    "# Note: This is checkpoint for model fitting; data load is done in persist cell\n",
+    "#       to validate counts\n",
+    "\n",
+    "TRAIN_DIR = \"../data/processed/train\"\n",
+    "VAL_DIR   = \"../data/processed/val\"\n",
+    "TEST_DIR  = \"../data/processed/test\"\n",
+    "\n",
+    "\n",
+    "print(\"\\nReloading splits from disk...\")\n",
+    "train_df = spark.read.parquet(TRAIN_DIR)\n",
+    "val_df   = spark.read.parquet(VAL_DIR)\n",
+    "test_df  = spark.read.parquet(TEST_DIR)\n",
+    "\n",
+    "print(f\"Train rows: {train_df.count():,}\")\n",
+    "print(f\"Val rows:   {val_df.count():,}\")\n",
+    "print(f\"Test rows:  {test_df.count():,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d87f0b0-3843-4043-a059-6cdf231df745",
+   "metadata": {},
+   "source": [
+    "## Milestone 3: Model Training\n",
+    "\n",
+    "We use `SparkXGBClassifier` from the `xgboost.spark` module, which ships with XGBoost ≥ 1.6. The cell below verifies availability and installs if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "49c11962-97db-4aee-ac72-7ebf837d9402",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGBoost 2.0.3 available — SparkXGBClassifier ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check for XGBoost and Install if needed\n",
+    "\n",
+    "try:\n",
+    "    from xgboost.spark import SparkXGBClassifier\n",
+    "    import xgboost as xgb\n",
+    "    print(f\"XGBoost {xgb.__version__} available — SparkXGBClassifier ready\")\n",
+    "except ImportError:\n",
+    "    import subprocess, sys\n",
+    "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"xgboost>=1.7\"])\n",
+    "    from xgboost.spark import SparkXGBClassifier\n",
+    "    import xgboost as xgb\n",
+    "    print(f\"Installed XGBoost {xgb.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd8d97b-7f45-4c92-bd37-c7f6025241f4",
+   "metadata": {},
+   "source": [
+    "### Class Weight Computation\n",
+    "\n",
+    "To address label imbalance (low-engagement 44.3%, viral 29.9%, crowd-pleaser 14.0%, debate-starter 11.8%), we compute inverse-frequency weights from the training set only, then broadcast and join to all three splits. This prevents information leakage from val/test distributions into the weight values.\n",
+    "\n",
+    "Weights are computed as `N / (num_classes * class_count)`, the normalized inverse frequency formulation used by scikit-learn, which keeps the effective total sample weight equal to N regardless of class distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e088e77a-3f1e-46dc-8f59-3dcda38131b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------------+------------------+\n",
+      "|label_4class_idx|     weight_4class|\n",
+      "+----------------+------------------+\n",
+      "|             0.0|0.5301268182465868|\n",
+      "|             1.0|0.9731065704183982|\n",
+      "|             2.0|1.6904547488515607|\n",
+      "|             3.0| 2.022386046668015|\n",
+      "+----------------+------------------+\n",
+      "\n",
+      "+----------------+------------------+\n",
+      "|label_binary_idx|     weight_binary|\n",
+      "+----------------+------------------+\n",
+      "|             0.0|0.9462264655073706|\n",
+      "|             1.0|1.0602536364931736|\n",
+      "+----------------+------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "NUM_CLASSES_4 = 4\n",
+    "NUM_CLASSES_2 = 2\n",
+    "\n",
+    "N_train = train_df.count()\n",
+    "\n",
+    "# Compute per-class counts from train only\n",
+    "class_counts_4 = (\n",
+    "    train_df.groupBy(\"label_4class_idx\")\n",
+    "            .agg(F.count(\"*\").alias(\"class_count\"))\n",
+    ")\n",
+    "\n",
+    "class_counts_2 = (\n",
+    "    train_df.groupBy(\"label_binary_idx\")\n",
+    "            .agg(F.count(\"*\").alias(\"class_count\"))\n",
+    ")\n",
+    "\n",
+    "# Normalize: weight = N / (num_classes * class_count)\n",
+    "weight_map_4 = (\n",
+    "    class_counts_4\n",
+    "    .withColumn(\"weight_4class\", F.lit(N_train) / (F.lit(NUM_CLASSES_4) * F.col(\"class_count\")))\n",
+    "    .select(\"label_4class_idx\", \"weight_4class\")\n",
+    ")\n",
+    "\n",
+    "weight_map_2 = (\n",
+    "    class_counts_2\n",
+    "    .withColumn(\"weight_binary\", F.lit(N_train) / (F.lit(NUM_CLASSES_2) * F.col(\"class_count\")))\n",
+    "    .select(\"label_binary_idx\", \"weight_binary\")\n",
+    ")\n",
+    "\n",
+    "weight_map_4.orderBy(\"label_4class_idx\").show()\n",
+    "weight_map_2.orderBy(\"label_binary_idx\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eb930a0-9d16-481f-924f-dacb58190fb9",
+   "metadata": {},
+   "source": [
+    "### Class Weight Results\n",
+    "\n",
+    "The 4-class weights reflect the label imbalance introduced by the per-subreddit 75th-percentile thresholding scheme. Low-engagement (class 0) receives the smallest weight (0.530) because it is the majority class at 44.3% of the training set. Viral (class 1) is nearly balanced at 0.973, while crowd-pleaser (class 2, 14.0%) and debate-starter (class 3, 11.8%) receive the largest upweights (1.690 and 2.022 respectively) to compensate for their underrepresentation. The binary weights are close to 1.0 for both classes (0.946 and 1.060), consistent with a near-balanced binary split of 44.3% / 55.7% — the binary task requires minimal correction.\n",
+    "\n",
+    "These weights will be passed to `SparkXGBClassifier` via `weight_col` so that the boosting objective penalizes misclassification of minority classes proportionally during tree construction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24e66f58-a91b-48a7-b870-77d547b4f498",
+   "metadata": {},
+   "source": [
+    "### Joining Class Weights to Splits\n",
+    "\n",
+    "We broadcast-join the 4-class and binary weight maps onto all three splits. The join is essentially free, both weight maps are 4 rows and 2 rows respectively, so Spark resolves them as broadcast hash joins with no shuffle.\n",
+    "\n",
+    "After joining, we project each split down to only the three columns XGBoost needs (`features`, `label_4class_idx`, `weight_4class`). This avoids loading the full wide DataFrame which preserves all original columns including raw text and metadata into the XGBoost DMatrix during training, significantly reducing memory pressure on the JVM. The full-width `train_w`, `val_w`, and `test_w` are retained as lazy DataFrames for any post-hoc analysis in evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ce0a55a4-e268-4f41-9e64-90f9c18bdc58",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Weight join complete. Projected splits ready for training.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def attach_weights(df, wmap_4, wmap_2):\n",
+    "    return (\n",
+    "        df\n",
+    "        .join(F.broadcast(wmap_4), on=\"label_4class_idx\", how=\"left\")\n",
+    "        .join(F.broadcast(wmap_2), on=\"label_binary_idx\", how=\"left\")\n",
+    "    )\n",
+    "\n",
+    "train_w = attach_weights(train_df, weight_map_4, weight_map_2)\n",
+    "val_w   = attach_weights(val_df,   weight_map_4, weight_map_2)\n",
+    "test_w  = attach_weights(test_df,  weight_map_4, weight_map_2)\n",
+    "\n",
+    "# Project down to only what XGBoost needs — avoids loading wide DataFrame into DMatrix\n",
+    "train_xgb = train_w.select(\"features\", \"label_4class_idx\", \"weight_4class\").repartition(16)\n",
+    "val_xgb   = val_w.select(\"features\", \"label_4class_idx\", \"weight_4class\").repartition(16)\n",
+    "test_xgb  = test_w.select(\"features\", \"label_4class_idx\", \"weight_4class\").repartition(16)\n",
+    "\n",
+    "print(\"Weight join complete. Projected splits ready for training.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b333d291-06d7-4450-bfe6-922066e4605b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "train_xgb partitions: 16\n",
+      "val_xgb partitions:   16\n",
+      "test_xgb partitions:  16\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"train_xgb partitions: {train_xgb.rdd.getNumPartitions()}\")\n",
+    "print(f\"val_xgb partitions:   {val_xgb.rdd.getNumPartitions()}\")\n",
+    "print(f\"test_xgb partitions:  {test_xgb.rdd.getNumPartitions()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8494758-9695-4c43-bd64-f39f9fde354b",
+   "metadata": {},
+   "source": [
+    "### XGBoost Model Configurations - 4-Class Model\n",
+    "\n",
+    "We train two configurations on the 4-class problem to analyze the underfitting/overfitting tradeoff.\n",
+    "\n",
+    "**Config A — Conservative (shallow, regularized):** `max_depth=4`, low learning rate, strong L2 regularization. Prioritizes stability; expected to underfit slightly given the complexity of 19 features across 102K subreddits.\n",
+    "\n",
+    "**Config B — Aggressive (deep, fast learning):** `max_depth=8`, higher learning rate, light regularization. Risks overfitting on subreddit-level aggregation features that may encode training-period-specific behavior given the temporal train/val/test split.\n",
+    "\n",
+    "Both configs target the 4-class label. `SparkXGBClassifier` sets the multiclass objective internally and uses `mlogloss` as the default evaluation metric — neither is passed explicitly. To avoid JVM OOM in `local[*]` mode, we use `num_workers=1` with `nthread=16` so XGBoost runs as a single worker using all 16 cores via multithreaded tree-building rather than 16 concurrent booster instances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6fa83ce9-a934-483c-85d0-d3eebdd7142e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config A and Config B defined.\n"
+     ]
+    }
+   ],
+   "source": [
+    "COMMON_PARAMS = dict(\n",
+    "    features_col=\"features\",\n",
+    "    label_col=\"label_4class_idx\",\n",
+    "    weight_col=\"weight_4class\",\n",
+    "    num_class=4,\n",
+    "    num_workers=16, # Match partition size / core config\n",
+    "    device=\"cpu\",\n",
+    "    seed=42,\n",
+    ")\n",
+    "\n",
+    "# Config A: conservative — shallow trees, strong regularization\n",
+    "config_A = SparkXGBClassifier(\n",
+    "    **COMMON_PARAMS,\n",
+    "    max_depth=4,\n",
+    "    n_estimators=200,\n",
+    "    learning_rate=0.05,\n",
+    "    subsample=0.8,\n",
+    "    colsample_bytree=0.8,\n",
+    "    reg_lambda=5.0,\n",
+    "    reg_alpha=1.0,\n",
+    "    min_child_weight=50,\n",
+    ")\n",
+    "\n",
+    "# Config B: aggressive — deep trees, faster learning, light regularization\n",
+    "config_B = SparkXGBClassifier(\n",
+    "    **COMMON_PARAMS,\n",
+    "    max_depth=8,\n",
+    "    n_estimators=300,\n",
+    "    learning_rate=0.1,\n",
+    "    subsample=0.7,\n",
+    "    colsample_bytree=0.7,\n",
+    "    reg_lambda=1.0,\n",
+    "    reg_alpha=0.0,\n",
+    "    min_child_weight=10,\n",
+    ")\n",
+    "\n",
+    "print(\"Config A and Config B defined.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9362aa81-c6cc-430e-9db6-ea0d3a3de1a8",
+   "metadata": {},
+   "source": [
+    "### Training Config A (Conservative)\n",
+    "\n",
+    "SparkXGBClassifier distributes tree-building across 16 Spark workers, each processing ~17M rows in parallel within the single JVM. Open the Spark UI at port 4040 during training to capture the parallelism screenshot required by the milestone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "58345041-2282-4e9f-9d5c-03eed1d2d035",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create directories\n",
+    "\n",
+    "import os\n",
+    "os.makedirs(\"../outputs/models/xgb_config_A_checkpoints\", exist_ok=True)\n",
+    "os.makedirs(\"../outputs/models\", exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "46bcacdd-0fe1-4ce0-af9d-20ed7a8bf5f5",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training Config A...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-09 01:33:24,408 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'multi:softprob', 'colsample_bytree': 0.8, 'device': 'cpu', 'learning_rate': 0.05, 'max_depth': 4, 'min_child_weight': 50, 'reg_alpha': 1.0, 'reg_lambda': 5.0, 'subsample': 0.8, 'num_class': 4, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 200}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n",
+      "2026-05-09 02:32:05,254 INFO XGBoost-PySpark: _fit Finished xgboost training!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config A training time: 3610.9s\n",
+      "Config A saved.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "print(\"Training Config A...\")\n",
+    "t0 = time.time()\n",
+    "\n",
+    "model_A = config_A.fit(train_xgb)\n",
+    "elapsed_A = time.time() - t0\n",
+    "print(f\"Config A training time: {elapsed_A:.1f}s\")\n",
+    "\n",
+    "model_A.write().overwrite().save(\"../outputs/models/xgb_config_A\")\n",
+    "print(\"Config A saved.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26d61a53-2a29-4147-97d6-e194777a348d",
+   "metadata": {},
+   "source": [
+    "#### Spark UI — Executor Summary\n",
+    "\n",
+    "Querying the Spark REST API to document executor configuration and confirm distributed execution for Config A."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "3ba3a96f-759e-4182-8397-814572fab32e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       id  totalCores    maxMemory  activeTasks  isActive  maxMemory_GB\n",
+      "0  driver          16  77120667648            0      True         71.82\n",
+      "\n",
+      "Spark master: local[*]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import requests\n",
+    "import pandas as pd\n",
+    "\n",
+    "sc = spark.sparkContext\n",
+    "url = f\"{sc.uiWebUrl}/api/v1/applications/{sc.applicationId}/executors\"\n",
+    "\n",
+    "executors = requests.get(url).json()\n",
+    "\n",
+    "sparkUI_df = pd.DataFrame(executors)[['id', 'totalCores', 'maxMemory', 'activeTasks', 'isActive']]\n",
+    "sparkUI_df['maxMemory_GB'] = (sparkUI_df['maxMemory'] / (1024**3)).round(2)\n",
+    "print(sparkUI_df)\n",
+    "print(f\"\\nSpark master: {sc.master}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1653c4f-5e4a-47c0-8be9-fdda3462a7e0",
+   "metadata": {},
+   "source": [
+    "### Training Config B (Aggressive)\n",
+    "\n",
+    "Same distributed setup as Config A w/ 16 workers each processing ~17M rows. Deeper trees and faster learning rate are expected to produce a larger model with longer training time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "667afab3-f03d-478f-93f7-7e8f27acefa5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training Config B...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-09 03:47:32,161 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'multi:softprob', 'colsample_bytree': 0.7, 'device': 'cpu', 'learning_rate': 0.1, 'max_depth': 8, 'min_child_weight': 10, 'reg_alpha': 0.0, 'reg_lambda': 1.0, 'subsample': 0.7, 'num_class': 4, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 300}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n",
+      "2026-05-09 05:43:11,075 INFO XGBoost-PySpark: _fit Finished xgboost training!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config B training time: 7059.0s\n",
+      "Config B saved.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "print(\"Training Config B...\")\n",
+    "t0 = time.time()\n",
+    "\n",
+    "model_B = config_B.fit(train_xgb)\n",
+    "elapsed_B = time.time() - t0\n",
+    "print(f\"Config B training time: {elapsed_B:.1f}s\")\n",
+    "\n",
+    "model_B.write().overwrite().save(\"../outputs/models/xgb_config_B\")\n",
+    "print(\"Config B saved.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eebe1e08-e51b-4265-84fb-ffd06b176800",
+   "metadata": {},
+   "source": [
+    "### Reloading Persisted Models\n",
+    "\n",
+    "Both configs trained and saved in the previous session. Loading directly from disk to proceed with evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f56cb4f0-5a98-4b53-8d15-b6b7e329b68c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config A and Config B loaded successfully.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from xgboost.spark import SparkXGBClassifierModel\n",
+    "\n",
+    "model_A = SparkXGBClassifierModel.load(\"../outputs/models/xgb_config_A\")\n",
+    "model_B = SparkXGBClassifierModel.load(\"../outputs/models/xgb_config_B\")\n",
+    "\n",
+    "print(\"Config A and Config B loaded successfully.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be8cecb5-d77a-4e4d-a354-50d8bcc14372",
+   "metadata": {},
+   "source": [
+    "### Evaluation\n",
+    "\n",
+    "We evaluate both models across all three splits using weighted F1, accuracy, weighted precision, and weighted recall. Per-class precision, recall, and F1 are derived from the confusion matrix directly, which is reliable across all Spark versions. The train/val/test error gap is the primary diagnostic for over and underfitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4f45e661-0a23-4e5e-872f-bef9358b6526",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "====== Config A ======\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/spark/python/pyspark/sql/context.py:158: FutureWarning: Deprecated in 3.0.0. Use SparkSession.builder.getOrCreate() instead.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Train ---\n",
+      "  Weighted F1:    0.5283\n",
+      "  Accuracy:       0.5049\n",
+      "  W-Precision:    0.5911\n",
+      "  W-Recall:       0.5049\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7309  R=0.5075  F1=0.599\n",
+      "    viral                P=0.6517  R=0.504  F1=0.5684\n",
+      "    crowd-pleaser        P=0.3324  R=0.5345  F1=0.4099\n",
+      "    debate-starter       P=0.2417  R=0.4615  F1=0.3172\n",
+      "\n",
+      "--- Val ---\n",
+      "  Weighted F1:    0.5759\n",
+      "  Accuracy:       0.5531\n",
+      "  W-Precision:    0.6270\n",
+      "  W-Recall:       0.5531\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7287  R=0.5146  F1=0.6032\n",
+      "    viral                P=0.747  R=0.6574  F1=0.6993\n",
+      "    crowd-pleaser        P=0.3408  R=0.487  F1=0.401\n",
+      "    debate-starter       P=0.2364  R=0.4555  F1=0.3113\n",
+      "\n",
+      "--- Test ---\n",
+      "  Weighted F1:    0.5689\n",
+      "  Accuracy:       0.5463\n",
+      "  W-Precision:    0.6111\n",
+      "  W-Recall:       0.5463\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7059  R=0.5393  F1=0.6115\n",
+      "    viral                P=0.7402  R=0.6538  F1=0.6943\n",
+      "    crowd-pleaser        P=0.2935  R=0.3767  F1=0.3299\n",
+      "    debate-starter       P=0.2301  R=0.4339  F1=0.3007\n",
+      "\n",
+      "====== Config B ======\n",
+      "\n",
+      "--- Train ---\n",
+      "  Weighted F1:    0.5767\n",
+      "  Accuracy:       0.5564\n",
+      "  W-Precision:    0.6317\n",
+      "  W-Recall:       0.5564\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7557  R=0.5722  F1=0.6513\n",
+      "    viral                P=0.7051  R=0.5162  F1=0.5961\n",
+      "    crowd-pleaser        P=0.4072  R=0.6035  F1=0.4863\n",
+      "    debate-starter       P=0.2743  R=0.523  F1=0.3599\n",
+      "\n",
+      "--- Val ---\n",
+      "  Weighted F1:    0.6089\n",
+      "  Accuracy:       0.5868\n",
+      "  W-Precision:    0.6590\n",
+      "  W-Recall:       0.5868\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7527  R=0.5608  F1=0.6428\n",
+      "    viral                P=0.7809  R=0.6522  F1=0.7107\n",
+      "    crowd-pleaser        P=0.3927  R=0.5603  F1=0.4618\n",
+      "    debate-starter       P=0.2669  R=0.5134  F1=0.3512\n",
+      "\n",
+      "--- Test ---\n",
+      "  Weighted F1:    0.5866\n",
+      "  Accuracy:       0.5642\n",
+      "  W-Precision:    0.6309\n",
+      "  W-Recall:       0.5642\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7261  R=0.5597  F1=0.6321\n",
+      "    viral                P=0.7527  R=0.6415  F1=0.6927\n",
+      "    crowd-pleaser        P=0.3295  R=0.4571  F1=0.3829\n",
+      "    debate-starter       P=0.2525  R=0.4649  F1=0.3272\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.ml.evaluation import MulticlassClassificationEvaluator\n",
+    "from pyspark.mllib.evaluation import MulticlassMetrics\n",
+    "\n",
+    "def evaluate_model(model, df, label_col=\"label_4class_idx\", split_name=\"\"):\n",
+    "    preds = model.transform(df)\n",
+    "    \n",
+    "    # Overall metrics via MLlib evaluator\n",
+    "    evaluator = MulticlassClassificationEvaluator(\n",
+    "        labelCol=label_col,\n",
+    "        predictionCol=\"prediction\",\n",
+    "    )\n",
+    "    metrics = {}\n",
+    "    for metric in (\"f1\", \"accuracy\", \"weightedPrecision\", \"weightedRecall\"):\n",
+    "        evaluator.setMetricName(metric)\n",
+    "        metrics[metric] = evaluator.evaluate(preds)\n",
+    "\n",
+    "    # Per-class metrics via confusion matrix — reliable across all Spark versions\n",
+    "    preds_and_labels = preds.select(\"prediction\", label_col) \\\n",
+    "                            .rdd.map(lambda r: (float(r[0]), float(r[1])))\n",
+    "    mm = MulticlassMetrics(preds_and_labels)\n",
+    "    \n",
+    "    per_class = {}\n",
+    "    for cls in range(4):\n",
+    "        per_class[cls] = {\n",
+    "            \"precision\": round(mm.precision(float(cls)), 4),\n",
+    "            \"recall\":    round(mm.recall(float(cls)), 4),\n",
+    "            \"f1\":        round(mm.fMeasure(float(cls)), 4),\n",
+    "        }\n",
+    "\n",
+    "    print(f\"\\n--- {split_name} ---\")\n",
+    "    print(f\"  Weighted F1:    {metrics['f1']:.4f}\")\n",
+    "    print(f\"  Accuracy:       {metrics['accuracy']:.4f}\")\n",
+    "    print(f\"  W-Precision:    {metrics['weightedPrecision']:.4f}\")\n",
+    "    print(f\"  W-Recall:       {metrics['weightedRecall']:.4f}\")\n",
+    "    print(f\"  Per-class metrics:\")\n",
+    "    for cls, m in per_class.items():\n",
+    "        label = {0: \"low-engagement\", 1: \"viral\", 2: \"crowd-pleaser\", 3: \"debate-starter\"}[cls]\n",
+    "        print(f\"    {label:20s} P={m['precision']}  R={m['recall']}  F1={m['f1']}\")\n",
+    "    \n",
+    "    return metrics, per_class\n",
+    "\n",
+    "results = {}\n",
+    "for name, model in [(\"A\", model_A), (\"B\", model_B)]:\n",
+    "    print(f\"\\n====== Config {name} ======\")\n",
+    "    tr_m,  tr_pc  = evaluate_model(model, train_xgb, split_name=\"Train\")\n",
+    "    val_m, val_pc = evaluate_model(model, val_xgb,   split_name=\"Val\")\n",
+    "    te_m,  te_pc  = evaluate_model(model, test_xgb,  split_name=\"Test\")\n",
+    "    results[name] = {\"train\": tr_m, \"val\": val_m, \"test\": te_m}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4cc6acb-f080-4f6a-ada5-a01c94428661",
+   "metadata": {},
+   "source": [
+    "### Persisting Evaluation Results\n",
+    "\n",
+    "Evaluation results are saved to disk to avoid re-running the full scoring pipeline across 535M rows on every kernel restart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9bbcf737-1f45-4a12-8663-3bc0bcbf7c59",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Results saved to ../outputs/xgboost_4class_evaluation_results.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "RESULTS_PATH = \"../outputs/xgboost_4class_evaluation_results.json\"\n",
+    "\n",
+    "# Convert results dict to JSON-serializable format\n",
+    "results_serializable = {\n",
+    "    config: {\n",
+    "        split: {\n",
+    "            metric: float(val)\n",
+    "            for metric, val in metrics.items()\n",
+    "        }\n",
+    "        for split, metrics in splits.items()\n",
+    "    }\n",
+    "    for config, splits in results.items()\n",
+    "}\n",
+    "\n",
+    "with open(RESULTS_PATH, \"w\") as f:\n",
+    "    json.dump(results_serializable, f, indent=2)\n",
+    "\n",
+    "print(f\"Results saved to {RESULTS_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e3edc181-46f1-4fce-8607-050034fbe5b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Results loaded from disk.\n",
+      "{\n",
+      "  \"A\": {\n",
+      "    \"train\": {\n",
+      "      \"f1\": 0.5283424471810294,\n",
+      "      \"accuracy\": 0.5048856400182672,\n",
+      "      \"weightedPrecision\": 0.5911198128323302,\n",
+      "      \"weightedRecall\": 0.5048856400182673\n",
+      "    },\n",
+      "    \"val\": {\n",
+      "      \"f1\": 0.5759404285528308,\n",
+      "      \"accuracy\": 0.5531042222618696,\n",
+      "      \"weightedPrecision\": 0.6270222511990466,\n",
+      "      \"weightedRecall\": 0.5531042222618696\n",
+      "    },\n",
+      "    \"test\": {\n",
+      "      \"f1\": 0.5689253442074707,\n",
+      "      \"accuracy\": 0.5463398341454108,\n",
+      "      \"weightedPrecision\": 0.6111074982497237,\n",
+      "      \"weightedRecall\": 0.5463398341454108\n",
+      "    }\n",
+      "  },\n",
+      "  \"B\": {\n",
+      "    \"train\": {\n",
+      "      \"f1\": 0.5766723214878866,\n",
+      "      \"accuracy\": 0.5563592635077068,\n",
+      "      \"weightedPrecision\": 0.6316884701299854,\n",
+      "      \"weightedRecall\": 0.5563592635077068\n",
+      "    },\n",
+      "    \"val\": {\n",
+      "      \"f1\": 0.6088603729693711,\n",
+      "      \"accuracy\": 0.5868066571241337,\n",
+      "      \"weightedPrecision\": 0.6589766816611697,\n",
+      "      \"weightedRecall\": 0.5868066571241337\n",
+      "    },\n",
+      "    \"test\": {\n",
+      "      \"f1\": 0.5866071217774935,\n",
+      "      \"accuracy\": 0.5641812863873193,\n",
+      "      \"weightedPrecision\": 0.6308736760217246,\n",
+      "      \"weightedRecall\": 0.5641812863873195\n",
+      "    }\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reload Results JSON \n",
+    "\n",
+    "import json\n",
+    "\n",
+    "RESULTS_PATH = \"../outputs/xgboost_4class_evaluation_results.json\"\n",
+    "\n",
+    "with open(RESULTS_PATH, \"r\") as f:\n",
+    "    results = json.load(f)\n",
+    "\n",
+    "print(\"Results loaded from disk.\")\n",
+    "print(json.dumps(results, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ebe4bc6-ab88-491a-9f72-f5dbeeb67683",
+   "metadata": {},
+   "source": [
+    "### Results Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ca904e87-8855-40d0-9fd6-318d1dc3ee13",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                Weighted F1  Accuracy  W-Precision  W-Recall\n",
+      "Config   Split                                              \n",
+      "Config A train       0.5283    0.5049       0.5911    0.5049\n",
+      "         val         0.5759    0.5531       0.6270    0.5531\n",
+      "         test        0.5689    0.5463       0.6111    0.5463\n",
+      "Config B train       0.5767    0.5564       0.6317    0.5564\n",
+      "         val         0.6089    0.5868       0.6590    0.5868\n",
+      "         test        0.5866    0.5642       0.6309    0.5642\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "CLASS_LABELS = {0: \"low-engagement\", 1: \"viral\", 2: \"crowd-pleaser\", 3: \"debate-starter\"}\n",
+    "\n",
+    "rows = []\n",
+    "for config_name, splits in results.items():\n",
+    "    for split_name, metrics in splits.items():\n",
+    "        rows.append({\n",
+    "            \"Config\":      f\"Config {config_name}\",\n",
+    "            \"Split\":       split_name,\n",
+    "            \"Weighted F1\": round(metrics[\"f1\"], 4),\n",
+    "            \"Accuracy\":    round(metrics[\"accuracy\"], 4),\n",
+    "            \"W-Precision\": round(metrics[\"weightedPrecision\"], 4),\n",
+    "            \"W-Recall\":    round(metrics[\"weightedRecall\"], 4),\n",
+    "        })\n",
+    "\n",
+    "summary_df = pd.DataFrame(rows).set_index([\"Config\", \"Split\"])\n",
+    "print(summary_df.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71fb1e34-1a71-4492-8db3-5bf81c39194f",
+   "metadata": {},
+   "source": [
+    "### Fitting Analysis - 4-Class\n",
+    "\n",
+    "#### Underfitting vs. Overfitting\n",
+    "\n",
+    "Both configurations sit clearly in the underfitting region of the bias-variance spectrum. The hallmark of overfitting is train performance significantly exceeding val/test performance — the opposite pattern appears here. Config A's train weighted F1 (0.5283) is nearly 5 points below its val F1 (0.5759), and Config B shows the same pattern (train 0.5767 vs val 0.6089). This is not a sign of a well-fitted model — it indicates the models are not fully capturing the signal available in the training data.\n",
+    "\n",
+    "The likely cause is temporal distribution shift. The training set spans 2012–2016, a period covering Reddit's early growth phase through its mainstream expansion, producing a wide and noisy distribution of posting and engagement behavior. The 2017 validation and 2018 test sets represent a more mature, behaviorally stable platform where subreddit norms are more consistent and posting patterns are more predictable. The model generalizes better to these later years not because it has learned to generalize well, but because the later data is inherently less noisy.\n",
+    "\n",
+    "A secondary contributor is the feature ceiling imposed by restricting to pre-publication signals only. With 19 features — many of which are structural title properties and community-level aggregates — the model lacks access to the semantic content of posts, which is likely a strong predictor of engagement. This hard ceiling on expressiveness means even a perfectly tuned model would underfit relative to what is achievable with richer features.\n",
+    "\n",
+    "#### Which Configuration Performs Best and Why\n",
+    "\n",
+    "Config B (aggressive) outperforms Config A (conservative) consistently across every split and every metric. On the test set, Config B achieves a weighted F1 of 0.5866 versus Config A's 0.5689 — a meaningful gap. The deeper trees (max_depth=8 vs 4) and higher learning rate (0.1 vs 0.05) allow Config B to capture more complex feature interactions, particularly the relationship between subreddit-level aggregates and engagement thresholds. The lighter regularization (reg_lambda=1.0 vs 5.0) also allows the model to fit minority classes more aggressively, which is reflected in Config B's higher crowd-pleaser and debate-starter F1 scores across all splits.\n",
+    "\n",
+    "Notably Config B does not overfit despite being the more aggressive configuration — its train/val gap is similar to Config A's, confirming that the underfitting is driven by the feature set and data distribution rather than by regularization being too weak.\n",
+    "\n",
+    "#### Per-Class Performance\n",
+    "\n",
+    "Both configs show a clear performance hierarchy across classes that directly reflects class frequency and signal clarity. Low-engagement and viral — the two majority classes — are learned most reliably, with test F1 scores in the 0.61–0.69 range for Config B. Crowd-pleaser and debate-starter — the two minority classes at 14.0% and 11.8% respectively — are substantially harder, with test F1 scores of 0.38 and 0.33 for Config B despite inverse-frequency class weighting. The low precision on these classes (0.25–0.33) indicates frequent false positives — the model over-predicts these classes relative to how often it is correct when it does.\n",
+    "\n",
+    "This pattern suggests that the distinction between crowd-pleaser (high score, low comments) and debate-starter (low score, high comments) is particularly difficult to capture from pre-publication features alone, as these engagement patterns are more likely driven by post content and community dynamics that emerge after publication."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e88a174-1b26-4ab0-b88e-aa4acd23ebe0",
+   "metadata": {},
+   "source": [
+    "### Sample Predictions - 4-Class Model\n",
+    "\n",
+    "Representative examples of ground truth labels versus model predictions across train, validation, and test splits for both configurations. Class index mapping: 0 = low-engagement, 1 = viral, 2 = crowd-pleaser, 3 = debate-starter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6e0c7acf-cfc2-4cf5-a0eb-dba929f0e3dd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "====== Config A ======\n",
+      "\n",
+      "--- Train (n=5 per class) ---\n",
+      "    true_label predicted_label  correct\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "         viral  low-engagement    False\n",
+      "         viral  low-engagement    False\n",
+      "         viral  low-engagement    False\n",
+      "         viral  low-engagement    False\n",
+      "         viral  debate-starter    False\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser  low-engagement    False\n",
+      "debate-starter  debate-starter     True\n",
+      "debate-starter  low-engagement    False\n",
+      "debate-starter  debate-starter     True\n",
+      "debate-starter   crowd-pleaser    False\n",
+      "debate-starter  low-engagement    False\n",
+      "\n",
+      "--- Val (n=5 per class) ---\n",
+      "    true_label predicted_label  correct\n",
+      "low-engagement  debate-starter    False\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement   crowd-pleaser    False\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser           viral    False\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter  debate-starter     True\n",
+      "\n",
+      "--- Test (n=5 per class) ---\n",
+      "    true_label predicted_label  correct\n",
+      "low-engagement           viral    False\n",
+      "low-engagement   crowd-pleaser    False\n",
+      "low-engagement  debate-starter    False\n",
+      "low-engagement  debate-starter    False\n",
+      "low-engagement   crowd-pleaser    False\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser           viral    False\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser  debate-starter    False\n",
+      " crowd-pleaser           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "\n",
+      "====== Config B ======\n",
+      "\n",
+      "--- Train (n=5 per class) ---\n",
+      "    true_label predicted_label  correct\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "         viral  low-engagement    False\n",
+      "         viral  low-engagement    False\n",
+      "         viral   crowd-pleaser    False\n",
+      "         viral  low-engagement    False\n",
+      "         viral  debate-starter    False\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser  debate-starter    False\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      "debate-starter  low-engagement    False\n",
+      "debate-starter  low-engagement    False\n",
+      "debate-starter  debate-starter     True\n",
+      "debate-starter   crowd-pleaser    False\n",
+      "debate-starter  low-engagement    False\n",
+      "\n",
+      "--- Val (n=5 per class) ---\n",
+      "    true_label predicted_label  correct\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  debate-starter    False\n",
+      "low-engagement  low-engagement     True\n",
+      "low-engagement  low-engagement     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser           viral    False\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter  debate-starter     True\n",
+      "debate-starter           viral    False\n",
+      "debate-starter  debate-starter     True\n",
+      "\n",
+      "--- Test (n=5 per class) ---\n",
+      "    true_label predicted_label  correct\n",
+      "low-engagement           viral    False\n",
+      "low-engagement   crowd-pleaser    False\n",
+      "low-engagement  debate-starter    False\n",
+      "low-engagement  debate-starter    False\n",
+      "low-engagement   crowd-pleaser    False\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      "         viral           viral     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      " crowd-pleaser  debate-starter    False\n",
+      " crowd-pleaser   crowd-pleaser     True\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n",
+      "debate-starter           viral    False\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "CLASS_MAP = {0.0: \"low-engagement\", 1.0: \"viral\", 2.0: \"crowd-pleaser\", 3.0: \"debate-starter\"}\n",
+    "SAMPLE_PER_CLASS = 5  # 5 examples per class = 20 total per split\n",
+    "\n",
+    "for name, model in [(\"A\", model_A), (\"B\", model_B)]:\n",
+    "    print(f\"\\n====== Config {name} ======\")\n",
+    "    for split_name, df in [(\"Train\", train_xgb), (\"Val\", val_xgb), (\"Test\", test_xgb)]:\n",
+    "        preds = model.transform(df).select(\"label_4class_idx\", \"prediction\")\n",
+    "        \n",
+    "        # Stratified sample — 5 rows per true class\n",
+    "        samples = []\n",
+    "        for cls in range(4):\n",
+    "            cls_sample = preds.filter(F.col(\"label_4class_idx\") == cls) \\\n",
+    "                              .limit(SAMPLE_PER_CLASS) \\\n",
+    "                              .toPandas()\n",
+    "            samples.append(cls_sample)\n",
+    "        \n",
+    "        sample_df = pd.concat(samples, ignore_index=True)\n",
+    "        sample_df[\"true_label\"]      = sample_df[\"label_4class_idx\"].map(CLASS_MAP)\n",
+    "        sample_df[\"predicted_label\"] = sample_df[\"prediction\"].map(CLASS_MAP)\n",
+    "        sample_df[\"correct\"]         = sample_df[\"label_4class_idx\"] == sample_df[\"prediction\"]\n",
+    "        \n",
+    "        print(f\"\\n--- {split_name} (n={SAMPLE_PER_CLASS} per class) ---\")\n",
+    "        print(sample_df[[\"true_label\", \"predicted_label\", \"correct\"]].to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1addf53-6241-483c-9595-844123608519",
+   "metadata": {},
+   "source": [
+    "### Sample Predictions - 4 Class\n",
+    "\n",
+    "The tables below show stratified examples of ground truth versus predicted labels across train, validation, and test splits for both configurations (5 examples per class, 20 total per split). Rows are grouped by true label to illustrate per-class prediction behavior.\n",
+    "\n",
+    "Both configs correctly identify low-engagement and viral posts with reasonable consistency, reflecting their stronger per-class F1 scores in the aggregate evaluation. Minority class predictions are notably less reliable. Debate-starter posts are frequently misclassified as viral in the val and test splits, which aligns with the low precision scores (0.24–0.27) observed in the full evaluation. However, this confusion is interpretable: debate-starter posts by definition generate high comment counts relative to their score, and without access to post content the model has limited signal to distinguish these from viral posts beyond subreddit-level aggregates."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd7f751e-7347-45c5-9131-7095965ce632",
+   "metadata": {},
+   "source": [
+    "### Feature Importance - 4-Class Model\n",
+    "\n",
+    "We extract feature importance scores from both trained XGBoost configurations using the `weight` metric which is the number of times each feature appears in a split across all trees. Higher weight indicates the feature was more frequently selected by the booster as a useful split criterion. Config B's deeper trees produce more total splits, so absolute weights are larger but the relative ranking is what matters for comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "37ceddd9-eaad-4226-aa5e-60fe1050be7e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABjIAAAMsCAYAAAD+vjuEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdeVxN6eMH8M9t31eKSCWytAhFsmbLvmYLFWGMfSyDWaxjzIixD2PGPhj7OpbByL4v2UIoMUKKUiLV8/ujX+d7T902oovP+/W6r9e951nPdu+55znP8yiEEAJERERERERERERERERqSKO4K0BERERERERERERERJQbNmQQEREREREREREREZHaYkMGERERERERERERERGpLTZkEBERERERERERERGR2mJDBhERERERERERERERqS02ZBARERERERERERERkdpiQwYREREREREREREREaktNmQQEREREREREREREZHaYkMGERERERERERERERGpLTZkEBERERHRRykoKAgKhQIKhQKNGjUq7uoQfVRWrFghnT8KhaK4q5On/M71M2fOoEWLFrCwsICGhoZsnSZNmiR9tre3/7AVLyB7e3upjpMmTSru6hAREaklNmQQEdFH6c6dOzAyMpL+9LVq1SpHnIyMDDRs2FCKY2pqiujo6Bzx4uLiMHPmTPj6+sLGxgb6+vowMTGBk5MTGjVqhEmTJuHMmTMQQkhpoqKiZH/+s16ampowNjZGlSpV0LdvX5w7d+69boei9q5/pFVtk+yv4rqJ8KndJMh+Ayo0NLS4q/TBfWr79GOUlpaGmjVryo7FoKCgt85PCIFdu3ahV69eqFixIoyNjWFgYICKFSuiVatW+P333xEfH190K6Am1Pm7k96/omxQCAsLw9ChQ+Hu7g4LCwvo6uqiXLlyqF+/PqZNm4Y7d+4UUa3Vx6NHj9CyZUvs27cPz549k12vqQP+VhERERUNreKuABER0dtwdHTErFmzMHDgQADAnj17sHjxYukzAMyePRtHjhyRPs+fPx/lypWT5bN06VKMGDECSUlJsuWvXr3CixcvEBERgcOHD2Py5MmIjIzM90ZSRkYGkpKScOPGDdy4cQOrVq3Cli1b0K5du3dcYyIi9TN9+nRcuHChSPK6d+8eevTogZMnT+YIu337Nm7fvo09e/bg2rVrmDNnTpGUSfSpSElJwdChQ7F06dIcYffv38f9+/dx7NgxbNy4EZcuXfrwFXxH3bt3h4uLCwDA1tZWFrZ3716pgVOhUGDIkCGy673mzZvDyMgIAGBqavqBalw43377LRISEgAA3t7exVwbIiIi9cSGDCIi+mh98cUX2LFjB3bv3g0AGD16NJo1awZHR0dcv34d3333nRS3Y8eOCAgIkKWfPXs2Ro4cKX1WKBTw8fFB7dq1YWJigvj4eISFheHo0aNISUnJsy7NmjVD8+bNkZGRgevXr2PVqlUQQiA9PR0TJkz4LBsyPDw80K1btxzL1fUmwvvy4sULGBsbF3c1Phncnurj8uXLmDp1apHk9ejRIzRs2BD37t2Tljk6OqJNmzawtrZGfHw8Tpw4gRMnThRJeeqM351UWOnp6fDz85OuhwDAzMwMnTp1gqOjI1JSUnDp0iXs37+/GGv5blq0aIEWLVqoDFPubVumTBnMmzdPFu7t7a32jQP9+/cv7ioQERGpP0FERPQRe/jwobC0tBQABADh7e0tUlJSRI0aNaRl1tbW4smTJ7J04eHhQktLS4pTokQJcfLkSZVlJCcniyVLlojY2FhpWWRkpJQWgJg4caIsTZs2baQwXV1dlflu3LhRtGzZUlhZWQktLS1hbm4u6tevLxYuXChev36tMs2NGzfEF198ISpUqCD09PSEgYGBqFSpkhg6dKiIjIzMET82NlaMGjVKVK1aVRgYGAhtbW1hbW0tPD09xeDBg6V1DgwMlK2PqldBKMcPDAwsUJq0tDSxYsUK0aRJE1GiRAmhpaUlSpYsKdq1ayf+/fffHPEfP34sRo8eLXx8fES5cuWEkZGR0NbWFlZWVqJZs2Zi9erVIiMjQ4pfmHVTXrZ8+XJZuQ0bNlS5btmPhX///VcsXLhQuLi4CF1dXdGwYUNZPlu3bhVt2rQRpUqVEtra2sLc3Fw0bdpUbN68uUDbK8vy5ctl5R46dCjXsOfPn4uhQ4eKUqVKCQMDA9GoUSNx+vRpqf5+fn7CzMxMGBkZCV9fX3HlyhVZWdnX8dChQ2LVqlWiRo0aQk9PT5QsWVIEBweLx48fq6zrmTNnRK9evYSdnZ3Q0dERRkZGws3NTYwfPz7HuSmEEHZ2drJz68CBA6JBgwbC2NhY2v4F3acbNmwQ/v7+wtnZWZQsWVJoa2sLQ0NDUbVqVTFkyBCV5032fX3jxg3h5+cnzM3NhZ6envDy8pJtb2WxsbFi4sSJwtPTU5iamgodHR1RtmxZ0apVK7F9+/Yc8YvqePjQUlNThbu7uwAgPDw8RJkyZQp97ivr1q2bbP8NGjRIvHnzJke8q1evio0bN0qflY+F7Ofa4sWLhZ+fn6hUqZKwtLQUWlpawtjYWLi7u4uxY8fKvtOzREVFiQEDBkjfsbq6usLGxkZ4e3uLr776Sly/fl0Wf/ny5aJhw4ZS/mZmZsLJyUl07dpVLFy4sMDr/zbfndnPk9OnT4sWLVoIY2NjYWhoKJo2bSrCwsJUpv3999+l76gyZcqIESNGiMTExBx5ZklJSRHffPON8PX1FQ4ODsLExERoaWkJS0tLUb9+fTF//nyV++ttyspy4cIFERQUJBwcHISurq4wMjISHh4eYtasWSIlJSXPbbh8+XKxatUqUa1aNaGnpyccHR3FL7/8IoQQ4s2bN2LatGnCwcFB6OjoiMqVK4slS5aorHtKSoqYO3euqFevnjA3Nxfa2trCxsZG9OjRQ1y4cCFH/IkTJ0p1sLOzE8+ePRMjRowQZcuWFTo6OsLJyUn8+uuvUvzs362qXqq2TXaLFi2SpalTp454+vRpjnixsbFiwYIF0ufsvxXK9u/fL/r06SPc3d2FtbW10NHREfr6+qJChQqiT58+4vLlyznyT0pKEpMnTxbVq1cXRkZG0u95tWrVRL9+/cSePXtk8Y8cOSI6dOggbGxspO9mOzs70aJFCzFx4kTx/PlzKa6qc/3QoUN5bruseNn3S3YvXrwQM2fOlO3nUqVKicaNG4tly5ZJ8d7n9Ud+58O7/o4W5vuBiIhIXbEhg4iIPnobNmyQ/Sl0c3OTfd6xY0eONAMHDpTFKexNw9waMtLT08X169dFuXLlcv3TnJaWJrp27ZrnH9tatWrJ/sALIcT69euFnp5ermmMjY3Fvn37pPgpKSmiUqVKeZYzduxYIUTxNWQkJycLHx+fPMudNm2aLM3Zs2fzrWufPn2k+B+6IaNu3boqb6Skp6cLf3//POsxYMCAAm1nIQrXkFGzZs0cZenp6YkdO3bIGgKzXpaWlrIbI9nXsXHjxirrX6FChRw3z2bPni00NDRyXWdra+scNwSVb8B4eXkJTU3NHMdWQfdp69at84xnYmKS44ac8r52c3MTRkZGOdLp6OiIq1evytKdOnVKWFlZ5VqW8nFT1MfDh5Z1Y1BXV1dcu3ZNts8K25Dx8OFDoVAopPTu7u4iPT29QGnzashwdnbOc/uWKVNG/Pfff1L8x48fi5IlS+aZZtGiRTm2QV7HdkHldpzkRXmb16pVS9Y4n/WysLAQjx49kqUbN26cyvp6enoKa2tr6bPyzdTY2Nh8z7mmTZuKtLS0dy5LCCHmz5+f47zPnj77b6RyuKrvPADi+++/Fx07dlQZtnTpUll+jx8/Fq6urrnWQUtLS6xcuVKWRvmYsLS0FJUrV1aZNqvhpKgaMpR/6/X09GTHdV7yasgYPHhwnvXS0dER+/fvl6Vp1KhRnmm6desmxT1w4ECe+xiACA8Pl+K/r4aMiIgI4ejomG8eQrzf64+8GjLe9Xe0MN8PRERE6oxDSxER0UevS5cu6NmzJ9asWQMgc7iTLMHBwWjbtm2ONP/++6/03tzcHB07dnynOkyePBmTJ09WGTZ27FjZ52nTpmHDhg3S57p166JJkya4dOkSduzYAQA4c+YMvvjiC/z1118AgIiICAQEBOD169cAgJIlSyIwMBBpaWlYtmwZEhMT8eLFC3Tp0gW3bt2CtbU1Dh06hJs3bwIA9PT0EBwcjDJlyuDRo0e4ffs2Dh8+LNUha+zpH3/8Ec+ePQPwv+Gy3ta1a9cwc+bMHMuVh3gYMWIEDh06BADQ1dWFv78/ypcvj4sXL2LLli0AMseN9vDwkOqioaEBZ2dneHp6wtraGmZmZnj16hUuXryInTt3QgiB5cuXY+DAgahVq9Z7Wbe8HD9+HOXLl0enTp2gp6eHly9fAgB++uknrF27VlqHLl26wMXFBREREVizZg3S09OxZMkS1KxZEwMGDCjSOl28eBH9+vWDsbEx5s+fj7S0NLx69Qrt2rWDgYEBRowYgWfPnmHlypUAgLi4OCxduhTjxo1Tmd+///4LHx8f1K9fH8ePH8fBgwcBZM5jMHbsWPzxxx8AgMOHD2PkyJHSxKsODg7o3r074uPjsXz5cqSmpuLx48fo2LEjbt68CV1d3RxlnTp1CsbGxujZsydsbGxw7ty5Qu1Tc3NztGjRApUqVYK5uTl0dHTw+PFjbNmyBffv30diYiLGjh0rG5JF2eXLl1GiRAkMHDgQjx8/xurVqwEAqampmDdvHn777TcAQGJiItq1a4cnT55IaZs1awYvLy88f/48x2TsxXk8vKtLly7hxx9/BABMmTIFVatWfaf8Dh06JJucNzAwEBoaGu+UJwBYW1ujQoUKKF++PCwsLKBQKPDff/9hw4YNiIuLw3///YcffvgBv/76KwBg8+bNiI2NBZB53PTp0weWlpZ4+PAhbty4gaNHj8ryX7RokfS+SZMm8PHxQXJysjQXQX5DEuamIN+d2Z05cwZ2dnbo0aMHrl27hp07dwIA4uPjsWzZMowfPx4AcPbsWfz8889SOisrKwQGBuLFixdYtmwZUlNTVeavUChQoUIF1K5dGzY2NjA3N8ebN29w48YNbNy4EWlpaThw4AA2b96Mrl27vlNZx48fx7Bhw6Rjol69emjatCmeP3+OlStX4tmzZzh79iy+/PJL6RzK7vz586hTpw6aNm2K9evX49atWwAgDYXWqlUr1KhRA4sXL8bTp08BADNmzEDfvn2lPHr16oUrV64AyBzWq2fPnihVqhQOHz6MgwcPIi0tDf369UPNmjXh7Oycow5xcXF4/vw5+vbtC0tLSyxcuFD6PZg5cyb69+8PCwsLhISE4Ny5c1i/fr2UNiQkRHqf35BIDx8+lH7rAcDX1xc2NjZ5pikIIyMj+Pj4wNnZGRYWFtDX10dcXBz+/vtvhIeHIzU1FcOGDcP169cBAOHh4dL3nIaGBgICAuDk5ISnT58iMjIyx3fgkiVLkJ6eDgCoXLkyunTpAi0tLURHR+PSpUsFmnvH0dERISEh+Oeff6Rhs8zNzfHNN98AyDmXRnbp6eno0KGDbAJ0Ly8vNG7cGK9evcoxlF1xXH8Uxe9oQb8fiIiI1F5xtqIQEREVlWfPnonSpUvLnjQrW7asSExMVBnfwMBA9qSastyekOzcuXO+cbK/vvjiC9kwA2lpacLCwkIKr1evnuzJ4759+0phCoVC3L9/XwghxPDhw6XlGhoasuFNjhw5Iivzhx9+EEIIsWXLFmmZr69vjm3w6tUr8eDBA9my/IY2yE9BtklWvnFxcbKnMdeuXSvLq3v37lJYs2bNcpR17949sWnTJrFgwQIxc+ZMERISIhveZsqUKYVeN+V6vm2PjIoVK4qEhARZ2vT0dFnPhx9//FEWrvzUcsWKFfPYwv9TmB4ZWceEEPLtCkCsW7dOCvP09JSWd+rUKdd1bN68uXRcZ2RkiObNm0thurq6Ijk5WQghRPv27aXlxsbGsqF8Vq1aJcvzzz//lMKU95WWlpbKIUyyx8vreE1NTRVHjhwRS5cuFbNnzxYhISGiT58+sjqnpqZK8ZX3tYaGhmz4jQ4dOkhhNWrUkJbPnTtXtj4//fRTjnrcvXtXCPF+jocPJTU1VVSrVk0Amb1lsp7Af5ceGTNmzJBtu+zDz+Qlrx4ZQmT2+jpw4IBYsmSJ+OWXX0RISIjsuCxfvrwU95dffpF9d2eXlJQke3rZxMREih8TE5Mj/p07dwq8HoX57syivM2NjIxkdahevbrKc3nAgAGyY1u5V1H27w1V59Tjx4/F9u3bxa+//ip977q4uEhp+vbt+85lKfeY8PX1lf2G7t27V+VvZPZtWLVqVemcVk4DQLRo0UJKs3DhQllY1jVDWFiYbPmJEyekNBkZGaJOnTpSWP/+/aWw7L10lIdxmjNnjsqyVG2Pwjhz5owsbVZPy4LIr9z09HRx+vRpsWLFCjFnzhwREhIiRo4cKUsTHR0thMgcCixrWZUqVWT7TYjM65+oqCjpc7t27VT+DmWJiYmRfkuEyPtcz2/oqNzCt2/fLluXL7/8Mke9VZ3H7+P6I7c4RfE7WtDvByIiInXHHhlERPRJePDgAeLj42XLYmNjER0drfJJSWUKheKdy1ee7Pvu3btYtWoVUlJS8NtvvyE1NRXLli0DANy8eVNWT39/f9mTx4GBgVJcIQROnjyJLl26yJ4K9PDwQJUqVaTP9evXh4ODAyIjIwFAiuvp6QldXV28fv0a+/btg7OzM9zc3ODk5ITq1aujSZMmKFOmzDuv+9s6ffq09DQmkLkt/P39VcZVXv+4uDgEBgbi77//zjP/Bw8eFE1FC2nQoEEwMTGRLbt58ybi4uKkz9988430xGh2ERERePr0KUqUKFFkderZs6f03t7eXnqvra0NPz8/6bOTkxPOnj0LANLTo6r06tVLOm8UCgV69uyJf/75BwDw+vVrXL16FbVq1ZLtt5YtW8rWyd/fH8HBwXjz5g2AzH2sXM8srVu3hqura2FWV2bNmjUYMWKE9NS1Kq9fv8bTp09RunTpHGF16tSBm5ub9LlSpUrSe+VtdPz4cem9sbExRo8enSMvBwcHAEV/PCQmJmLJkiW5hhdUt27d8n2CeerUqQgLC4Oenh5WrFgBTU3NfPPNbZLurB4GQqk3RlH65ZdfMHHiRCQlJeUa57///pPe161bFwqFAkIILFmyBGfPnkXVqlVRqVIleHh4wMfHB9bW1lL8+vXrS99DLi4uqF27NipWrAhnZ2f4+PigQoUK72W9VGnfvj1KlSolfXZycsLFixcByI/T8+fPS++z9yTo1asX+vfvj7S0tBz5p6SkYNCgQVi1ahUyMjJyrYfy9+7blqV8Lu3bty/X3jlCCJw6dUr2HZalS5cu0NbWBiD/zgMyeyBmcXJykoU9e/YMxsbGsjoAefeKyG0Cek1NTQQHB0uflb87lMt6V+/r/Nm/fz/69esnm0hblQcPHsDW1hZVqlSBpaUl4uLiEB4ejgoVKqB69epwcnKCm5sbmjZtCjs7Oyld/fr1pV6oQUFB+O233+Dk5IRKlSqhbt26qFWrVpFcn+Ul+36eNGlSjjLLly8vvS+O64+i+B0t6PcDERGRumNDBhERffTevHmD3r17S8MuZXn9+jUCAgJw6tQp6YZGljJlyiAiIgJA5o1CIYT05zVrqAcAsuEA8uLt7S27cenl5YU+ffoAAJYvX44vvvgCtWvXzpGXlZWV7LPyTTLgf38wldNlT5OVLqshIytu2bJlsWLFCgwdOhRPnz7F9evXpSEggMxhI/744w9069Yt3/V7G4GBgVixYkWu4dkbnvKSnJyMlJQU6OvrIzg4ON+bCAByHA+Flf3mUEHzy35jDCjcugKZjXBF2ZCh3GClPOyElZUVtLT+dzmo/D6vm5VFcdxqamrC0tISjx49yhFXmartWVAXLlxAQEBAnuuSJbf9q3zjDZBvP+V8lfexra1tnjf4i/p4iI+Px5gxYwqVpyoeHh55NmTcv38f06dPB5A5RF72G7O5+eeff1QOvTdx4kR4e3ujbNmysuU3btxAixYtClHznLZt24ZRo0blG095v9eqVQu//PILvv/+eyQlJeHChQuy4W1KlCiBjRs3olGjRgAyh5bq2rUrTp06hbi4uBzDk3Xt2hXr1q0r9DBZ+X13qlLQ4/T58+fSe+Ubm0Dm+V+iRAnpnFQ2fvz4AtVJeXu+bVmFOT+yhgLLLrfvvOxhyt95wP+2VVHUwdraGnp6ernWoyDfSwWh6vx5Vw8fPkSHDh2kobDykrXP9fT0sGHDBvTp0wfR0dG4e/cu7t69K8XT0dHBTz/9hK+++gpA5tCSly9fxtq1a/H69WuEhobKhp9ycXHB/v37cxw7RUl5PxsYGKi8vlL2oa4/lBXF72hBvx+IiIjUHRsyiIjoozdx4kRcunRJ+jxo0CBpzPMLFy5gypQp0rjYWZo0aSI1ZMTHx2PHjh1o3749AMDExERqlFiwYMFbPa1Wq1Yt2eeTJ0+idu3aMDc3ly1XHk8fAB4/fiz7nBVfOV32NNnTKcft3r07OnfujDNnzuDKlSuIiIjAoUOHcPHiRSQlJSE4OBht2rSBoaFhIdfw3WXfFmPGjMnzJoKWlhaSk5Oxa9cuaVn37t0REhICGxsbaGhooFatWlKPgreR9TQ2ANn49lk9bQrCwMAgx7Ls69qvX788bwLndzOlsLI35GXJfhOvoPI7bs3MzABkrnfWTb7sadLT02W9ErJvoyyqtmdBbdy4UbpJY2hoiE2bNqFhw4bQ19fH7t270bp163zzyL7tcntC2MLCQnp///59pKen59qYUdzHw9uKi4uTnqAfNWpUrg0FK1euxMqVKwt8Q75Ro0ayc2/VqlUYNmzYO82ToTzfgI2NDTZv3ozq1atDV1cXv/76KwYPHqwy3YgRIzBgwACcOnUK165dQ0REBPbu3Sv1jAkKCkJUVBSAzAarkydP4vbt2zhz5gwiIiJw+fJl7NixA2lpadiwYQNatmyJoKCgt16PgirocZp1bgI5z8m0tLRcey4pb08fHx8sWbIEDg4O0NTURNeuXbFx48YiK0v5e8PHxwetWrVSGQ/I7DGlSm7feUDBvveyn6M//vhjrnnm9h1V0H3yrmxsbFCpUiVpnox9+/YhJiZGZQ+zgtq5c6fUiKFQKPDnn3+ibdu2MDY2xvXr13Pt6dq4cWNERkbiwoULuHTpEm7fvo0TJ07g6NGjSE1NxejRo9GuXTs4OjpCS0sLq1atwqxZs3DixAncvHkTN2/exNatW/Hs2TNcvXoV48aNK3SjXmEof2+/fPkSsbGxKFmypMq47/v6IzdF8Tv6oY5FIiKi940NGURE9FE7efIkZsyYIX3u378/Fi5ciKSkJKxatQoAMH36dLRp0wa1a9eW4g0ZMgS///67NLTRwIEDUa5cOVSvXr1I6pX9z2xWOZUqVYKFhYX0FODatWvxxRdfSDfssiZbBjL/aHp5eQHI7PGRlee5c+cQHh4uDS919OhRqTdGVlwgs4HmxYsXsLOzQ926dVG3bl0AmU/sZf15T05Oxo0bN1CzZk0A8j+7BXkS813Url0bmpqa0rbR19dXORzP9evXER8fD21tbcTGxsqGo+rSpYv0NGp4eDjCwsJyLa8g62ZmZiY1XJ0+fRqDBg0CAKxYsUJlA1JBVa5cWRpyA8h8WlPVukZHRyM8PByWlpZvXdaH8Oeff0rDSwkhsGbNGilMR0dHGgrK29sb27dvBwDs3btXNkTS2rVrpeEwsuIWVn77VPkGT/ny5WVP+f/111+FLi8vdevWxYYNGwAAL168wOzZs3Ps43v37sHOzq7Ijwd7e/v3NrxMUZg0aRImTZqUa7iNjQ38/Pykm+EXL17EiBEjMHv27ByNQdeuXUN4eLjK4YSUKe/7mjVrSt+lGRkZKm+6A5lPoWtqasLa2hqNGzdG48aNpfrUqFEDQOY+jIuLg6WlJcLCwuDq6ooKFSrIhpFq3769NGTO+fPnP0hDRkF5enpKQz6dO3cOt2/flur+559/qhzqCZBvzzZt2khpnjx5gkOHDhVpWcrfG48ePcKXX36Zo7E9MTERe/bsgbu7e0FWu9Cyfx+VKlVK6mWp7MyZMyonVy6s7DeaX758WahG3GHDhkmNc69evUKXLl2wY8cO2Y16AHj69CnWr1+fa0NeFuX9bWpqiu7du0vXKbl9d7569QqRkZGoUqUKPDw84OHhASCzd6O5uTkSEhKQkZGBS5cuwdHRETdv3oStrS1KliwpPUgCZPbEGDlyJAD58GTvQ9Z1UZbJkydjwYIFsmVZ39sJCQnv9fojN+/7d5SIiOhjwoYMIiL6aCUnJyMgIED6Y+ng4IBffvkFADB//nyEhoYiOjoa6enpCAgIwMWLF6UbA87Ozpg6dao0Lv2jR4/g6emJFi1aoGbNmtDV1cW9e/dyPGmemxMnTmDmzJkQQkhzZCjL+nOpqamJYcOGSTf1jh07hgYNGqBp06a4dOmS9GcVAPz8/KRhXgYNGoRFixYhNTUVGRkZaNiwIQIDA5GWlibNqQFkjs3fr18/AMCtW7dQp04deHp6olq1arCxsYGWlhb27t0rq5vyU7NlypTB7du3AWTevNfT04OJiQkcHR3RsWPHAm2LgrK0tERQUBCWLl0KAJgyZQpOnToFLy8vaGtrIzo6GsePH8f169cxceJE1KtXD1ZWVjAzM5OGLBk+fLjUu2TFihVITU3NtbyCrJuHhwf2798PIPOp8EePHkFbWxt79ux5p3XV0NDAiBEj8P333wMAVq9ejYiICDRu3BiGhoZ4+PAhTp06JQ2F5Ovr+07lvW///PMPmjRpggYNGuDYsWM4ePCgFNazZ0/pPBsxYoR0TCcmJqJWrVro3r07nj17JjtubW1t0blz50LXI799qtzL4cqVK+jWrRtcXFwQGhqKf//9963WPTdBQUGYNm2a1OA1ZswY7N+/H15eXkhKSsLRo0dRtWpVrFix4qM9HszMzHLdT3v27JFu0NnZ2cHDwwOenp4FznvOnDk4deoU7t+/DyDzO3zPnj1o27YtrKysEBcXJ821MXz48HwbMipVqiSdy3///Tf69++PMmXK4O+//8a5c+dUpjly5Ah69uyJevXqoUqVKrCxsUF6ejq2bNkixdHR0YG+vj6AzDlFEhIS4OPjgzJlysDCwgJ37tyRDTGl/P1aUNeuXcPMmTNVhg0dOvSdbpwHBwfjt99+gxAC6enpaNiwIXr37o3ExETpu1iVSpUq4erVqwCAH374AY8fP4ZCocDq1atz7VnxtmWNGjUKO3bsgBAC4eHhcHFxQadOnVCiRAnEx8fj0qVLOHr0KEqVKvXehkZ0d3dHkyZNpO+2/v37Y+fOnVLDSWRkJA4fPozIyEgsX74c1apVe6fyss9X5e/vD29vb2hoaKB37945hu/LbsCAAdixYwf27dsHIHPuhwoVKqBTp05wdHTEy5cvERYWhn/++QeVK1fOtyFD+bvz+fPnaNmyJerXr4/z589j27ZtKtM8f/4cVatWhbOzM2rVqgUbGxvo6+vj2LFjSEhIkOJlnROzZ8/G6tWr0aRJEzg4OMDa2hrx8fGy66e3OX8Ko3Xr1nB2dsa1a9cAAAsXLsSFCxfg4+ODtLQ0nD17FkIIHDp06L1ff+Tmff+OEhERfVQ++PTiREREReSLL74QAAQAoaGhIY4cOSILP3TokFAoFFKcIUOG5Mhj3rx5Qk9PT4qT12vAgAFSusjIyAKlASD69OkjK/PNmzeiU6dOeaapWbOmiI+Pl6Vbt26d0NXVzTWNoaGh2L17txT/5MmT+datU6dOsjLmzp2rMl7r1q0LtE+U0wQGBuYbPykpSfj4+ORbz4kTJ0ppfvrpJ5VxXFxcRM2aNXMtvyDrtnfvXtkxk/Wys7MTlSpVUpl39mPh0KFDKtc1LS1N9OjRI991Lch2E0KI5cuX51pu9jBlEydOlK2XssDAQCmsYcOGua5j69atVda9fPnyIjY2VpbnzJkzhYaGRq7rW7JkSXHu3DlZGjs7O5X7Prv89mlcXJywsbHJdTsrf46MjJTybdiwYa77I6/td+rUKWFlZVWgfVvUx0NxU95nb1vnu3fvilq1auW7TYYPHy6lye2YjYiIEMbGxjnSamlpiZ49e6o8P9atW5dv2SNHjpTiK38nqHpZWFjIjqu85Fdu1uvZs2cqt3n28yS37SKEEOPGjVOZd40aNYS1tbX0efLkyflum9KlS4tmzZoVaVlCZP42a2pq5rktsp9/ymHLly+Xluf1HX3o0KFcvwcePXokXF1d890nymXl9f2QV1mvXr0SpUuXVpn/2bNnRUEkJSWJoKCgfOtbrVo1KU1uvxWpqam5rnv2786s7RkTE5Nv2bVq1RJv3rwRQsiv4VS9NDQ0xNatW6U65XVM57Xd8wuPiIgQ5cuXz7UeymW9z+uPvM7nov4dzWtbEhERqbO3H3iWiIioGO3duxe//fab9HnkyJGoX7++LE6jRo2kSSWBzCftDhw4IIszdOhQREZGYsqUKWjQoAGsrKygra0NfX192NraomnTppgwYQLOnj0rKy8v2trasLGxQevWrfHXX3/lePJUS0sLmzZtwl9//QVfX1+UKFECWlpaMDMzQ926dTFv3jwcP348x1jH3bt3x8WLF9G/f384OjpCT08Penp6cHJywuDBg3H58mW0bNlSil+pUiXMmjULnTp1gpOTE0xNTaGpqQlzc3PUrVsXc+fOzTFExODBgzFp0iSUL1/+redPKAxDQ0McOHAAq1atQvPmzVGyZEloa2ujRIkSqFatGoKCgrB161aMHTtWSjN27FgsXLgQTk5O0NbWRqlSpdC/f38cPnwYRkZGuZZVkHXz9fXFxo0bUa1aNejo6MDKygr9+/fHmTNn3nnCUU1NTaxduxbbt29H+/btYWNjA21tbZibm8PFxQXdunXDmjVrMHfu3Hcq50MYPXo01q1bh5o1a0JPTw8lSpRA3759ceLEiRyTUo8aNQonTpyAv78/bG1toaOjAwMDA7i6umLs2LG4cuWKNLRZYeW3Ty0sLHDs2DF06tQJJiYm0NfXh6enJ7Zs2fJehvupXbs2rl69igkTJqBmzZowMTGRjlFfX1/Zk7ef0vFQVBwcHHDy5Els27YN/v7+cHR0hKGhIfT19eHo6IgWLVrgt99+w4QJE/LNq0KFCjhy5AiaN28OAwMDGBkZoWHDhjh48CCaNm2qMk29evUwbdo0tG7dGo6OjjA2NoaWlhZKliyJJk2aYMWKFbKeEtOnT8fAgQNRs2ZNlCpVCtra2jAwMEDlypUxaNAgnD9/Hvb29kW1eYrM9OnTsWTJEjg7O0NHRwelS5fGkCFDcPDgQbx48UKKp/w0fPfu3bFhwwZUq1YN2trasLS0RLdu3XDq1CnY2NgUaVlA5m/zuXPnEBwcjAoVKkBPTw+GhoaoWLEiWrRogblz5+LIkSNFtk1Usba2xpkzZzB//nw0bNgQFhYW0NLSQqlSpVCzZk18+eWX2LdvH3r27PnOZenq6mL37t1o1qwZTExM3ioPQ0NDLF++HOfPn8fgwYPh5uYGU1NTaGtro2zZsqhbty6mTp2KzZs355uXtrY2/v33XwQFBcHS0hK6urpwcXHBkiVLch0mztzcHAsWLECPHj1QtWpVWFhYQFNTEyYmJvDw8MDUqVNx8OBB6bs6ODgYY8eORYMGDWBraws9PT3o6OjA1tYWXbp0weHDh9GhQ4e32haFUaFCBYSFhSEkJATe3t4wMzOTzvsGDRogICBAivs+rz/y8j5/R4mIiD4mCiHUeEBdIiIiIip2UVFRcHBwkD4fOnQIjRo1Kr4KEdFbS0lJkYbHUrZr1y60bdtW+nz8+PF3HnP/Q5ZFRERERJ82zpFBRERERET0mfjmm29w6dIltG3bFg4ODtJcAIsWLZLieHh4oE6dOh9VWURERET0aWNDBhERERER0WdCCIHQ0FCEhoaqDK9QoQI2btwIhULxUZVFRERERJ82NmQQERERERF9Jjp06IDHjx/j9OnTiI2NxatXr2BmZgYXFxd07NgR/fr1g4GBwUdXFhERERF92jhHBhERERERERERERERqS2N4q4AERERERERERERERFRbtiQQUREREREREREREREaosNGURERETInJTW09MTCoUC+vr6iImJKe4qFUhUVBQUCoX0ym1S3Xdlb28vlTFp0qQiqdubN28wceJEODk5QUdHp9D5f0xWrFgh2xYFNWnSJCmNvb29LOxt9gl9ekJDQ2XHVlRU1DvnyWNLPQgh4O7uDoVCAWNjYzx69Ki4q0RERERUbNiQQURERARg9erVOHfuHACgX79+KF26tBSW/Sa08svY2Bju7u4YP348njx5UlzV/yhNmjQJU6ZMQUREBN68eZMjPCgoSNrOjRo1KnT+jRo1UrnP9PT0YGtri3bt2mHLli1FsCbq533eiD5+/DgmTJgAHx8fODo6wtDQEPr6+nBycsKXX36J27dv50ijvC/ze6mSnp6OFStWwNfXF1ZWVtDR0YGVlRVq1KiBESNGyG7wZm9AUygUqF27tsp8Dx48mCNuUFBQvtsgt2Mrr9eKFSsKtH2pYD6H81uhUOC7774DACQlJeHbb78t5hoRERERFR+t4q4AERERUXFLT0/HhAkTpM8jRowocNqkpCSEhYUhLCwMf/zxBw4ePAg3N7f3UMuPj4WFBUJCQqTPjo6OsvA1a9ZI711dXeHv7w8tLS14e3u/13q9fv0aDx48wIMHD7Bz50588803mDZt2nst83349ttvkZCQAADvfZspCw4Oxs2bN3Msj4iIQEREBFauXIldu3ahcePGRVJebGws2rVrh1OnTuVYHhsbi4sXL8LPzw+lSpXKNY8zZ87gzJkzqFWrlmz5ggULiqSOxcnR0VF2nllYWLxznsV1bBWFT+X8ztK5c2fY2dnh3r17WLFiBcaNG4eKFSsWd7WIiIiIPjg2ZBAREdFnb9euXbh37x6AzJt22W+4Zzdw4EA4OjoiJSUFBw4cwJEjRwAAT58+RWBgIC5evPje6/wxMDExwejRo3MNj46Olt4PHz4cwcHB760u5ubm+Oabb5CWloZbt25hzZo1SE1NBQDMmDEDo0aNKpIbwB9S//79i7X8OnXqoEGDBtDV1cXevXtx5swZAEBKSgqCgoIQFRUFDY3MDuDdu3eHi4tLjjyEEJgwYQJevXoFAGjRooUsPC0tDR06dJAaMfT09NCxY0c4OTlBoVDg0aNHuHDhAnR0dPKt7/z587F69Wrp871797Bz5863Wvcvv/wSbdq0kS0bM2aM9N7DwwPdunWThXt6euaa34sXL2BsbPxWdbG1tc3zPHsbxX1sFdaneH5nUSgU6NGjB3766SdkZGRg0aJF+OWXX4q7WkREREQfniAiIiL6zLVr104AEADErFmzcoQvX75cCgcgDh06JAuvV6+eLPzOnTtCCCEmTpwoLbOzs5OlOXTokCxNZGSkFJaUlCQmT54sqlevLoyMjISWlpYoWbKkqFatmujXr5/Ys2ePFDcyMjJH3TZs2CA8PT2Fnp6esLS0FIGBgSIuLk7lejVs2FBYWloKLS0tYWZmJpycnETXrl3FwoULZXHt7OykMiZOnCguXrwoWrduLUxMTIShoaFo2rSpCAsLk6VRVTchhGjYsKFsefZX9u2t6pV9H6iiXE727T927FhZfidPnsyR/tmzZ2Lq1KnCw8NDmJiYCB0dHWFnZyf69esnIiIiVJYZFRUlunfvLszNzYWBgYGoX7++2L9/f451yu7y5cuidevWwtjYWBgbGwtfX19x/vz5PI+h7PtECCECAwPz3XbvavTo0eLq1auyZRkZGaJp06ayci5fvpxvXjt27JClOXDggCxcebvZ2NiIu3fv5ptn9uNOQ0NDABA6Ojri0aNHUryvv/5aiqOpqSm9DwwMLNiGyEa5TFV5ZD/G//rrL+Hp6SkMDAykffv48WMxevRo4ePjI8qVKyeMjIyEtra2sLKyEs2aNROrV68WGRkZsnzz+i5RPh4aNmwo/vvvP9G3b19hZWUldHV1hZubm9i0aVOOuqo6tlSVdfv2bTF37lzh7OwsdHR0ROnSpcXw4cNFSkpKjjyfPn0qBg4cKKytrYWenp6oUaOGWLt2bZ71z8u7nt9xcXFi4sSJonr16sLY2Fjo6OiIsmXLim7duoljx47J4m7dulXKy8DAQLx580YK69ChgxS2ZMkSafmBAwdkx1dCQoIQQog3b96I2bNnCy8vL2Fqaio0NTWFhYWFqFq1qujdu7dYt25djrqeO3dOysvCwkKkpaUVaBsRERERfUrYkEFERESftbS0NGFiYiLdJDpx4kSOOPk1ZIwePVoWfvz4cSHE2zdkNGrUKM8b0d26dZPiZr9p27x5c5Vp6tatKytfuW6qXtbW1rL4yjc2GzRoIHR1dXOksbCwkN0oVueGjHnz5snyu3Xrliz8xo0boly5crmWb2hoKPbt2ydLExkZKUqVKpUjrkKhEC1btsy1MeHs2bPCyMgoRzpdXV3RpEmTXNehuBoycjN//nxZOefOncs3jfI+ql69eo7wBg0aSOHBwcEiICBA2NnZCV1dXeHo6ChGjx4t4uPjZWmyH3ft27eX3k+ZMkUIIcTLly+FpaWlACDc3d1l2/JDNGTUrVtX9jlr3549ezbf/denTx9ZvgVtyChfvnyux2f2Y7mgDRnZ1yPr5e/vL8vv2bNnonLlyirjtm3bNtf65+Vdzu9r166JsmXL5rqNFQqFmDZtmqz+WQ1iAMTp06elMCsrK2l57969peXK37G1atVSuU9UvWrXrp1jXd+8eSMMDAykOGfPni3QNiIiIiL6lHBoKSIiIvqsXblyBYmJidLn6tWrFzqP7GP35zVWf37Cw8MRGhoKANDQ0EBAQACcnJzw9OlTREZGSmG5+eeff1CnTh00adIEu3btwqVLlwBkTtB88uRJ1KlTBwCwaNEiKU2TJk3g4+OD5ORk3L9/H8eOHUNKSkquZRw5cgR2dnbo0aMHrl27Jg3PEx8fj2XLlmH8+PF51jFrWB7loXi6desGDw8PAICDgwNCQkKwfv16aQL28uXL48svv5Ti5zf8V27S09Nx69YtLFu2TFpWvXp1VKhQQRanY8eO0tBX1tbW6NmzJ0xNTbFr1y6cPXsWycnJ6Nq1KyIiIlCyZEkAwJAhQ2STTrdt2xbVq1fHnj17sGfPnlzr1LdvXyQlJQHIHEbG398f9vb22Lx5Mw4ePFio9csawunHH3/Es2fPAADNmjVD8+bNC5XP21CeN8PIyAiVK1fOM/758+dx+PBh6XP24ZHS09Ol4aoAYOnSpbLwO3fuYObMmdi2bRuOHz8OKysrleU0bdoUN2/exI0bN7B48WKMHz8ea9euRVxcHABg6NChmDJlSsFWsogcP34c1tbW6NatGywsLBAZGQkg85x3dnaGp6cnrK2tYWZmhlevXuHixYvYuXMnhBBYvnw5Bg4cmGO+j/zcvXsXBgYGGDp0KDIyMrB48WKkp6dDCIFZs2a91TFy/Phx+Pr6wtPTE2vXrsXdu3cBAOvWrcOMGTNQpkwZAMB3332HGzduSOnq1asHHx8fHD169K2H91KlIOd3WloaOnbsiAcPHgAAtLS0EBgYCGtra2zcuBEREREQQuDbb79F9erV0bJlS5iZmcHd3R0XLlwAABw9ehS1atXCzZs38eTJEynvo0ePSu+zhhwEAB8fHwCZcyr9+eef0vLOnTujRo0aSEhIwL1792TngzItLS24uLhI58Px48el70siIiKiz0YxN6QQERERFatdu3ZJT7kaGxurjJO9h8DAgQNFSEiImDp1ao7eBdWqVZPSvU2PjAsXLkjLqlSpkmMYmbS0NBEVFSV9zv70uZeXlzTsSVxcnGzInHnz5knplHuhxMTE5FjnrOGxsig/oW1kZCRLU716dSmsU6dOudYtey8K5bDly5fnqEP2YXEKK7+eHwCEp6enbHsKIcT27dulcB0dHVn469evZT01sp7afvjwoVAoFNLyXr16SWlSU1OFs7OzrNwsJ0+elC3/7rvvpLCEhARRokSJXI+h3J6azy/sfTh27JjQ0dGRypwwYUK+abp37y7FL1eunGy4HiGEiI2NzbG/KleuLL7//nvRuXNn2fIePXpI6bIfd/PnzxcLFiyQPq9fv164u7sLAMLS0lKkpKR88B4ZZmZm4r///ss1r3v37olNmzaJBQsWiJkzZ4qQkBBRpkwZKX1WzxIhCt4jA4DYtWuXFDZixAhpuYWFhaz8gvbI8PPzk8IuXbokC9uxY4cQIvP4V+5x5O3tLQ2NlJ6eLnx8fHKtf17e9vxWHiYKgPjtt9+ksGfPngkLCwsprGnTplLYqFGjpOXt27cXQgjxxx9/SMdRVtj9+/dFamqqrAdFVo+X+Ph4aZmJiYl4/fq1rG4ZGRm5Dp/Wpk0bKe2YMWMKtI2IiIiIPiXskUFERESftefPn0vvTUxMCpRm8eLFKpdbWFhgxYoV71SfKlWqwNLSEnFxcQgPD0eFChVQvXp1ODk5wc3NDU2bNoWdnV2u6YODg6GlpSXVp0SJEnj8+DEASE/oA0D9+vXx999/AwBcXFxQu3ZtVKxYEc7OzvDx8ZE9wZxd+/btZb1OnJycpAnOlctQd1ZWVvjhhx9ybM/jx49L71NTU2Fvb59rHidOnACQ2btACCEt79mzp/ReW1sbXbt2xcSJE3Okz+pxoiqdiYkJ2rZti+XLlxdshYrJnj170LVrV2lyZT8/P5Xrqiw6OhqbNm2SPg8fPlw6brNk5ZdFT08Phw8flnpedO7cGVu2bAEAbNmyBSkpKdDX11dZXmBgIL755hskJiZi5MiR+O+//wBkTmqtp6dXiLUtGoGBgbCxscmxPC4uDoGBgdK5mZus3gSFUaZMGbRu3Vr6XKlSJen92563X3zxhcr8lPO8efOm1OMIyDzGNTU1AWT2QAkMDMShQ4feqvy85HZ+Z52zWXr16iW9NzMzQ/v27aVzTjmuj48PZs2aBSDzO0IIgWPHjgEAOnbsiL179+LBgwc4evQoHBwc8PLlSwCZ53/dunUBZE5K7uzsjGvXriExMREODg7w9PRExYoV4erqiiZNmsDBwUHl+ij/Pin/bhERERF9LjSKuwJERERExcnMzEx6rzzEVEEZGhrC1dUVX3/9Na5duwZ3d3eV8ZRvcgPA69evVcbT09PDhg0bUK5cOQCZw8Fs3rwZ06dPR48ePVCmTBnMnj071/pkv2mnq6srvc/IyJDeL1q0CF5eXgAyb57u3r0bc+fOxYABA1CxYkV069ZNFv9tylAn5ubmCAkJwZgxY2BtbQ0AePLkCVq1apVjOJf4+PgC5xsbGwsg543F7MMcZZWZ3dumUxe///472rVrJ92o9vf3x7p166ChkfffjDlz5iAtLQ0AYGpqiv79++eIo3xuAkDVqlVl26dhw4bS+9evX0uNE6oYGRkhMDAQAKR4mpqasuHKPiQnJyeVy4ODg/NtxABy//7IS17nbfbvp7fJUzk/4H/fBdmP8exD773LUHxZCnN+KzfaGBkZwcDAQBaufM69fPlSalCrX7++1ADz9OlT3LhxQ2rIqFevHurVqwcAOHbsmGxYqdq1a8PQ0FD6vHbtWlStWhUA8PDhQ2zfvh0zZ85EYGAgypUrh5EjR6pcR+Xfp+znBhEREdHngD0yiIiI6LOm/FT0ixcv8OrVq3yf0D506BAaNWqUb97KN3OzzzkRERGRa7rGjRsjMjISFy5cwKVLl3D79m2cOHECR48eRWpqKkaPHo127dqpnCdCW1tb9lmhUKgsw9bWFidPnsTt27dx5swZRERE4PLly9ixYwfS0tKwYcMGtGzZEkFBQW9dhjoxMTGR5mAYMGAA3N3dkZycjPT0dAwcOBBXrlyRegSYm5tL6YyMjPLsXZB1Ezb7jUXlcfMBSL1islOVzsLCIt90xU38/xwC06dPl5Z9/fXX+Omnn/I9HhITE/HHH39InwcMGABjY+Mc8QwMDODg4CDNH5Fd9nLyO2+HDBmCBQsWSDft27dvLzUYfmjZb54DQHJyMnbt2iV97t69O0JCQmBjYwMNDQ3UqlULZ8+efesy38d5q5xnbvnld24ozyvztt72/E5KSsLLly9l+0P5nDMwMICOjo5URs2aNaV5KjZt2oTbt28DyGzISE5Oxl9//YWjR49K8+sA/5sfI4ubmxuuXbuGK1eu4MKFC4iIiMCFCxewZ88eZGRkYPbs2WjXrl2O3xjl7ZY19wgRERHR54Q9MoiIiOiz5urqCiMjI+lz1uTYRUH5Bl5sbKw0Ee6LFy9kk20re/XqFcLDw6GhoQEPDw/069cPP/30Ew4fPgxTU1MAmU86v2s9w8LCkJGRgQoVKsDf3x8TJ07E5s2b0apVKynO+fPn36mMd6V8kzRrmJaiUKFCBdnE0jdu3MCaNWukz97e3tL7pKQk1KhRA6NHj5a9Ro0aherVq0tDxtSoUUN2I1c5vzdv3mDDhg0q65J9wl7ldImJiW89EXJBtt2kSZOgUCigUCjyHD4ru9TUVPTs2VNqxNDS0sJvv/2Gn3/+uUA3x5csWYIXL15I9Rw+fHiucdu0aSO9Dw8Pl3rAAJA9aV+qVKl8b+46OTnJJrQeOnRovnX9kBISEpCeni597tKlC8qWLQsNDQ2Eh4cjLCysGGv39ipXrixrqFq/fr3UmCSEwMqVK4u0vMKc3wBkk28/f/4c27dvzzWucqPEvHnzAAClS5eGo6Mj6tevDwC4evWq7Nhs3LixLI+s725XV1cEBgbihx9+wO7du+Hm5ibFyf7dm5aWhitXrkifs753iIiIiD4n7JFBREREnzUtLS00aNAAu3fvBgCcOnVKGnLpXWW/SV2vXj00atQIp06dyvUp8+fPn6Nq1apwdnZGrVq1YGNjA319fRw7dgwJCQlSvHcdWqRbt25ISEiAj48PypQpAwsLC9y5c0faDkVRxrtSvjF9/vx5DB8+HLa2ttDR0cGwYcPeKe/hw4dj1qxZ0pBI06dPR+/evaGhoYE2bdqgUqVKuHnzJgCgdevW6Ny5MypXroy0tDTcunULoaGhiImJwaFDh+Dg4AAbGxu0bNlS2n5//vknEhMT4e7ujj179uDatWsq61G7dm1pzHwAmDZtGqKiomBvb49Nmzbh6dOnb7V+ZcqUkZ4WX7FiBfT09GBiYgJHR0d07NjxrfLM0qlTJ9nwR02aNEFiYiJmzpwpi9eyZUs4OzvLlqWlpUk3gIHMXgd5NUB89dVXWLZsGZKTk5GSkoJGjRrBz88P4eHh2Lx5sxRv6NChBWpEWbhwIa5cuQJNTc0C9ar6kKysrGBmZiYNxTR8+HBcvHgRSUlJWLFiRY45Qz4WWlpaCAoKwvz58wEAoaGhaNKkCerXr48jR44gNDS0yMvM7/yuWLGi1Ctu8ODBOHPmDEqVKoUNGzbIhpb76quvZPn6+Pjg559/BgDp3MwaUsrFxQXm5uZ49uyZ1FCnp6eHOnXqyPLw8vKCjY0N6tevDxsbG5iYmCAsLAyXL1+W4mT/7r106ZLUq8/CwgLVq1d/p+1DRERE9DFiQwYRERF99oKDg6Ub0Js3b8aIESOKJF9vb294e3tLE8bGxMRg3bp1AIDmzZvjn3/+yTXttWvXcr35XatWLdn8AG/r0aNHUn2ys7CwQHBw8DuX8S46dOiAqVOnIiMjAxkZGdINcENDw3duyDA3N8fAgQOlm+83b97Epk2b0LVrV2hpaWHbtm3w9fVFdHQ0Xr16JXuiOzcLFiyAl5eXNATMjh07sGPHDgCZ8zlkH6sfyByOZ9myZWjcuDGSk5MhhJCeENfW1pYdP4XRqVMnqbzY2FhMnToVQGajzLs2ZFy9elX2ed++fdi3b1+OeCVKlMjRkLF+/Xrcv39f+qz85LwqDg4OWLVqFXr06IHU1FRcv34dU6ZMkcXp2LEjvv766wLV3dHRUeWQbOpAS0sL48aNw7hx4wBkTuj9ww8/AMi8Se7o6FjsvaTe1pQpU7B//37cuHEDQObwfFkTfLds2RJ79uyR4uY3v0pB5Hd+b9myBb6+vnj48CHS0tKwdOnSHHlMnjxZ1kMNyGy00NbWxps3b2TLgMxzuW7durLhwby9vXPMHQIAkZGRuTZmOzg4wM/PT7Zs06ZN0vvAwEBprg4iIiKizwmHliIiIqLPnvJY+cePH8/1BtPb2LlzJ4KCgmBpaQk9PT14eHhgw4YNGD9+vMr45ubmWLBgAXr06IGqVavCwsICmpqaMDExgYeHB6ZOnYqDBw9K472/renTp2PgwIGoWbMmSpUqBW1tbRgYGKBy5coYNGgQzp8/X6jhht4Hd3d3rFu3DjVq1Mh3/oO3MWrUKNlNxh9//FEa8qZy5cq4fPkyfvzxR9SuXRumpqbQ1tZGmTJlULt2bYwaNQpHjx5FgwYNpPQODg44deoUunbtCjMzM+jr66NOnTrSMZCbWrVq4fjx42jZsiWMjIxgZGSEJk2aIDQ0FM2aNXurdRs8eDAmTZqE8uXL53qsKI+5X7t27bcqp7BmzZolvW/WrJlsOJ3cdOrUCRcuXEBAQADKli0LbW1tmJqaokGDBlixYgU2b978zueDuhg7diwWLlwIJycnaGtro1SpUujfvz8OHz4sGwLvY2NmZoajR4/iiy++gJWVFXR1dVGtWjWsWrUKAQEBOeIWhbzObxcXF1y+fBnff/893N3dYWhoKJ3fXbp0wZEjRzBhwoQceRoaGsLT01O2LKshA4A0vFSW7PNjAMCiRYvQp08fuLm5oWTJktDS0oKRkRHc3Nzw9ddf4/Tp09IwgkDmUIJZDc4aGhrFNkE9ERERUXFTiKyrOSIiIqLP2KpVqxAYGAggc1LgrGFQiD5VVatWRXh4OAwNDXHjxg2ULVu2uKtEn7CUlBTo6+vnWO7n5ycNE1axYkXcunXrQ1dNrW3cuBFdu3YFkNl78I8//ijmGhEREREVDzZkEBERESFz0tlatWrh3Llz0NPTw927d1G6dOnirhbRexEbGwsrKysAwE8//YSxY8cWc43oU1euXDn4+vpKc/88efIEGzdulA0rNX/+fAwZMqQYa6lehBCoXr06wsLCYGRkhIiICJQqVaq4q0VERERULNiQQURERET0mdm0aRO6dOkiDaGlra1d3FWiT5yZmRkSEhJyDe/fvz9+++23Ak3aTkRERESfHzZkEBERERER0Xv1888/Y+/evbhx4wbi4+OhoaGB0qVLw8vLC8HBwWjSpElxV5GIiIiI1BgbMoiIiIiIiIiIiIiISG1pFHcFiIiIiIiIiIiIiIiIcsOGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIjW1e/dueHt7w9zcHAqFAgqFAnPmzEFoaKj02d7evrirWWh//PGHVP/9+/cXd3WoABo1aiTtsxUrVnywcpWPlX///feDlUtEREQF86ler/bq1QsKhQLGxsaIj48v7up8clasWCEdH40aNfpg5T579gwmJiZQKBQICAj4YOUSUdFgQwYREX32MjIysH37dnTt2hX29vYwMDCAqakpnJ2dERgYiF27dkEI8UHrdPHiRbRr1w4nT57E8+fPP2jZqvj6+kp/NhQKBdq2bftW+SQnJ2PChAkAAE9PTzRr1ixHHHXcH5+6SZMmSS91ON6yBAQEoGzZsgCA0aNHc78TEdFnSx2vj9ThetXe3l52japQKKClpQVLS0t4eXnhxx9/RHJycqHyPH/+PNauXQsA+PLLL2FhYaEy3vTp02XllihRAqmpqe+8TvT+mJubY+DAgQCAP//8ExcvXizmGhFRYSgE/xESEdFn7PHjx+jatSuOHDmSZ7xnz57BzMzsw1QKwMSJEzFlyhQAmTf8p0+fDl1dXZQvXx6Ghoa4cuUKAEBPTw8eHh7vtS7//fcfypUrh4yMDGmZlpYWHjx4AGtr60LlNXv2bIwcORIAsHLlyhxPQqnr/vjUKRQK6X1kZGSOJyevXLmChIQEAICTkxOsrKw+WN2mTp0qNX5t27YN7du3/2BlExERqQN1vT5Sh+tVe3t73Lt3L884derUwdGjR6GpqVmgPNu3b48dO3ZAoVAgMjISdnZ2KuNVrlwZN2/elC3btGkTOnfuXLDKf8aePHmCW7duAQBMTU3h6ur6wcqOjo6Gvb09hBDo0KEDtm7d+sHKJqJ3o1XcFSAiIiouKSkp8PX1RVhYGABAQ0MDQUFBaNOmDUxNTXH//n3s2bMHW7Zs+eB1u3//vvS+ZcuWaNKkiSy8Xr16H6wuq1atkjViAEBaWhr+/PNPjBo1qsD5CCGwePFiAIC+vj46duwoC1fn/VEc3rx5AyEEdHR0irsqH/TPZXY9evSQGjIWL17MhgwiIvqsqPP1kTpdrwJAnz590LdvX6SmpmLNmjVYtmwZAODkyZM4fvw4GjRokG8e9+/fx99//w0A8Pb2zrUR4+TJkzkaMYDMIZPUsSEjIyMDr1+/hr6+fnFXBQBgZWX1QR+MUVauXDl4e3vj+PHj2LVrF/777z+UKVOmWOpCRIUkiIiIPlPTp08XAKTXunXrVMa7efOmeP36tfQ5IyNDrF69WjRu3FhYWFgIbW1tUbJkSdGqVSuxc+fOHOnt7OykMvbv3y9mzJghKlasKHR0dIS9vb0ICQmR4h46dEhWp+yvyMhIWRw7OztZWSkpKWL8+PGibNmyQldXV7i5uYmVK1eK5cuXS2kaNmxYqO1UqVIlKW2fPn2k9y4uLoXK59y5c1JaX1/fHOHquD+yrF27VjRs2FBYWFgITU1NYW5uLqpUqSL8/f3F7t27ZXHT0tLE4sWLRb169YSZmZnQ1tYW5cqVE/369RN3796VxY2MjJStc0xMjAgMDBQlS5YUCoVC/PTTT1KYo6Njjnp9+eWXUvjIkSOFEEKcPXtW9OrVS7i6uoqSJUsKbW1tYWhoKJydncWoUaNEbGyslD4wMDDP42358uVCCCEaNmyYY1n37t2lZVOnTpXV6/Xr18LMzEwKDwsLk8KuX78ugoODhYODg9DV1RXGxsbC29tbLF++XGRkZKja5cLJyUkAEBoaGiIuLk5lHCIiok+ROl4fqdP1qnK9J06cKC1/8eJFgbZbdjNnzpTSTJ8+Pdd4AwYMkOL17t1baGpqCgBCS0tLPHr0SGWanTt3Cg8PD6GrqytKlSolhgwZIp4/f55j2ylbtmyZcHZ2Fjo6OqJcuXLiu+++Ezdu3JClUaa8PCwsTAwbNkzY2NgIDQ0NsXXrVinevn37RLt27YS1tbXQ1tYWJUqUEG3bthVHjhzJUe8zZ86Ijh07itKlSwttbW1hZGQk7O3tRdu2bcW8efNkcQt6zaxqX+/du7fQ171CCJGcnCx+/vln4enpKYyNjYWOjo6oUKGC+Oqrr8STJ09U7osff/xRymvOnDkq4xCR+mFDBhERfbaUb9A3adKkQGnS09OFn59fnn/evvrqK1ka5T9YFStWVJlmzZo1Qoh3+2OYkZEhWrRooTJdzZo136oh48SJE1K6EiVKiBcvXshuUJ87d67AeSn/MZwwYUKOcHXcH0IIsWLFijzz/+KLL6S4L1++FD4+PrnGNTMzE6dPn5biZ2/IyF6f8+fPi3LlykmfT506JaV98+aNKFGihBR29epVIYQQixYtyrO+Dg4O4tmzZ0KId2vIOHDggLSscuXKsm28detWKczT01O2XE9PL9fyevbsqbIxo3fv3lIc5T/hREREnzp1vD5Sp+tVVQ0Zqamp4vfff5flfe3atQLl16ZNGynNv//+qzJOSkqK7Hr40qVLsnWaOXNmjjRr1qwRCoUiz3XO2nZZlG+255VGWV7XlVnXUGPHjs1132loaIhFixZJ+d24cUPo6urmGr9SpUpS3MJcM6tqyEhPTy/0dW9sbKxwcXHJtcwyZcrkeJBICCEOHjwoxWnfvr3qg4GI1A4n+yYios9ScnKyrDu4qkmnVfn111+xadMmAJnzREycOBF79uzB8OHDpTizZ8/Grl27VKa/e/cuJk6ciF27dsm6t8+bNw8AUL16dRw9ehQtW7aUwvr06YOjR4/i6NGjKF26dK51W7t2Lfbu3St9Hj58OHbv3o3Ro0fjwoULBVq/7FasWCG979atG4yMjODn56cyPD9Z4yQDmfMsKFPX/QEAGzdulN5PnDgRBw8exLZt2zBv3jy0b98exsbGUvikSZNw6NAhAICDgwOWL1+Offv24YsvvgAAPH/+HD169MCbN29U1ic6OhpTpkzBvn37sGTJElhZWaFPnz5S+Jo1a6T3+/btw9OnTwEAXl5ecHZ2BgC4ublh5syZ2LJlC/bv34/Q0FBs3boVvr6+ADLnwPjjjz8AAN9++y2OHj0qq8PGjRul461Vq1Yq6wkAjRs3hoODAwDgxo0bsmNMuZ7BwcEAgNjYWPTu3RuvXr0CAAwcOBB79+7FqlWrUK5cOSnd8uXLc5RVqVIl6f3ly5dzrRMREdGnRF2vj9TtejXL5MmToVAooKOjg/79+wMAtLW18dNPP6Fq1aoFyiOv69UsW7dulSY3d3Z2RrVq1dCrVy8pPPv1cVJSEgYPHixNxu7h4YEtW7ZgxYoVePjwocoy7t27Jw2tCQC+vr7YsWMHFixYgIiIiAKty507dzBq1Cjs2bMHq1evhqOjI/bs2YOff/4ZQOZQrzNmzMD+/fsxc+ZM6OrqIiMjA0OHDpXmr9i5cydev34NAPDz88PevXuxZ88e/PHHH+jbt69sSKbCXDOroqGhUejr3sGDB+Pq1asAAHd3d/z111/Ys2cPOnXqBCBzrr/AwMAcZfHakugjVdwtKURERMXhwYMHsqd1fv/99wKlq1GjhpTmyy+/lIW1atVKCuvcubO0XPlJscGDB0vLT548KS23sLCQ5aX8pLxyN3khRK5PuLVt21Za3qJFC1majh07FvoJt+xPm508eVIIIURoaKi0zNLSUjaMQV6Ut8+ePXtkYeq8P/z9/aXl69evz7WLekZGhihZsqQU95dffhFHjx6VXqVLl5bC9u7dK4TI2SMje/d8IYSIiooSGhoaAoCwsrISb968EUII0aNHD5Xb682bN2L+/PmiXr16Urd+5TIAiE6dOsnKUA7LPqSBEKp7ZAghxJQpU6TlWV38ExISpF4XBgYGIiEhQQghxPz586W4Li4usm3z7bffSmFeXl45yv/111+l8EGDBqnc/kRERJ8adb4+EkI9rleV663qZWRkJL799luRnp5eoPwMDAyktCkpKSrjNG/eXIqTNfxUcnKyMDIykpYr91revHmztFxLS0vcv39fCtu+fbvK67BZs2bJrreTk5OlNHPnzpWlUaa8XHn4pSydO3eWwnv37i27HlM+NsaNGyeEEGLJkiXSsjFjxoioqKhct2VBr5mFUN0jQ4jCXfc+e/ZMdp27du1aaV0OHToktLW1pbAbN27Iyn/58qUUZmBgkGs9iUi9sEcGERF9lszMzGSf4+LiCpQuPDxcep99AkPlJ9aU4ylr3Lix9L5EiRLS+/j4+AKVnxflp7Pq168vC2vYsGGh81N+2qx8+fLw8vICkLmeWRMfxsXFYefOnQXKT/z/U2jZ3wPqvT+++OILaGpqAsjslWJlZQVzc3PUr18fP/zwA549ewYgs8dBbGyslG7kyJGoX7++9IqJiZHCrl27prI+qiaHtLOzkybPfPLkCQ4cOICkpCRs374dAGBoaIhu3bpJ8fv27YuhQ4fi2LFjiI+PR3p6eo48s+r8rvr06QMNjczLyb/++gsZGRnYvHmz1OvCz88PJiYmAIDr169L6a5evSrbNtOmTZPCVG0b5eNFoVAUSd2JiIjUnTpfH72tor5eVZbVKyQ0NBQLFy6Eubk5kpKSMG3aNEydOrXQ+WW/XgUyn/A/cOAAgMxrkh49egAADAwM0LFjRymecq8M5XV2cHBA2bJlpc+5rbNymho1asDAwCDfNNmpuq5Uvh5bvXq17Hps9+7dUljW9ViHDh1gY2MDAAgJCYG9vT0MDQ3h7u6O4cOHy3oMFfSaOS+Fue69deuW7DrX399fWhcfHx9ZD+js15e8tiT6OLEhg4iIPkuGhoayLsVZf0jehao/O9lZWFhI77W0tN65zNxkvyAvSN2yU/4DdvfuXSgUCigUCmhoaODevXsq4+XFyspKep/9j7A6748GDRrg4sWLUsNEqVKl8Pz5cxw7dgzff/89fH19VTYW5OXFixcql+c2FEPW8ExAZjf7bdu24eXLlwAy/yhmddX/77//sHr1ainusGHDsG/fPhw9ehRff/21tDwjI6NQ9c1N2bJl0bx5cwDAw4cPcejQIdkwAP369St0nqq2jfLxUrJkybeoKRER0cdHna+PikJRXK8qK1euHOrVq4eGDRti0KBBGDNmjBS2dOnSAuWhfJ2hquFm1apV0nWUEAL29vbSNbLyNdi6deuQmpqaI/3b3DR/2+2U1xBf+cm6HitZsiQuXLiAadOmoUWLFnBwcEBqairCwsIwb948eHl54f79+wCK7pq5oNe9b7M+WXhtSfRxYkMGERF9toKCgqT3Bw4ckI3rquzWrVvSH5EqVapIy48fPy6Ld+zYMel95cqVi7CmBaM8ju+JEydkYUeOHClUXspPm+Vn7969ePz4cb7xXF1dpffKT29lUdf9IYSAq6srZs2ahSNHjiAmJgYPHz6Evb09AODs2bOIiIhAyZIlZU8t7tu3D0KIHK/ExERMnDhRZVm5/bnt2LEjLC0tAQDbtm3D77//LoUp/9nL+iMJZN6EmDt3Lpo3b4569erluY+Uyy1sI4dyY8XMmTOlOUIqVqwoe9JSeV95e3ur3DZZ2yc75eNF+TgiIiL61Knr9dHbKsrr1fwo3/BX7jWbl/yuV1euXFmgfJR7LSuvc2RkJB49eiR9Pnz4sMr0ymkuXLgg9XYFCr6dVF1XKh8b48ePV3kt9ubNG6l3hhAC1tbW+Oabb7Bnzx7cvXsXiYmJUu+T58+f4++//5biFuSaOT8Fve51cnKSeoAAmfsrt2vL7PNk8NqS6OP0/prWiYiI1Nzw4cPx119/ISwsDADQo0cP/PPPP2jTpg1MTExw//597NmzB5s3b8aTJ0+go6ODPn36SBMR/v777yhVqhQ8PT3xzz//SBfxAGQT1X0o3bp1w44dOwAAf//9N8aMGYMmTZrg33//xbZt2wqVl/LTZhUrVsSwYcNyxJk9ezbu3r2LtLQ0/Pnnnxg1alSeeTZq1Eh6f+bMmRzh6ro/RowYgdu3b6N58+awtbWFubk5IiIiZH+IX716BYVCgT59+iAkJAQAEBAQgHHjxsHFxQXJycmIjo7Gv//+i7179yIlJaVQddDR0UGvXr0wd+5cJCUlSX9gK1euDG9vbyle+fLlpffx8fGYMmUKvLy8sG/fPqxatSrX/C0tLaUJFBcvXow2bdpAQ0MDtWrVgo6OTp51a9euHUqWLInY2FjZ5J3KfzSBzOPzm2++QVJSEk6cOAE/Pz/4+/vD1NQU//33H8LDw7Flyxb06NEDkyZNkqXNOl4UCoVsSAwiIqJPnbpeH72torxezS46OhrHjh1Deno6wsPDMWvWLClM+QZ+Xho1aiRNgn7mzBnZMFsnT56UboBrampi1qxZshvpALBr1y7s27cPQGav5c6dO6N58+YwNzfHs2fP8ObNG3Tq1Aljx47F8+fPMX78eJX16Ny5M77++mukpaXh6dOn6NKlCwYOHIioqCh8//33Bd8o2QQHB2PLli0AMoeKSk9PR8OGDaGhoYH79+/j3Llz2LJlCzZu3IhGjRphw4YNmDVrFtq1a4cKFSrA2toacXFxsmHJshpZCnrNnJ+CXveamZmhU6dOUuNeq1atMGbMGFSoUAHPnz/HvXv3sG/fPty9ezdHA4ryf5F3HdKMiD6g9zoDBxERkZqLiYkRDRo0yHOSQADi2bNnQggh0tLSZJPkqXqNGDFCVobyJISHDh2Slmef6FnZ20yemJGRIVq0aKGyTtWrVy/U5ImVKlWS4k+ZMkVlHOUJml1cXPLNMyMjQzg5OQkAQl9fXyQmJuaIo47744svvsgz/xo1akiTHr58+VI0atQo3/rnV6Yqly9fzpFPSEhIjnjKEy0qv3x8fHI9BpQnUFR+ZU1Gmdtk31lGjhwpS6elpSViYmJyxNuyZYs0EXhur+zHe0REhBTWrFmzPLcRERHRp0gdr4+EKP7r1ez1zu2lra0t9uzZU6D8oqOjpQmk69atKwsbMGCAlGfjxo1Vpt+/f7/seujRo0dCCCH+/PNPoVAo8lxn4H+TfQshxI8//pjvdsq+T3LLS9nXX3+d7zbLOgbWrVuXZzwTExNx7949IUThrplzm+w7S0Gve588eSJcXFzyLFf5+MtSt25dAUBoamqK6OholduJiNQPh5YiIqLPWqlSpXDo0CFs3boVfn5+KFeuHPT09GBkZIRKlSrB398f27dvh6mpKYDMp682btyIVatWwcfHB+bm5tDS0kKJEiXQsmVL7NixA7Nnzy6WdVEoFNi6dSvGjRuHMmXKQEdHB87Ozli2bBkCAgKkeIaGhnnmc+rUKVl3az8/P5XxlCcQvHr1Ks6fP59v/b744gsAQEpKCrZu3ZojjjruD39/f/Tv3x9ubm4oUaIEtLS0YGBgABcXF4wdOxYHDx6UJrzW19fHgQMHsGTJEjRq1AgWFhbQ0tKCtbU1atasia+++koaeqmwXF1d4enpKX3W1taW7dcsv//+O0aPHg07Ozvo6enB3d0d69evVxk3y9y5c9GtWzdYWFi81djN2XtftGrVCqVKlcoRr2PHjrh48SIGDBiAChUqQE9PD4aGhqhQoQLatGmDxYsXY9CgQbI069atk95/+eWXha4bERHRx04dr4/eVlFdr+ZHV1cX5cuXR+/evXHq1Cm0aNGiQOlsbW3RqlUrAJlDX2XNC/fq1Sts2LBBipfb9XGjRo2kYZGyei0DQM+ePbF9+3Z4eHhAV1cXVlZWGDhwIDZv3ixLr7ze48ePx9KlS1G1alXo6OigbNmyGD9+PH799VcpjvIk4AX1888/459//kHHjh1RunRpaGtrw9zcHFWrVkVAQAA2bdoELy8vAEDt2rUxevRoeHt7o3Tp0tDR0YGOjg7s7e0RGBiI06dPo1y5cgAKd82cn4Je95YsWRJnzpzBzJkz4eXlBVNTU2hra8PGxgZeXl749ttvc2zj6OhoaViz1q1bw9bWttDbkIiKh0KId5xNiYiIiNSGEELljeiOHTtK3fVHjhwp62r/ISUnJ6NixYqIiYmBp6enyiGmiLKkpqbC0dERDx48gLu7O86fP1/gP8BERESkntT9evX8+fPw9PSEEAJjxozBjBkz3jnP3NZ5+/bt6NChA4DMoT5jY2OleLmlmTt3LkaMGAEAqFGjRr4PE5Hc119/jZCQECgUCpw9exY1a9Ys7ioRUQFxjgwiIqJPyJAhQ2BlZYWmTZvCzs4OsbGxWL16tfSnUKFQoHfv3sVWP0NDQ0ydOhX9+vXD2bNn8c8//6B58+bFVh9Sb6tXr8aDBw8AZE4kzkYMIiKij5+6X6/WrFkTPXv2xJ9//olFixZh3LhxsLCweKc89+/fjz/++AO9e/dGlSpVIITAqVOnMHbsWClOQECArOFi2bJlOHXqFPz8/ODk5IRXr17h33//xYQJE6Q42Sexprw9f/4cixcvBpDZS4aNGEQfF/bIICIi+oR0794d69evVxmmoaGBWbNmSU9wERERERF9aJ/j9erevXvRsmXLXMPr16+PPXv2yIaWWrx4cZ7Danbp0gXr1q3LMeE4EdGnij0yiIiIPiGdOnXC8+fPcfXqVTx9+hQKhQJlypRBvXr1MHjwYNlYs0REREREH9rneL3q5OSEgIAAnD59GjExMXj58iXMzc1RrVo1dO/eHUFBQTkaJGrVqoWuXbvi3LlzePz4MVJTU1GiRAnUrFkTAQEB6NKlSzGtDRFR8WCPDCIiIiIiIiIiIiIiUlscaJiIiIiIiIiIiIiIiNQWGzKIPiFCCCQmJoIdrYiIiIjoQ+J1KBERERG9T2zIIPqEvHjxAqampnjx4kVxV4WIiIiIPiO8DiUiIiKi94kNGUREREREREREREREpLbYkEFERERERERERERERGqLDRlERERERERERERERKS22JBBRERERERERERERERqiw0ZRERERERERERERESkttiQQUREREREREREREREaosNGUREREREREREREREpLbYkEFERERERERERERERGqLDRlERERERERERERERKS22JBBRERERERERERERERqiw0ZRERERERERERERESkttiQQUREREREREREREREaosNGUREREREREREREREpLbYkEFERERERERERERERGqLDRlERERERERERERERKS22JBBRERERERERERERERqiw0ZRERERERERERERESkttiQQUREREREREREREREaosNGUREREREREREREREpLbYkEFERERERERERERERGqLDRlERERERERERERERKS22JBBRERERERERERERERqiw0ZRERERERERERERESkttiQQUREREREREREREREaosNGUREREREREREREREpLbYkEFERERERERERERERGqLDRlERERERERERERERKS22JBBRERERERERERERERqiw0ZRERERERERERERESktrSKuwJEVPQGLzkKHX3D4q4GEREREQFYOrhRcVfhw1ldA9DXLO5aEBEREREA9L1Z3DUoMuyRQUREREREREREREREaosNGUREREREREREREREpLbYkEFERERERERERERERGqLDRlERERERERERERERKS22JBBRERERERERERERERqiw0ZRERERERERERERESkttiQQUREREREREREREREaosNGWrM3t4ec+bM+WDlKRQKbNu2LdfwqKgoKBQKXLp0CQAQGhoKhUKB58+ff5D6ERERERF9al69eoUOHTrAyckJ7u7uaNGiBaKiogAA586dQ506dVC9enVUqVIFM2bMkNIFBQWhbNmycHd3h7u7O8aMGSOFTZo0CVZWVlJYz549P/RqEREREdFHwN7eHpUrV5auG9evXy8LX7lyJRQKBXbt2iUt8/Pzk+K7u7tDQ0MDO3bsAADMmzcPLi4ucHNzy5Hf2bNn4e3tDQMDA/j5+RW6rlpvuY5E8Pb2RkxMDExNTQEAK1aswIgRI9SqYUMd61QQoaGh8PHxwbNnz2BmZlbc1SEiIiKi92jAgAFo2bIlFAoFFixYgAEDBuCff/5B//79MXnyZLRr1w7x8fGoXLky2rRpg6pVqwIAxo0bhyFDhqjMMyAgADNnzvyQq0FEREREH6FNmzbBxcUlx/IHDx7gt99+g5eXV474Wc6dO4cWLVrA19cXAODs7Izjx4/D1NQU9+/fR40aNeDl5QU7OzuULl0ac+bMwcWLF7F///5C15M9Mj4xb968+WBl6ejooFSpUlAoFB+sTCIiIiKiT4menh5atWolXVN7eXnh7t27UnjWAznJycnQ0dGBhYVFcVSTiIiIiD4zAwYMwOzZs6Grq5trnGXLlqFXr15SnCZNmkgPvdva2sLa2hr3798HAJQtWxa1atXKM7+8sCHjPdu0aRNcXV2hr68PS0tLNG3aFMnJyWjUqBFGjBghi9uhQwcEBQXJlr148QL+/v4wMjKCjY0N5s+fLwtXKBRYvHgx2rdvD0NDQ/zwww8AgJ07d6JmzZrQ09ND+fLlMXnyZKSlpUnpIiIi0KBBA+jp6aFq1aoqW8HOnDmD6tWrQ09PDx4eHrh48aIsXHloqdDQUPTp0wcJCQlQKBRQKBSYNGlSvtvH3t4eU6dOzXMdo6Oj0b59exgZGcHExARdu3bF48ePpfCwsDD4+PjA2NgYJiYmqFmzJs6dO/fWdXr9+jW+/vpr2NraQldXFxUrVsTSpUul8MOHD0snXenSpTFu3DjZtlU1JJi7u7usbIVCgT/++AMdO3aEgYEBKlasKHXBioqKgo+PDwDA3NwcCoUix3GhXNfExETZi4iIiIg+XvPmzUPbtm0BAMuXL8f333+PcuXKwcnJCdOnT0epUqWkuL/88gvc3NzQpk0bafjXLOvWrUO1atXQuHFjHDp0qMjryetQIiIiok9Dz5494erqin79+iE2NhYAsGjRIjg7O6N27dq5pnv16hXWrVuH4OBgleEHDhzAs2fPULNmzSKpJxsy3qOYmBj06NEDffv2RXh4OEJDQ9GpUycIIQqcR0hICNzc3HDhwgWMHz8eX331VY5Gh4kTJ6J9+/a4cuUK+vbti3379qFXr14YNmwYrl+/jt9++w0rVqzAtGnTAAAZGRno1KkTNDU1cerUKSxevBhjx46V5ZmcnIw2bdqgUqVKOH/+PCZNmoTRo0fnWk9vb2/MmTMHJiYmiImJQUxMTJ7xC7qOQgh06NAB8fHxOHz4MPbv3487d+6gW7duUvqePXuibNmyOHv2LM6fP49x48ZBW1v7resUEBCAv/76C/PmzUN4eDgWL14MIyMjAMB///2HVq1awdPTE2FhYVi0aBGWLl0qNSAVxuTJk9G1a1dcvnwZrVq1Qs+ePREfHw9bW1ts3rwZAHDz5k3ExMRg7ty5KvOYPn06TE1NpZetrW2h60FERERE6uHHH39ERESEdN0eEhKCkJAQREdH49q1a/j2229x8+ZNAMC0adNw+/ZtXL58GcHBwWjZsiWSkpIAAAMHDkRUVBTCwsIwdepUdOvWDffu3SvSuvI6lIiIiOjjd+TIEYSFheHChQuwtLREYGAgIiMj8fvvv2PKlCl5pt28eTMqVqwIV1fXHGFXrlxBnz59sH79eujr6xdJXTlHxnsUExODtLQ0dOrUCXZ2dgCgcsfmpW7duhg3bhwAwMnJCcePH8fs2bPRrFkzKY6/vz/69u0rfe7duzfGjRuHwMBAAED58uUxdepUfP3115g4cSIOHDiA8PBwREVFoWzZsgAy/zS1bNlSymPNmjVIT0/HsmXLYGBgAGdnZzx48ABffvmlynrq6OjA1NQUCoVC9pTYu67jgQMHcPnyZURGRkp/jlavXg1nZ2ecPXsWnp6eiI6OxpgxY1C5cmUAQMWKFaW8C1unW7duYcOGDdi/fz+aNm0qbb8sv/76K2xtbbFgwQIoFApUrlwZDx8+xNixYzFhwgRoaBS8bTAoKAg9evQAkLn958+fjzNnzqBFixbSkAFWVlZ5zpExfvx4jBw5UvqcmJjIP5FEREREH6GZM2diy5YtOHDgAAwMDPD06VNs3boVa9asAZB5TVq7dm2cOHEClSpVQpkyZaS0HTt2xLhx43Dz5k3UrFlTdu1bt25dVK9eHefOnZP+kxQFXocSERERffzKlSsHANDW1saIESPg5OSEkydP4uHDh6hSpQoA4NGjRwgODsYPP/yA/v37S2mXLl2qsjfG9evX0aZNGyxbtgz16tUrsrqyR8Z7VK1aNTRp0gSurq7o0qULfv/9dzx79qxQedSpUyfH5/DwcNkyDw8P2efz589jypQpMDIykl79+/dHTEwMXr58ifDwcJQrV05qxFBVTnh4OKpVqwYDA4Nc4xSVvNYxPDwctra2sj9FVatWhZmZmRRn5MiR6NevH5o2bYqffvoJd+7ceeu6XLp0CZqammjYsKHK8PDwcNSpU0c2L0jdunWRlJSEBw8eFKosNzc36b2hoSGMjY3x5MmTQuWhq6sLExMT2YuIiIiIPi6//PIL1q1bh/3790sPsZibm0NPTw+HDx8GADx9+hSnTp2SJmJUvvY8deoU4uLiUKFChRxhERERuHTpUqEfqMoPr0OJiIiIPm7JycnSfGxA5tCk1atXh7+/Px49eoSoqChERUXBy8sLS5culTViREZG4syZM9JD2lnCw8PRqlUrLFmyRPYgflFgj4z3SFNTE/v378eJEyfwzz//YP78+fj2229x+vRpaGho5BhiqqATdWefXNvQ0FD2OSMjA5MnT0anTp1ypNXT01M5tFX2PAsz/NX7kFUfIYTKycSVl0+aNAn+/v74+++/sWfPHkycOBF//fUXOnbsWOhy8+vqpKo+Wdsqa3lB9622trbss0KhQEZGRqHrTEREREQfrwcPHmDUqFEoX768NE+arq4uTp8+jQ0bNmDkyJFIS0vDmzdvMHr0aHh6egLI7N37+PFjaGpqQl9fHxs3bpQmVvz2229x/vx5aGlpQVNTEwsXLoSTk1OxrSMRERERqZ/Hjx+jc+fOSE9PhxAC5cuXx6pVqwqUdtmyZejcuXOOh1mGDRuGhIQEjB07VprK4Oeff4avry/u3LmDhg0b4uXLl3j16hXKli2Lb775BoMGDSpQmWzIeM8UCgXq1q2LunXrYsKECbCzs8PWrVtRsmRJxMTESPHS09Nx9epV6c9LllOnTuX4nDWEUm5q1KiBmzdvSk9kZVe1alVER0fj4cOHsLGxAQCcPHkyR5zVq1cjJSVFurmfvS7Z6ejoID09Pc84quS1jll1vX//vtQr4/r160hISJC6NwGZQ1I5OTnhq6++Qo8ePbB8+XJ07Nix0HVydXVFRkYGDh8+LA0tpaxq1arYvHmzrEHjxIkTMDY2lrr3Z9+3iYmJiIyMLHAdgMxtCeCtticRERERfTzKli2b60NETZs2xfnz51WGHThwINc8V65cWSR1IyIiIqJPV/ny5XHx4sV844WGhuZYNnXqVJVxs8/trMzR0bHQI9oo49BS79Hp06fx448/4ty5c4iOjsaWLVsQGxuLKlWqoHHjxvj777/x999/48aNGxg0aJCsK0+W48ePY8aMGbh16xYWLlyIjRs3Yvjw4XmWO2HCBKxatQqTJk3CtWvXEB4ejvXr1+O7774DkPmHqFKlSggICEBYWBiOHj2Kb7/9VpaHv78/NDQ0EBwcjOvXr2P37t2YOXNmnuXa29sjKSkJBw8exNOnT/Hy5csCbae81rFp06Zwc3NDz549ceHCBZw5cwYBAQFo2LAhPDw8kJKSgiFDhiA0NBT37t3D8ePHcfbsWamRo7B1sre3R2BgIPr27Ytt27YhMjISoaGh2LBhAwBg0KBBuH//PoYOHYobN25g+/btmDhxIkaOHCnNj9G4cWOsXr0aR48exdWrVxEYGAhNTc0CbYssdnZ2UCgU2LVrF2JjY6WJG4mIiIiIiIiIiIg+N2zIeI9MTExw5MgRtGrVCk5OTvjuu+8wa9YstGzZEn379kVgYKB0U97BwSFHbwwAGDVqFM6fP4/q1atj6tSpmDVrFnx9ffMs19fXF7t27cL+/fvh6ekJLy8v/PLLL9LkfhoaGti6dStev36NWrVqoV+/fpg2bZosDyMjI+zcuRPXr19H9erV8e233+Lnn3/Os1xvb28MHDgQ3bp1Q8mSJTFjxowCbae81lGhUGDbtm0wNzdHgwYN0LRpU5QvXx7r168HkDl8V1xcHAICAuDk5ISuXbuiZcuWmDx58lvXadGiRfDz88OgQYNQuXJl9O/fH8nJyQCAMmXKYPfu3Thz5gyqVauGgQMHIjg4WGokAjInPmzQoAHatGmDVq1aoUOHDnB0dCzQtshSpkwZTJ48GePGjYO1tTWGDBlSqPREREREREREREREnwqFKO7JEOizZm9vjxEjRmDEiBHFXZVPQmJiIkxNTdErZBd09A3zT0BERERE793SwY2KuwrvXdZ1aMICR5joF643MhERERG9J31vFncNigx7ZBARERERERERERERkdpiQwa9N0ePHoWRkVGuL9aJiIiIiIiIiIiIiPKjVdwVoE+Xh4cHLl26lGecqKioD1KXLAWpExERERERERERERGpDzZk0Hujr6+PChUqFHc1ZNSxTkRERERERERERESUOw4tRUREREREREREREREakshhBDFXQkiKhqJiYkwNTVFQkICTExMirs6RERERPSZ4HUoEREREb1P7JFBRERERERERERERERqiw0ZRERERERERERERESkttiQQUREREREREREREREaosNGUREREREREREREREpLbYkEFERERERERERERERGpLq7grQERFb/CSo9DRNyzuahARvbWlgxsVdxWIiOhtrK4B6GsWdy2IiIgKpu/N4q4BERUQe2QQEREREREREREREZHaYkMGERERERERERERERGpLTZkEBERERERERERERGR2mJDBhERERERERERERERqS02ZBARERERERERERERkdpiQwYREREREREREREREaktNmQQEREREREREREREZHaYkMGAQDs7e0xZ86c4q4GEREREREREREREZEMGzI+MytWrICZmVlxV+OD+VjXNzQ0FAqFAs+fPy/uqhARqaVhw4bB3t4eCoUCV69ezRG+cuVKKBQK7Nq1S1r2zTffoEqVKqhWrRpq1aqFf//9VwpbuHAhXF1d4e7uDldXV8ybN++DrAcREREREamv5s2bw83NDe7u7qhfvz4uXboEADh37hzq1KmD6tWro0qVKpgxY4aUJq//HcOGDYO7u7v00tPTy/HfIzY2FtbW1vDz8/sg60j0sdAq7grQpys1NRU6OjrFXQ0iIvoE+fn54euvv0a9evVyhD148AC//fYbvLy8ZMvr16+P77//Hvr6+ggLC0OjRo0QExMDPT099OrVC4MHDwYAJCYmwsXFBY0aNYKbm9sHWR8iIiIiIlI/GzZskB6Q3bZtG/r27YsLFy6gf//+mDx5Mtq1a4f4+HhUrlwZbdq0QdWqVfP836HcaPHo0SM4ODiga9eusjIHDRqEVq1a4cWLFx9yVYnUHntkfGT27t2LevXqwczMDJaWlmjTpg3u3LkDQPVT/JcuXYJCoUBUVBRCQ0PRp08fJCQkQKFQQKFQYNKkSVLcly9fom/fvjA2Nka5cuWwZMkSWdlXrlxB48aNoa+vD0tLSwwYMABJSUlSeFBQEDp06IDp06fDxsYGTk5O+a6Pvb09pk6dCn9/fxgZGcHGxgbz58+XxYmOjkb79u1hZGQEExMTdO3aFY8fP5bCw8LC4OPjA2NjY5iYmKBmzZo4d+5cvuubm9evX+Prr7+Gra0tdHV1UbFiRSxdulQKP3z4MGrVqgVdXV2ULl0a48aNQ1pammydsg/T5e7uLitboVDgjz/+QMeOHWFgYICKFStix44dAICoqCj4+PgAAMzNzaFQKBAUFJRvvYmIPicNGjRA2bJlVYYNGDAAs2fPhq6urmx5y5Ytoa+vDwBwdXVFeno6nj59CgAwNTWV4r18+RJpaWlQKBTvqfZERERERPQxUB7lIyEhARoa/7uVmnX/LTk5GTo6OrCwsACQ9/8OZatWrYKvry9KlSolLVuzZg2sra3RsGHD97A2RB83NmR8ZJKTkzFy5EicPXsWBw8ehIaGBjp27IiMjIx803p7e2POnDkwMTFBTEwMYmJiMHr0aCl81qxZ8PDwwMWLFzFo0CB8+eWXuHHjBoDMmzotWrSAubk5zp49i40bN+LAgQMYMmSIrIyDBw8iPDwc+/fvlw3nkZeQkBC4ubnhwoULGD9+PL766ivs378fACCEQIcOHRAfH4/Dhw9j//79uHPnDrp16yal79mzJ8qWLYuzZ8/i/PnzGDduHLS1tfNd39wEBATgr7/+wrx58xAeHo7FixfDyMgIAPDff/+hVatW8PT0RFhYGBYtWoSlS5fihx9+KNC6Kps8eTK6du2Ky5cvo1WrVujZsyfi4+Nha2uLzZs3AwBu3ryJmJgYzJ07V2Uer1+/RmJiouxFRPQ5W7RoEZydnVG7du084y1fvhyOjo6yxpBNmzbB2dkZdnZ2GDNmDFxdXd93dYmIPlq8DiUios9FQEAAbG1t8d1332HlypUAMv9PfP/99yhXrhycnJwwffp0WYNEFlX/O7IsW7YMwcHB0ueHDx/il19+wU8//fT+VoboI8ahpT4ynTt3ln1eunQprKyscP369XzT6ujowNTUFAqFQuWXa6tWrTBo0CAAwNixYzF79myEhoaicuXKWLNmDVJSUrBq1SoYGhoCABYsWIC2bdvi559/hrW1NQDA0NAQf/zxR6GGlKpbty7GjRsHAHBycsLx48cxe/ZsNGvWDAcOHMDly5cRGRkJW1tbAMDq1avh7OyMs2fPwtPTE9HR0RgzZgwqV64MAKhYsaKUd17rq8qtW7ewYcMG7N+/H02bNgUAlC9fXgr/9ddfYWtriwULFkChUKBy5cp4+PAhxo4diwkTJsha5vMTFBSEHj16AAB+/PFHzJ8/H2fOnEGLFi2kVnwrK6s85/iYPn06Jk+eXOAyiYg+ZZGRkfj9999x/PjxPOMdPHgQkydPlhrNs/j5+cHPzw9RUVHo2LEjWrVqhUqVKr3PKhMRfbR4HUpERJ+LVatWAcich2/MmDHYvXs3QkJCEBISgq5du+Lu3bto1KgRatWqJfv/kNv/DgA4fvw4EhMT0apVK2lZ//79MWPGDOlhWiKSY4+Mj8ydO3fg7++P8uXLw8TEBA4ODgAyh196V8rjgGfd/H/y5AkAIDw8HNWqVZMaMYDMBoiMjAzcvHlTWubq6lroeTHq1KmT43N4eLhUrq2trdSIAQBVq1aFmZmZFGfkyJHo168fmjZtip9++kkaauttXLp0CZqamrl24QsPD0edOnVkw43UrVsXSUlJePDgQaHKUt7ehoaGMDY2lrZ3QY0fPx4JCQnS6/79+4VKT0T0KTl58iQePnyIKlWqwN7eHqdOnUJwcDB+//13Kc7hw4fRp08f7Ny5M9dGCnt7e9SuXbvAPQuJiD5HvA4lIqLPTWBgIA4dOoTHjx9j69at0twW5cuXR+3atXHixAkpbn7/O5YuXYrAwEBoampKy06ePIng4GDY29tj9OjR2LNnD3x9fd//ihF9JNiQ8ZFp27Yt4uLi8Pvvv+P06dM4ffo0gMyJtbN6AwghpPhv3rwpcN7a2tqyzwqFQhqySgiR61jhysuVGzreRVaeuZWrvHzSpEm4du0aWrdujX///RdVq1bF1q1b36rcrDEMc6OqPlnbO2u5hoaGbB8AqvdDXtu7oHR1dWFiYiJ7ERF9rvz9/fHo0SNERUUhKioKXl5eWLp0Kfr37w8AOHLkCHr37o3t27ejWrVqsrRZjeMAEBsbi4MHD3KibyKiPPA6lIiIPnWJiYl4+PCh9Hnr1q2wtLREiRIloKenh8OHDwMAnj59ilOnTsHFxQVA3v87ACApKQmbNm1C3759Zcvj4+Ol/zIzZ85Ey5YtsW/fvve4hkQfFw4t9RGJi4tDeHg4fvvtN9SvXx8AcOzYMSm8ZMmSAICYmBiYm5sDyOxhoExHRwfp6emFLrtq1apYuXIlkpOTpcaK48ePQ0NDo0CTeufl1KlTOT5nDRNVtWpVREdH4/79+1KvjOvXryMhIQFVqlSR0jg5OcHJyQlfffUVevTogeXLl6Njx46FXl9XV1dkZGTg8OHD0tBSyqpWrYrNmzfLGjROnDgBY2NjlClTBkDmfoiJiZHSJCYmIjIyssB1ACD1anmbfUVE9DkYPHgwtm/fjkePHqFp06YwMjLC7du380wTHByM169fo0+fPtKy1atXw9XVFfPnz8fhw4ehra0NIQS++uorNGvW7H2vBhERERERqamEhAR07twZKSkp0NDQQMmSJbFr1y5oampiw4YNGDlyJNLS0vDmzRuMHj0anp6eAPL+3wEA69evR/Xq1WVDoxNR/tiQ8RExNzeHpaUllixZgtKlSyM6OlqaWwIAKlSoAFtbW0yaNAk//PADIiIiMGvWLFke9vb2SEpKwsGDB1GtWjUYGBjAwMAg37J79uyJiRMnIjAwEJMmTUJsbCyGDh2K3r17S/NjvK3jx49jxowZ6NChA/bv34+NGzfi77//BgA0bdoUbm5u6NmzJ+bMmYO0tDQMGjQIDRs2hIeHB1JSUjBmzBj4+fnBwcEBDx48wNmzZ6W5RAq7vvb29ggMDETfvn0xb948VKtWDffu3cOTJ0/QtWtXDBo0CHPmzMHQoUMxZMgQ3Lx5ExMnTsTIkSOlHjGNGzfGihUr0LZtW5ibm+P777+XdRUsCDs7OygUCuzatQutWrWCvr4+x0gkIlKycOFCLFy4MM84oaGhss8RERG5xv3111+LolpERERERPSJsLW1xZkzZ1SGNW3aFOfPn1cZltf/DiCzoUN5km9VgoKCEBQUVKB6En0uOLTUR0RDQwN//fUXzp8/DxcXF3z11VcICQmRwrW1tbFu3TrcuHED1apVw88//4wffvhBloe3tzcGDhyIbt26oWTJkpgxY0aByjYwMMC+ffsQHx8PT09P+Pn5oUmTJliwYME7r9eoUaNw/vx5VK9eHVOnTsWsWbOkMQAVCgW2bdsGc3NzNGjQAE2bNkX58uWxfv16AICmpibi4uIQEBAAJycndO3aFS1btpQmHnyb9V20aBH8/PwwaNAgVK5cGf3790dycjIAoEyZMti9ezfOnDmDatWqYeDAgQgODsZ3330npR8/fjwaNGiANm3aoFWrVujQoQMcHR0LtU3KlCmDyZMnY9y4cbC2tsaQIUMKlZ6IiIiIiIiIiIjoU6EQ2QfzJ/qA7O3tMWLECIwYMaK4q/JJSExMhKmpKXqF7IKOftHMV0JEVByWDm5U3FUgIqJCyLoOTVjgCBP9wvVGJiIiKjZ9bxZ3DYiogNgjg4iIiIiIiIiIiIiI1BYbMui9OXr0KIyMjHJ9sU5ERERERERERERElB9O9k3vjYeHBy5dupRnnKioqA9SlywFqRMRERERERERERERqQ82ZNB7o6+vjwoVKhR3NWTUsU5ERERERERERERElDsOLUVERERERERERERERGpLIYQQxV0JIioaiYmJMDU1RUJCAkxMTIq7OkRERET0meB1KBERERG9T+yRQUREREREREREREREaosNGUREREREREREREREpLbYkEFERERERERERERERGqLDRlERERERERERERERKS22JBBRERERERERERERERqS6u4K0BERW/wkqPQ0Tcs7moQERHR/1s6uFFxV4How1hdA9DXLO5aEBHRp6DvzeKuARGpEfbIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyCAiIiIiIiIiIiIiIrXFhgwiIiIiIiIiIiIiIlJbbMggIiIiIiIiIiIiIiK1xYYMIiIiIiIiIiIiIiJSW2zIICIiIiIiIiIiIiIitcWGDCIiIiIiIiIiIiIiUltsyPiM2NvbY86cOcVdDSIiIiJS8urVK3To0AFOTk5wd3dHixYtEBUVBQDo27cvKlWqBHd3dzRo0ACXLl2Spf31119RpUoVuLi4wM3NDa9evQIA/P333/Dw8ICuri5Gjx79gdeIiIiI6P1r3rw53Nzc4O7ujvr160vXSUIITJo0CU5OTnBxcUGjRo2kNC9fvkSPHj1QoUIFODk5YcuWLVLY48eP0alTJ7i5uaFy5cqye2g//fQT3N3dpZeJiQlGjhz5gdaUiABAq7grQEVvxYoVGDFiBJ4/f17cVSEiIiKiAhgwYABatmwJhUKBBQsWYMCAAfjnn3/QoUMHLFmyBFpaWti1axe6du2KW7duAQC2b9+ONWvW4NSpUzA1NcWTJ0+gra0NAKhYsSKWLl2KjRs3So0bRERERJ+SDRs2wMzMDACwbds29O3bFxcuXMC8efNw5coVXL16FTo6OoiJiZHSzJw5E7q6urh9+zYiIyNRp04d+Pj4wNzcHCNHjoSrqyu2bNmCpKQkeHt7o27duvD09MS4ceMwbtw4AEBqaipsbGzQs2fP4lhtos8We2TQO0lNTS3uKnwShBBIS0sr7moQERFRMdDT00OrVq2gUCgAAF5eXrh79y4AoF27dtDS0pKW37t3DxkZGQCAkJAQTJ48GaampgAAKysraGpqAgCcnJxQrVo1KS0RERHRpyarEQMAEhISoKGReZszJCQEP//8M3R0dAAApUuXluKtX78egwcPBgA4ODigQYMG2L59OwAgLCwMrVu3BgAYGRmhYcOGWL16dY5yt23bhrJly6JmzZrvZb2ISDU2ZKihvXv3ol69ejAzM4OlpSXatGmDO3fuAABCQ0OhUChkvS0uXboEhUKBqKgohIaGok+fPkhISIBCoYBCocCkSZOkuC9fvkTfvn1hbGyMcuXKYcmSJbKyr1y5gsaNG0NfXx+WlpYYMGAAkpKSpPCgoCB06NAB06dPh42NDZycnPJdH3t7e/zwww8ICAiAkZER7OzssH37dsTGxqJ9+/YwMjKCq6srzp07J0t34sQJNGjQAPr6+rC1tcWwYcOQnJwshf/555/w8PCAsbExSpUqBX9/fzx58kQKz9pWBw8ehIeHBwwMDODt7Y2bN28WaD+EhYXBx8cHxsbGMDExQc2aNWV1PH78OBo2bAgDAwOYm5vD19cXz549AwC8fv0aw4YNg5WVFfT09FCvXj2cPXs2R9327dsnDftw9OhRCCEwY8YMlC9fHvr6+qhWrRo2bdqUax1fv36NxMRE2YuIiIg+bvPmzUPbtm1zLJ87dy5atWol/Um/fv06zp07h7p168LDwwPz5s370FWlzxivQ4mISB0EBATA1tYW3333HVauXInExETExsZi69at8PLygpeXF9avXy/Fj46Ohp2dnfTZ3t4e0dHRAABPT0+sXbsWGRkZePLkCfbt2ycN96ls6dKlCA4Ofu/rRkRybMhQQ8nJyRg5ciTOnj2LgwcPQkNDAx07dpSevsuLt7c35syZAxMTE8TExCAmJkY2LvKsWbPg4eGBixcvYtCgQfjyyy9x48YNAJmNHC1atIC5uTnOnj2LjRs34sCBAxgyZIisjIMHDyI8PBz79+/Hrl27CrROs2fPRt26dXHx4kW0bt0avXv3RkBAAHr16oULFy6gQoUKCAgIgBACQGaDiq+v7/+xd9/xPZ3//8cf7ySyZCBGqBErBIkkpVYRozVLqE2JKPUp1VrFz4qt9m5VEXx8zBqtGrWitWeMyseIRPiK2om9kt8fvs7Xu4kVkXfwvN9u5/bJ+1znXOd1neRT1/u8znVdNGzYkEOHDrFo0SK2bt1qFsu9e/cYMmQIBw8eZMWKFURFRREUFJTk2n379mXs2LHs3bsXGxsbgoODXyjmli1bkjt3bvbs2cO+ffvo3bu3MV1DeHg41apVo3jx4uzYsYOtW7fyySef8PDhQwC+/fZbfv75Z+bMmWO0r0aNGly5csXsGt9++y0jRowgIiICHx8f+vXrx+zZs/n+++/566+/6Nq1K61atWLLli3JxjhixAhcXV2NLU+ePC/UNhEREUmfhg8fzokTJxg2bJjZ/n//+98sXryY6dOnG/sePHhAZGQkf/zxB7///jszZsxg9erVaR2yvKPUDxURkfRg7ty5nDlzhqFDh9KzZ0/u37/PvXv3uH37Njt37mTx4sV069aNI0eOGOc8HgULGM+h4NEzs/j4ePz9/WndujVVq1Y1ngM9dubMGbZu3apppUQswJT45P9jJV26ePEi2bNn5/Dhw1y6dIkqVapw9epVYwhdeHg4fn5+REVF4eHh8dQ1Mjw8PKhYsaIxLC4xMRF3d3cGDRpEx44dmTFjBr169eLMmTNkzJgRgNWrV/PJJ59w7tw5cuTIQVBQEGvXriUmJsYYovc8/7zu+fPnyZkzJ/3792fw4MEA7Ny5k3LlyhEbG4u7uzutW7fGwcHB7Mv61q1bqVy5Mjdv3sTe3j7Jdfbs2cMHH3zA9evXcXJyIiwsjCpVqrBhwwaqVatmtKdOnTrcvn072Tqe5OLiwuTJk2nTpk2SshYtWhATE8PWrVuTlN28eZPMmTMTGhpKixYtALh//z4eHh5888039OzZ04htxYoV1K9f3zgva9asbNq0iXLlyhn1ff7559y6dYv//Oc/Sa519+5d7t69a3yOj48nT548tBq9CluHjM9sn4iIiKSdmZ0CnnvMmDFjWLhwIRs2bDCbKmHRokX069ePjRs3kjdvXmN/iRIlmDRpElWrVgUevSDh6OhoNho3JCSEGzduMGbMmNRqigjw9H5o3JSCuDhYWzAyERF5awS/2Iwajzk4OHD27Fk8PDw4ePAgBQoUAKBJkybUrl2boKAgihcvTmhoKKVLl05S9k8dO3YkW7ZsDBkyxNg3ePBgIiIiWLBgQcrbJSIpohEZ6VBkZCQtWrSgQIECuLi4kD9/fgBjqNur8PHxMX42mUy4u7sb0zFFRERQsmRJI4kBUKFCBRISEsymY/L29n7hJEZy182RI4dRzz/3PY5l3759hIaG4uTkZGw1atQgISGBqKgoAA4cOED9+vXJly8fzs7OBAQEAEnv05PXfjwv4pNTUD1Nt27d+Pzzz6levTojR440pveC/xuRkZzIyEju379PhQoVjH0ZMmTggw8+ICIiwuzYUqVKGT8fPXqUO3fu8NFHH5m1e+7cuWbXfpKdnR0uLi5mm4iIiLx5xo0bx4IFC1i/fr1ZEmPx4sX069ePDRs2mCUx4NGLFWvXrgXgzp07bNmyhZIlS6Zl2PIOUz9UREQsKT4+nnPnzhmfly9fjpubG1myZKF58+ZGH+nq1avs3r3beDbUuHFjpk6dCkBUVBRbtmyhXr16AFy+fJn79+8DsH//flasWMGXX35pXCMxMZHQ0FBNKyViIVr9Lx365JNPyJMnDzNmzCBXrlwkJCRQokQJ7t27h5OTE2A+9O3xf2RfxD+HxJlMJmPKqsTERLPhdf887rEnEx0pue7jupLb9ziWhIQEvvjiC7p06ZKkrrx583Lz5k0+/vhjPv74Y/7973+TLVs2YmJiqFGjRpIFyJ91nWcJCQmhRYsW/Pbbb6xZs4aBAweycOFCGjRogIODw1PPe/y7+ee9TO7+PnkvH8f022+/8d5775kdZ2dn99x4RURE5M109uxZunfvToECBahSpQrw6N/+Xbt20bJlS9zd3Y0RnPBomk83Nze6du3KF198QbFixTCZTDRu3JgGDRoAj9bjatWqFfHx8SQmJrJw4UKmTZtmfFEXEREReZPFxcXx6aefcvv2baysrMiWLRurVq3CZDIxfPhw2rZty7Rp0wDo06cP/v7+APTs2ZPg4GAKFSqElZUVU6dOJUuWLADs3r2br776igwZMuDs7MzixYvNFgrftGkTiYmJT32xVUReLyUy0pnLly8TERHB9OnTqVixIoDZ9EXZsmUDIDY2lsyZMwOPRgc8ydbW1lir4WUUK1aMOXPmcPPmTeMB+7Zt27CysnqhRb1Tk7+/P3/99ReFChVKtvzxNFsjR4405uP952LhqcHT0xNPT0+6du1K8+bNmT17Ng0aNMDHx4eNGzcyaNCgJOcUKlQIW1tbtm7daja11N69e/nmm2+eeq1ixYphZ2dHTEwMlStXTvW2iIiISPqUO3dunjbb67NeWHFwcGDu3LnJlgUEBHD27NlUiU9EREQkvcmTJw+7d+9Otixr1qz8+uuvyZZlzJjRbPHvJ9WqVYuTJ08+9ZrVqlUzZgkRkbSnqaXSmcyZM+Pm5saPP/7IyZMn2bRpE926dTPKCxUqRJ48eQgJCeH48eP89ttvjB071qwODw8Pbty4wcaNG7l06RK3bt16oWu3bNkSe3t72rRpw5EjR9i8eTNfffUVn332mTH1U1rp1asXO3bsoFOnToSHh3PixAl++eUXvvrqK+DRqAxbW1smT57MqVOn+OWXX8zmLHxVt2/fpnPnzoSFhXH69Gm2bdvGnj178PLyAh5l8/fs2cOXX37JoUOH+O9//8v333/PpUuXyJgxI//617/o2bMna9eu5ejRo7Rv355bt249c/ihs7MzPXr0oGvXrsyZM4fIyEgOHDjA1KlTmTNnTqq1TURERERERERERORNokRGOmNlZcXChQvZt28fJUqUoGvXrowePdooz5AhAwsWLOC///0vJUuW5LvvvmPo0KFmdZQvX56OHTvStGlTsmXLxqhRo17o2o6Ojqxbt44rV65QunRpGjVqRLVq1ZgyZUqqtvFF+Pj4sGXLFk6cOEHFihXx8/Ojf//+xpC+bNmyERoaypIlSyhWrBgjR45M1UUsra2tuXz5Mq1bt8bT05MmTZpQq1YtYwSGp6cnv//+OwcPHuSDDz6gXLlyrFy5EhubR4OcRo4cyaeffspnn32Gv78/J0+eZN26dcYomqcZMmQIAwYMYMSIEXh5eVGjRg1+/fVXY50UERERERERERERkXeNKfFp49hF5I0THx+Pq6srrUavwtbh5dcyERERkddjZqcAS4cg8lo97ofGTSmIi4O1pcMREZG3QfAxS0cgIumIRmSIiIiIiIiIiIiIiEi6pUSGvJI///wTJyenp27pWfHixZ8a9/z58y0dnoiIiIiIiIiIiIgANpYOQN5spUqVIjw83NJhpMjq1au5f/9+smVpvbi5iIiIiIiIiIiIiCRPiQx5JQ4ODhQqVMjSYaRIvnz5LB2CiIiIiIiIiIiIiDyHFvsWeYsYiyzGxeHi4mLpcERERETkHaF+qIiIiIi8TlojQ0RERERERERERERE0i0lMkREREREREREREREJN1SIkNERERERERERERERNItJTJERERERERERERERCTdUiJDRERERERERERERETSLSUyREREREREREREREQk3bKxdAAikvo6/fgntg4ZLR2GiMgbY2anAEuHICLydpjnDw7Wlo5CROTZgo9ZOgIREXlJGpEhIiIiIiIiIiIiIiLplhIZIiIiIiIiIiIiIiKSbimRISIiIiIiIiIiIiIi6ZYSGSIiIiIiIiIiIiIikm4pkSEiIiIiIiIiIiIiIumWEhkiIiIiIiIiIiIiIpJuKZEhIiIiIiIiIiIiIiLplhIZqcjDw4MJEyak2fVMJhMrVqx4anl0dDQmk4nw8HAAwsLCMJlMXLt2LU3ie1X/vJ/Pa6+IiMjr0qVLFzw8PDCZTBw5csTYHxAQQIECBfD19cXX15fx48cbZUFBQeTOndso69mzp1E2depUvL298fX1xdvbm0mTJqVpe0REREQkeXfu3CEwMBBPT098fX2pWbMm0dHRACQmJhISEoKnpyclSpQgICDA7Nxp06bh5eVFiRIl8PHx4c6dO8Cz+34jR440+ou+vr64uLjQrVu3tGquiMgbw8bSAUjaKV++PLGxsbi6ugIQGhrKN99888YkNmJjY8mcObOlwxARkXdQo0aN+Pbbb/nwww+TlE2aNIm6desme17v3r3p3Llzkv2tWrWiU6dOAMTHxxtfhH18fFI3cBERERF5aR06dKBWrVqYTCamTJlChw4d+P3335k0aRKHDx/myJEj2NraEhsba5yzcuVK5s+fz86dO3F1deXChQtkyJABeHbfr3fv3vTu3RuAe/fukStXLlq2bJn2jRYRSeeUyLCw+/fvG/+wvW62tra4u7unybVehzc59udJy78DERF5eZUqVUrV+h6/VABw69YtHjx4gMlkStVriIiIiMjLs7e3p3bt2sbnsmXLGrNFjB49mrCwMGxtbQHImTOncdzo0aMZNGiQ0c/Lnj27Ufaifb8VK1aQO3du3n///VRtk4jI20BTS/3D0qVL8fb2xsHBATc3N6pXr87NmzcJCAjgm2++MTs2MDCQoKAgs33Xr1+nRYsWODk5kStXLiZPnmxWbjKZ+OGHH6hfvz4ZM2Zk6NChAPz666+8//772NvbU6BAAQYNGsSDBw+M806cOEGlSpWwt7enWLFirF+/Pknsu3fvxs/PD3t7e0qVKsWBAwfMyp+cWiosLIy2bdsSFxeHyWTCZDIREhLy3Pvj4eHB0KFDad26NU5OTuTLl4+VK1dy8eJF6tevj5OTE97e3uzdu9fsvO3bt1OpUiUcHBzIkycPXbp04ebNm0b5hQsX+OSTT3BwcCB//vzMnz8/ybX/ObVUr1698PT0xNHRkQIFCtC/f3/u379vlIeEhODr68u8efPw8PDA1dWVZs2acf369ee2E57+t/DYrFmzKF68OHZ2duTMmdPsjduYmBjjfri4uNCkSRP+/vvvJLHNmjWLAgUKYGdnR2JiInFxcXTo0IHs2bPj4uJC1apVOXjw4FNjvHv3LvHx8WabiIikrZ49e+Lt7U3Tpk05deqUWdm4cePw8fGhbt26xlSPjy1dupTixYuTL18+ow4RkTeF+qEi8q6YNGkSn3zyCfHx8Vy8eJHly5dTtmxZypYty6JFi4zjjh49yt69e6lQoQKlSpVKMnXoi/T9Zs6cSbt27V57m0RE3kRKZDwhNjaW5s2bExwcTEREBGFhYTRs2JDExMQXrmP06NH4+Piwf/9++vTpQ9euXZMkHQYOHEj9+vU5fPgwwcHBrFu3jlatWtGlSxeOHj3K9OnTCQ0NZdiwYQAkJCTQsGFDrK2t2blzJz/88AO9evUyq/PmzZvUrVuXIkWKsG/fPkJCQujRo8dT4yxfvjwTJkzAxcWF2NhYYmNjn3n8k8aPH0+FChU4cOAAderU4bPPPqN169a0atWK/fv3U6hQIVq3bm3ct8OHD1OjRg0aNmzIoUOHWLRoEVu3bjV78B8UFER0dDSbNm1i6dKlTJs2jQsXLjwzDmdnZ0JDQzl69CgTJ05kxowZZnOTA0RGRrJixQpWrVrFqlWr2LJlCyNHjnxuG5/3t/D999/TqVMnOnTowOHDh/nll18oVKgQ8GjOzMDAQK5cucKWLVtYv349kZGRNG3a1OwaJ0+eZPHixfz888/Gw606depw/vx5Vq9ezb59+/D396datWpcuXIl2ThHjBiBq6urseXJk+e5bRMRkdQzb948IiIiOHToEBUrVjSbYmrYsGGcPHmSQ4cO0a5dO2rVqsWNGzeM8kaNGvHXX39x7Ngx5s6dy7FjxyzRBBGRFFE/VETeBcOHD+fEiRMMGzaM+/fvc+/ePW7fvs3OnTtZvHgx3bp1M9ZPe/DgAZGRkfzxxx/8/vvvzJgxg9WrVxt1Pa/vd+bMGbZu3apppUREnkJTSz0hNjaWBw8e0LBhQ/Llywfw0m9HVqhQwZjb0NPTk23btjF+/Hg++ugj45gWLVoQHBxsfP7ss8/o3bs3bdq0AaBAgQIMGTKEb7/9loEDB7JhwwYiIiKIjo4md+7cwKN/TGvVqmXUMX/+fB4+fMisWbNwdHSkePHinD17ln/961/Jxmlra4urqysmk+mlp2yqXbs2X3zxBQADBgzg+++/p3Tp0jRu3Bh4NFKiXLly/P3337i7uzN69GhatGhhjGgpXLgwkyZNonLlynz//ffExMSwZs0adu7cSZkyZYBHbyF4eXk9M45+/foZP3t4eNC9e3cWLVrEt99+a+xPSEggNDQUZ2dn4NG93rhxo5Ekeprn/S0MHTqU7t278/XXXxv7SpcuDcCGDRs4dOgQUVFRxhe6efPmUbx4cfbs2WMcd+/ePebNm0e2bNkA2LRpE4cPH+bChQvY2dkBMGbMGFasWMHSpUvp0KFDkjj79OljtghYfHy8vkSKiKShx//NNZlMdO7cmR49enD58mXc3Nx47733jOMaNGhA7969OXbsWJKpAjw8PChTpgyrVq2iSJEiaRq/iEhKqR8qIm+7MWPGsGzZMjZs2ICjoyOOjo44OTnRqlUrAPLmzUuFChXYu3cvJUqUIG/evDRv3hxra2uyZMlCrVq12L17t9k0VfD0vt/s2bOpV68eWbJkSdN2ioi8KTQi4wklS5akWrVqeHt707hxY2bMmMHVq1dfqo5y5col+RwREWG2r1SpUmaf9+3bx+DBg3FycjK29u3bExsby61bt4iIiCBv3rxGEiO560RERFCyZEkcHR2fekxqeXIh0hw5cgDmD/kf73s8omLfvn2Ehoaata9GjRokJCQQFRVFREQENjY2ZvelaNGiZMqU6ZlxLF26lA8//BB3d3ecnJzo378/MTExZsd4eHgYSQx4NH/l80Z6wLP/Fi5cuMC5c+eoVq1asudGRESQJ08esy9yxYoVI1OmTGZ/C/ny5TOSGI/v040bN3BzczO7V1FRUURGRiZ7LTs7O1xcXMw2ERFJGw8ePDCbNvDnn38mR44cuLm5AXD27FmjbOfOnVy+fNkYvffkvwcXL15k48aNWuhbRN4o6oeKyNts3LhxLFiwgPXr15s9m2jevDlr164F4OrVq+zevdvow7Vo0cIou3PnDlu2bKFkyZLA8/t+iYmJhIaGalopEZFn0IiMJ1hbW7N+/Xq2b9/O77//zuTJk+nbty+7du3CysoqyRRTT67H8Cz/XMApY8aMZp8TEhIYNGgQDRs2THKuvb19slNb/bPOl5n+6lU9uSj14ziS25eQkGD87xdffEGXLl2S1JU3b15jOOXLLHK6c+dOmjVrxqBBg6hRowaurq4sXLiQsWPHPjXWx9d4HNezPOtvIWvWrM88NzExMdm2/HN/cn8HOXPmJCwsLMm5z0vqiIjI69WpUydWrlzJ+fPnqV69Ok5OThw8eJA6depw9+5drKysyJo1K7/88otxTlBQEH///TfW1tY4ODiwZMkSY6HHyZMns2XLFjJkyEBiYiJdu3Y1G70pIiIiIpZx9uxZunfvToECBahSpQrwKHm7a9cuhg8fTtu2bZk2bRrwaHSav78/AF27duWLL76gWLFimEwmGjduTIMGDYDn9/02bdpEYmLiU1+YFBERJTKSMJlMVKhQgQoVKjBgwADy5cvH8uXLyZYtG7GxscZxDx8+5MiRI8Y/ao/t3LkzyeeiRYs+85r+/v4cO3bMeEvzn4oVK0ZMTAznzp0jV65cAOzYsSPJMfPmzeP27ds4ODgkG8s/2dra8vDhw2cekxr8/f3566+/nto+Ly8vHjx4wN69e/nggw8AOHbsGNeuXXtqndu2bSNfvnz07dvX2Hf69OlUjftpfwvdunXDw8ODjRs3Jvn9w//9vs6cOWOMyjh69ChxcXHPnC7L39+f8+fPY2Njg4eHR6q2RUREXs3UqVOZOnVqkv179+596jkbNmx4atnjL78iIiIikr7kzp37qS+LZs2alV9//TXZMgcHB+bOnZts2fP6ftWqVSMqKurlAhURecdoaqknPM6u7927l5iYGJYtW8bFixfx8vKiatWq/Pbbb/z222/897//5csvv0z2Qfu2bdsYNWoUx48fZ+rUqSxZssRsHYXkDBgwgLlz5xISEsJff/1FREQEixYtMtaAqF69OkWKFKF169YcPHiQP//80+wBPjwawmhlZUW7du04evQoq1evZsyYMc+8roeHBzdu3GDjxo1cunSJW7duvdwNe0G9evVix44ddOrUifDwcE6cOMEvv/zCV199BUCRIkWoWbMm7du3Z9euXezbt4/PP//cSMgkp1ChQsTExLBw4UIiIyOZNGkSy5cvT7WYn/W3ABASEsLYsWOZNGkSJ06cYP/+/UyePBl49Pvy8fGhZcuW7N+/n927d9O6dWsqV66cZFqxJ1WvXp1y5coRGBjIunXriI6OZvv27fTr1++ZD8pERERERERERERE3mZKZDzBxcWFP/74g9q1a+Pp6Um/fv0YO3YstWrVIjg4mDZt2hgPpPPnz5/s2/jdu3dn3759+Pn5MWTIEMaOHUuNGjWeed0aNWqwatUq1q9fT+nSpSlbtizjxo0zFpm2srJi+fLl3L17lw8++IDPP/88yWLVTk5O/Prrrxw9ehQ/Pz/69u3Ld99998zrli9fno4dO9K0aVOyZcvGqFGjXvKOvRgfHx+2bNnCiRMnqFixIn5+fvTv35+cOXMax8yePZs8efJQuXJlGjZsSIcOHciePftT66xfvz5du3alc+fO+Pr6sn37dvr3759qMT/rbwGgTZs2TJgwgWnTplG8eHHq1q3LiRMngEcjOVasWEHmzJmpVKkS1atXp0CBAixatOiZ1zSZTKxevZpKlSoRHByMp6cnzZo1Izo62lh3RERERERERERERORdY0pMy8UVROS1io+Px9XVlVajV2HrkPH5J4iICAAzOwVYOgQRkTfa435o3JSCuDhYWzocEZFnCz5m6QhEROQlaUSGiIiIiIiIiIiIiIikW0pkiOHPP//EycnpqdvbJCYm5pltjYmJsXSIIiIiIiIiIiIiIgLYWDoAST9KlSpFeHi4pcNIE7ly5XpmW3PlypV2wYiIiIiIiIiIiIjIUymRIQYHBwcKFSpk6TDShI2NzTvTVhEREREREREREZE3maaWEhERERERERERERGRdMuUmJiYaOkgRCR1xMfH4+rqSlxcHC4uLpYOR0RERETeEeqHioiIiMjrpBEZIiIiIiIiIiIiIiKSbimRISIiIiIiIiIiIiIi6ZYSGSIiIiIiIiIiIiIikm4pkSEiIiIiIiIiIiIiIumWEhkiIiIiIiIiIiIiIpJu2Vg6ABFJfZ1+/BNbh4yWDkNE3mIzOwVYOgQREUmP5vmDg7WloxCRt0XwMUtHICIi6YRGZIiIiIiIiIiIiIiISLqlRIaIiIiIiIiIiIiIiKRbSmSIiIiIiIiIiIiIiEi6pUSGiIiIiIiIiIiIiIikW0pkiIiIiIiIiIiIiIhIuqVEhoiIiIiIiIiIiIiIpFtKZIiIiIiIiIiIiIiISLr1RicyPDw8mDBhQppdz2QysWLFiqeWR0dHYzKZCA8PByAsLAyTycS1a9fSJL5X9c/7+bz2ioiIiIiIiIiIiIi8bm90IiO9K1++PLGxsbi6ugIQGhpKpkyZLBvUS4iNjaVWrVqWDuOt9ab9PYiIvKguXbrg4eGByWTiyJEjxv62bdvi4+ODr68vpUuXZuPGjUbZrVu3aN68OYUKFcLT05Nly5YZZZcvXyYwMBAfHx+8vLxo06YNt2/fTtM2iYiIiEj6cufOHQIDA/H09MTX15eaNWsSHR1tdsycOXMwmUysWrXKbP+0adPw8vKiRIkS+Pj4cOfOHeD5/c6hQ4dSsGBBChYsSP/+/V97G0VE5P+8c4mM+/fvp9m1bG1tcXd3x2Qypdk1U5O7uzt2dnaWDkNERN4wjRo1YuvWreTLl89s//jx4zl06BDh4eHMmDGDpk2bkpiYCMCYMWOws7Pj5MmTrFu3ji+//JKrV68Cj74wFihQgEOHDnHkyBH+/vtvZs+enebtEhEREZH0pUOHDhw7dozw8HDq1q1Lhw4djLKzZ88yffp0ypYta3bOypUrmT9/Pjt37uTIkSNs2LCBDBkyAM/ud/7xxx8sWLCAQ4cOcfToUdasWcO6devSrrEiIu84iycyli5dire3Nw4ODri5uVG9enVu3rxJQEAA33zzjdmxgYGBBAUFme27fv06LVq0wMnJiVy5cjF58mSzcpPJxA8//ED9+vXJmDEjQ4cOBeDXX3/l/fffx97engIFCjBo0CAePHhgnHfixAkqVaqEvb09xYoVY/369Uli3717N35+ftjb21OqVCkOHDhgVv7k1FJhYWG0bduWuLg4TCYTJpOJkJCQ594fDw8Phg4dSuvWrXFyciJfvnysXLmSixcvUr9+fZycnPD29mbv3r1m523fvp1KlSrh4OBAnjx56NKlCzdv3jTKL1y4wCeffIKDgwP58+dn/vz5Sa79z6mlevXqhaenJ46OjhQoUID+/fubJYZCQkLw9fVl3rx5eHh44OrqSrNmzbh+/fpz2wmQkJDAd999R6FChbCzsyNv3rwMGzbMKD98+DBVq1Y1/lY6dOjAjRs3jPKgoCACAwMZPnw4OXLkIFOmTMbvtWfPnmTJkoXcuXMza9Ys45zH04EtXryYihUr4uDgQOnSpTl+/Dh79uyhVKlSODk5UbNmTS5evGgW7+zZs/Hy8sLe3p6iRYsybdq0JPUuW7aMKlWq4OjoSMmSJdmxYwfAM/8epk2bRuHChbG3tydHjhw0atTohe6fiEh6UalSJXLnzp1k/5Oj0K5du2aW6F+0aBGdOnUCIH/+/FSqVImVK1ca5devXychIYF79+5x69atZOsXERERkXeHvb09tWvXNvqUZcuW5dSpU0Z5hw4dGD9+fJIXNEePHs2gQYOM2TOyZ8+OtbW1Uf60fueiRYsICgoiY8aM2NnZERwczIIFC153M0VE5H9ZNJERGxtL8+bNCQ4OJiIigrCwMBo2bGi8nfkiRo8ejY+PD/v376dPnz507do1SdJh4MCB1K9fn8OHDxMcHMy6deto1aoVXbp04ejRo0yfPp3Q0FDjoXlCQgINGzbE2tqanTt38sMPP9CrVy+zOm/evEndunUpUqQI+/btIyQkhB49ejw1zvLlyzNhwgRcXFyIjY0lNjb2mcc/afz48VSoUIEDBw5Qp04dPvvsM1q3bk2rVq3Yv38/hQoVonXr1sZ9O3z4MDVq1KBhw4YcOnSIRYsWsXXrVjp37mzUGRQURHR0NJs2bWLp0qVMmzaNCxcuPDMOZ2dnQkNDOXr0KBMnTmTGjBmMHz/e7JjIyEhWrFjBqlWrWLVqFVu2bGHkyJEv1M4+ffrw3Xff0b9/f44ePcp//vMfcuTIATyacqRmzZpkzpyZPXv2sGTJEjZs2GDWJoBNmzZx7tw5/vjjD8aNG0dISAh169Ylc+bM7Nq1i44dO9KxY0fOnDljdt7AgQPp168f+/fvx8bGhubNm/Ptt98yceJE/vzzTyIjIxkwYIBx/IwZM+jbty/Dhg0jIiKC4cOH079/f+bMmWNWb9++fenRowfh4eF4enrSvHlzHjx48NS/h71799KlSxcGDx7MsWPHWLt2LZUqVXrqPbt79y7x8fFmm4hIeta7d28KFixIw4YNWbJkifHFMyYmxmwEh4eHBzExMQD079+fkydP4u7uTvbs2fHy8qJevXoWiV9ERB5RP1RE0ptJkybxySefAPD9999TvHhxypQpk+S4o0ePsnfvXipUqECpUqWYNGmSUfasfuez+qsiIvL62Vjy4rGxsTx48ICGDRsa/xh4e3u/VB0VKlSgd+/eAHh6erJt2zbGjx/PRx99ZBzTokULgoODjc+fffYZvXv3pk2bNgAUKFCAIUOG8O233zJw4EA2bNhAREQE0dHRRuZ9+PDhZutFzJ8/n4cPHzJr1iwcHR0pXrw4Z8+e5V//+leycdra2uLq6orJZMLd3f2l2li7dm2++OILAAYMGMD3339P6dKlady4MfBopES5cuX4+++/cXd3Z/To0bRo0cIY0VK4cGEmTZpE5cqV+f7774mJiWHNmjXs3LnT+Ed95syZeHl5PTOOfv36GT97eHjQvXt3Fi1axLfffmvsT0hIIDQ0FGdnZ+DRvd64caPZyIrkXL9+nYkTJzJlyhTj91KwYEE+/PBD4NH9vn37NnPnziVjxowATJkyhU8++YTvvvvOSHhkyZKFSZMmYWVlRZEiRRg1ahS3bt3i//2//wc8SpaMHDmSbdu20axZM+P6PXr0oEaNGgB8/fXXNG/enI0bN1KhQgUA2rVrR2hoqHH8kCFDGDt2LA0bNgQevT38OCn2OP7H9dapUweAQYMGUbx4cU6ePEnRokWT/XuIiYkhY8aM1K1bF2dnZ/Lly4efn99T79uIESMYNGjQM++tiEh6MnLkSEaOHMmGDRvo2bMn27Ztw9bWFsBshMaTLzUsWbIEHx8fNmzYwK1bt6hXrx6hoaFJRmmKiEjaUT9URNKT4cOHc+LECX744QeioqKYMWMG27ZtS/bYBw8eEBkZyR9//EFcXByVK1emUKFC1K5d+7n9zqf1V0VE5PWz6IiMkiVLUq1aNby9vWncuDEzZsww5sN+UeXKlUvyOSIiwmxfqVKlzD7v27ePwYMH4+TkZGzt27cnNjaWW7duERERQd68ec2mrfjndSIiIihZsiSOjo5PPSa1+Pj4GD8/fmD/ZMLn8b7HIyr27dtHaGioWftq1KhBQkICUVFRREREYGNjY3ZfihYt+tyFp5cuXcqHH36Iu7s7Tk5O9O/fP8nbBx4eHkYSAyBnzpzPHekBj+7n3bt3qVat2lPLS5YsaSQx4FESKyEhgWPHjhn7ihcvjpXV//1Z58iRw+xeWVtb4+bmliSmF7nHj8+5ePEiZ86coV27dmb3eOjQoURGRj613pw5cwI883589NFH5MuXjwIFCvDZZ58xf/58bt269dTj+/TpQ1xcnLH9c6SJiEh6Vb16da5fv87hw4cByJs3r9nijKdPnyZv3rwATJ48mZYtW2JtbY2zszONGjVi8+bNlghbRET+l/qhIpJejBkzhmXLlrFmzRocHR3ZsWMH586dw8vLCw8PD3bu3Em7du2YMWMG8Kjf2bx5c6ytrcmSJQu1atVi9+7dwLP7nc/qr4qIyOtn0USGtbU169evZ82aNRQrVozJkydTpEgRoqKisLKySpLdftGFuv+5uPaTD7/h0aiBQYMGER4ebmyHDx/mxIkT2NvbJ5tV/2edaZl5f7zo1JNxJLcvISHB+N8vvvjCrH0HDx7kxIkTFCxY0Ij9ZRYh37lzJ82aNaNWrVqsWrWKAwcO0LdvX+7du/fUWB9f43Fcz+Lg4PDM8sTExKfG++T+5K7/IjG9yD1+8v7Co+mlnrzHR44cYefOnc+t91n3w9nZmf3797NgwQJy5szJgAEDKFmyJNeuXUv2eDs7O1xcXMw2EZH06MGDB5w4ccL4vHv3bi5cuECBAgUAaNy4MVOnTgUgKiqKLVu2GMP4CxQowJo1a4BHfYG1a9dSokSJNG6BiIg8Sf1QEUkPxo0bx4IFC1i/fr3xcmaLFi04f/480dHRREdHU7ZsWWbOnEn79u2N8rVr1wJw584dtmzZQsmSJYFn9zsbN27MnDlzuHnzJnfv3mXWrFlmMz2IiMjrZdGppeDRw90KFSpQoUIFBgwYQL58+Vi+fDnZsmUjNjbWOO7hw4ccOXKEKlWqmJ3/zwfHO3fupGjRos+8pr+/P8eOHaNQoULJlhcrVoyYmBjOnTtHrly5AIxFmp88Zt68edy+fdt4CP/PWP7J1taWhw8fPvOY1ODv789ff/311PZ5eXnx4MED9u7dywcffADAsWPHnvqwHGDbtm3ky5ePvn37GvtOnz6dajEXLlwYBwcHNm7cyOeff56kvFixYkaH4XFiatu2bVhZWeHp6ZlqcbyIHDly8N5773Hq1ClatmyZ4nqe9vdgY2ND9erVqV69OgMHDiRTpkxs2rTJmMZKRCS969SpEytXruT8+fNUr14dJycn/vrrL4KCgoiLi8Pa2pqMGTOydOlSMmfODEDPnj0JDg6mUKFCWFlZMXXqVLJkyQLAxIkT6dixIyVKlCAhIYEKFSrQpUsXSzZRRERERCzs7NmzdO/enQIFChjPiuzs7Ni1a9czz+vatStffPEFxYoVw2Qy0bhxYxo0aAA8u98ZEBBAkyZNjNkbmjVrRs2aNV9jC0VE5EkWTWTs2rWLjRs38vHHH5M9e3Z27drFxYsX8fLyImPGjHTr1o3ffvuNggULMn78+GQftG/bto1Ro0YRGBjI+vXrWbJkCb/99tszrztgwADq1q1Lnjx5aNy4MVZWVhw6dIjDhw8zdOhQqlevTpEiRWjdujVjx44lPj7e7AE+PMrg9+3bl3bt2tGvXz+io6MZM2bMM6/r4eHBjRs32LhxozEt1ZNTU6WWXr16UbZsWTp16kT79u3JmDEjERERrF+/3hj1UrNmTdq3b8+PP/6IjY0N33zzzTNHRRQqVIiYmBgWLlxI6dKl+e2331i+fHmqxWxvb0+vXr349ttvsbW1pUKFCly8eJG//vqLdu3a0bJlSwYOHEibNm0ICQnh4sWLfPXVV3z22WfGVFBpKSQkhC5duuDi4kKtWrW4e/cue/fu5erVq3Tr1u2F6kju72HTpk2cOnWKSpUqkTlzZlavXk1CQgJFihR5zS0SEUk9U6dONUZXPOlp8xTDo9GTixYtSrYsf/78rFu3LtXiExEREZE3X+7cuV9otoywsDCzzw4ODsydOzfZY5/X7xwwYAADBgx4qThFRCR1WHRqKRcXF/744w9q166Np6cn/fr1Y+zYsdSqVYvg4GDatGlD69atqVy5Mvnz508yGgOge/fu7Nu3Dz8/P2MB5seLNj9NjRo1WLVqFevXr6d06dKULVuWcePGGQuOW1lZsXz5cu7evcsHH3zA559/nmSxaicnJ3799VeOHj2Kn58fffv25bvvvnvmdcuXL0/Hjh1p2rQp2bJlY9SoUS95x16Mj48PW7Zs4cSJE1SsWBE/Pz/69+9vrNEAMHv2bPLkyUPlypVp2LAhHTp0IHv27E+ts379+nTt2pXOnTvj6+vL9u3b6d+/f6rG3b9/f7p3786AAQPw8vKiadOmxnoSjo6OrFu3jitXrlC6dGkaNWpEtWrVmDJlSqrG8KI+//xzfvrpJ0JDQ/H29qZy5cqEhoaSP3/+F64jub+HTJkysWzZMqpWrYqXlxc//PADCxYsoHjx4q+xNSIiIiIiIiIiIiLplykxLRd7EJHXKj4+HldXV1qNXoWtQ8bnnyAikkIzOwVYOgQREUlHHvdD46YUxMXB2tLhiMjbIviYpSMQEZF0wqIjMkRERERERERERERERJ5FiQwL+vPPP3Fycnrq9jaJiYl5ZltjYmIsHaKIiIiIiIiIiIiIpEMWXez7XVeqVCnCw8MtHUaayJUr1zPbmitXrrQLRkRERERERERERETeGEpkWJCDgwOFChWydBhpwsbG5p1pq4iIiIiIiIiIiIikHk0tJSIiIiIiIiIiIiIi6ZYpMTEx0dJBiEjqiI+Px9XVlbi4OFxcXCwdjoiIiIi8I9QPFREREZHXSSMyREREREREREREREQk3VIiQ0RERERERERERERE0i0lMkREREREREREREREJN1SIkNERERERERERERERNItJTJERERERERERERERCTdsrF0ACKS+jr9+Ce2DhktHUa6MLNTgKVDEBEREXl3zPMHB2tLRyEib5rgY5aOQERE0jmNyBARERERERERERERkXRLiQwREREREREREREREUm3lMgQEREREREREREREZF0S4kMERERERERERERERFJt5TIEBERERERERERERGRdEuJDBERERERERERERERSbeUyBARERERERERERERkXRLiQx5J4SFhWEymbh27dozj/Pw8GDChAmpcs2QkBB8fX1TpS4RERERERERERGRd5USGfJWCggI4JtvvjE+ly9fntjYWFxdXQEIDQ0lU6ZMlglO0pWPP/4YHx8ffH19qVixIuHh4QAMHz6cIkWKYGVlxapVq8zO6du3L97e3vj6+uLr68uiRYssELmIiIiIiMjb786dOwQGBuLp6Ymvry81a9YkOjra7Jg5c+ZgMpnMvrvNmjULb29vbGxsmDJlitnxXbp0Mb7P+fr6Ym9vz6RJkwBYvny58R2xePHi9O3bl8TExNfeThEReTYbSwcgkhZsbW1xd3e3dBiSDi1evNhIaq1YsYLg4GD2799PtWrVaNq0Ke3atUtyTs+ePRk2bBgA586do2jRonz88cdkzpw5LUMXERERERF5J3To0IFatWphMpmYMmUKHTp04Pfffwfg7NmzTJ8+nbJly5qd8/7777N48WJGjBiRpL7HSQuA8+fPkz9/fpo0aQJA9erVqV+/PlZWVty7d48PP/yQMmXKUK9evdfYQhEReR6NyJC3TlBQEFu2bGHixImYTCZMJhOhoaHG1FJhYWG0bduWuLg4ozwkJCTZuuLi4ujQoQPZs2fHxcWFqlWrcvDgwRTHNnv2bLy8vLC3t6do0aJMmzbNKIuOjsZkMrFs2TKqVKmCo6MjJUuWZMeOHSm+njzfkyNz4uLisLJ69J/FMmXKULBgweeec/36dUwmEwkJCa8zTBERERERkXeSvb09tWvXxmQyAVC2bFlOnTpllHfo0IHx48djZ2dndl7JkiXx8vIyvuM9zdy5c6lRo4bx8qOzs7Nxzp07d7h79+5z6xARkddP/yWWt87EiRMpV64c7du3JzY2ltjYWPLkyWOUly9fngkTJuDi4mKU9+jRI0k9iYmJ1KlTh/Pnz7N69Wr27duHv78/1apV48qVKy8d14wZM+jbty/Dhg0jIiKC4cOH079/f+bMmWN2XN++fenRowfh4eF4enrSvHlzHjx4kGydd+/eJT4+3myTl9e6dWvy5MlDv379kvw+nmbSpEkUKVIEf39/fvzxR9zc3F5zlCIiIiLph/qhImIpkyZN4pNPPgHg+++/p3jx4pQpUybF9c2aNSvJSPzt27fj4+ND9uzZqVatGnXq1HmlmEVE5NUpkSFvHVdXV2xtbXF0dMTd3R13d3esra2NcltbW1xdXTGZTEa5k5NTkno2b97M4cOHWbJkCaVKlaJw4cKMGTOGTJkysXTp0peOa8iQIYwdO5aGDRuSP39+GjZsSNeuXZk+fbrZcT169KBOnTp4enoyaNAgTp8+zcmTJ5Otc8SIEbi6uhrbkwkbeXFz587lzJkzDB06lJ49e77QOV26dOHYsWNs376doUOHcvny5dccpYiIiEj6oX6oiFjC8OHDOXHiBMOGDSMqKooZM2YwePDgFNe3bds24uPjqV27ttn+8uXLc+jQIc6cOcOePXv4888/XzV0ERF5RUpkiDzFvn37uHHjBm5ubjg5ORlbVFQUkZGRL1XXxYsXOXPmDO3atTOra+jQoUnq8vHxMX7OmTMnABcuXEi23j59+hAXF2dsZ86ceclWypPatGnD5s2bXyopUbJkSd577z3CwsJeX2AiIiIi6Yz6oSKS1saMGcOyZctYs2YNjo6O7Nixg3PnzuHl5YWHhwc7d+6kXbt2zJgx44XrnDlzJm3atDF7+fFJ2bJlo06dOixZsiS1miEiIimkxb5FniIhIYGcOXMm+4D6yTUSXrQueDS91D+HvP6zw5QhQwbj58dzgD5t/QU7O7sk84DKi4uPj+fGjRvkypULgOXLl+Pm5kaWLFmeeV5ERAReXl4AREZGcuDAAYoVK/ba4xURERFJL9QPFZG0NG7cOBYsWMCGDRuM7+MtWrSgRYsWxjEBAQH06NGDunXrvlCdN27cYOnSpezbt89s/7FjxyhcuDBWVlZcv36dVatW0aZNm1Rri4iIpIwSGfJWsrW15eHDhykuB/D39+f8+fPY2Njg4eHxSvHkyJGD9957j1OnTtGyZctXqktST1xcHJ9++im3b9/GysqKbNmysWrVKkwmEyNGjGDq1KlcvHiRoKAg7O3tOXDgANmyZaN3796cPHmSDBkyYGNjw5QpU4zEhoiIiIiIiKSes2fP0r17dwoUKECVKlWAR8nUXbt2PfO8f//73/Tu3ZurV6+ycuVKRo4cya+//oqfnx8AixYtws/Pj8KFC5udt2TJEv7zn/+QIUMGHj58SKNGjfj8889fT+NEROSFKZEhbyUPDw927dpFdHQ0Tk5OSUY0eHh4cOPGDTZu3EjJkiVxdHTE0dHR7Jjq1atTrlw5AgMD+e677yhSpAjnzp1j9erVBAYGUqpUqZeKKSQkhC5duuDi4kKtWrW4e/cue/fu5erVq3Tr1u2V2ywvL0+ePOzevTvZsj59+tCnT59ky1auXPk6wxIREREREZH/lTt3bhITE5973D9nU2jVqhWtWrV66vHt2rVLssg3QL9+/ejXr99LxykiIq+X1siQt1KPHj2wtramWLFiZMuWjZiYGLPy8uXL07FjR5o2bUq2bNkYNWpUkjpMJhOrV6+mUqVKBAcH4+npSbNmzYiOjiZHjhwvHdPnn3/OTz/9RGhoKN7e3lSuXJnQ0FDy58+f4naKiIiIiIiIiIiIvO1MiS+S1haRN0J8fDyurq60Gr0KW4eMlg4nXZjZKcDSIYiIiIi89R73Q+OmFMTFIflFc0VEnir4mKUjEBGRdE4jMkREREREREREREREJN1SIkMkhYoXL46Tk1Oy2/z58y0dnoiIiIiIiIiIiMhbQYt9i6TQ6tWruX//frJlKVlDQ0RERERERERERESSUiJDJIXy5ctn6RBERERERERERERE3nqaWkpERERERERERERERNItU2JiYqKlgxCR1BEfH4+rqytxcXG4uLhYOhwREREReUeoHyoiIiIir5NGZIiIiIiIiIiIiIiISLqlRIaIiIiIiIiIiIiIiKRbSmSIiIiIiIiIiIiIiEi6pUSGiIiIiIiIiIiIiIikW0pkiIiIiIiIiIiIiIhIuqVEhoiIiIiIiIiIiIiIpFs2lg5ARFJfpx//xNYho6XDEHmtZnYKsHQIIiIi8k/z/MHB2tJRiEhqCz5m6QhEROQdpxEZIiIiIiIiIiIiIiKSbimRISIiIiIiIiIiIiIi6ZYSGSIiIiIiIiIiIiIikm4pkSEiIiIiIiIiIiIiIumWEhkiIiIiIiIiIiIiIpJuKZEhIiIiIiIiIiIiIiLplhIZIiIiIiIiIiIiIiKSbimRIW+M6OhoTCYT4eHhxr5t27bh7e1NhgwZCAwMtFhsyTGZTKxYscLSYYi8s9atW8f777+Pn58fJUqUYM6cOQAkJiYSEhKCp6cnJUqUICAgIMm5YWFhWFtbM2XKlDSOWkRERETkzXLnzh0CAwPx9PTE19eXmjVrEh0dDUBwcDBFihTB19eXSpUqmX2fv3XrFs2bN6dQoUJ4enqybNkyo+y3336jVKlS2NnZ0aNHD7Pr3bx5k7Zt2+Lt7U2RIkXo3bs3iYmJadFUERGxICUy5I3WrVs3fH19iYqKIjQ0lJCQEHx9fVP9Oq+rXhF5PRITE2nRogWzZ8/mwIEDrFq1ii+++ILr168zadIkDh8+zJEjRzhy5AgLFiwwO/f69ev06tWLWrVqWSh6EREREZE3S4cOHTh27Bjh4eHUrVuXDh06ABAYGMhff/1FeHg43377LU2aNDHOGTNmDHZ2dpw8eZJ169bx5ZdfcvXqVQAKFy7MzJkz6dmzZ5JrDR8+HIBDhw5x5MgRDhw4wNKlS9OglSIiYklKZMgbLTIykqpVq5I7d24yZcpk6XBEJJ25du0aAPHx8bi5uWFnZ8fo0aP57rvvsLW1BSBnzpxm53Tr1o2ePXuSNWvWtA5XREREROSNY29vT+3atTGZTACULVuWU6dOAVCvXj1sbGyM/adPnyYhIQGARYsW0alTJwDy589PpUqVWLlyJQCenp6ULFnSOPdJBw8epFatWphMJjJkyMDHH3/MvHnzXns7RUTEspTIkDS3dOlSvL29cXBwwM3NjerVq3Pz5k0AZs+ejZeXF/b29hQtWpRp06YlW8fjaaYuX75McHAwJpOJ0NBQBg0axMGDBzGZTMY+gLi4ODp06ED27NlxcXGhatWqHDx4EICLFy/i7u5uvNUBsGvXLmxtbfn999+fWe/L+J//+R+aNm1K5syZcXNzo379+sZwW4CgoCACAwMZM2YMOXPmxM3NjU6dOnH//v2n1nn37l3i4+PNNhF5NLXb4sWLadiwIfny5ePDDz9kzpw53Llzh4sXL7J8+XLKli1L2bJlWbRokXHemjVruHbtGo0aNbJg9CIiIumf+qEi8jSTJk3ik08+SbJ/4sSJ1K5dGyurR4+iYmJiyJcvn1Hu4eFBTEzMc+svXbo0ixcv5t69e1y/fp3ly5ebfbcWEZG3U9LUtshrFBsbS/PmzRk1ahQNGjTg+vXr/PnnnyQmJjJjxgwGDhzIlClT8PPz48CBA7Rv356MGTPSpk0bs3ry5MlDbGwsRYoUYfDgwTRt2hRXV1eOHDnC2rVr2bBhAwCurq4kJiZSp04dsmTJwurVq3F1dWX69OlUq1aN48ePky1bNmbNmkVgYCAff/wxRYsWpVWrVnz55Zd8/PHH3L59O9l6X8atW7eoUqUKFStW5I8//sDGxoahQ4dSs2ZNDh06ZLwZvnnzZnLmzMnmzZs5efIkTZs2xdfXl/bt2ydb74gRIxg0aNDL/hpE3noPHjxgxIgRrFy5kgoVKrBnzx4CAwM5dOgQ9+7d4/bt2+zcuZOYmBjKlStH8eLFyZ07N71792b9+vWWDl9ERCTdUz9URJIzfPhwTpw4wQ8//GC2/9///jeLFy/mzz//NNv/eBQH8MLrXPTq1Ys+ffrwwQcfkDlzZsqXL8/GjRtfPXgREUnXlMiQNBUbG8uDBw+Mt6QBvL29ARgyZAhjx46lYcOGwKOhpUePHmX69OlJEhnW1ta4u7tjMplwdXXF3d0dACcnJ2xsbIzPAJs2beLw4cNcuHABOzs74NFcnCtWrGDp0qV06NCB2rVr0759e1q2bEnp0qWxt7dn5MiRADg4OCRb78tYuHAhVlZW/PTTT0ZHbfbs2WTKlImwsDA+/vhjADJnzsyUKVOwtramaNGi1KlTh40bNz41kdGnTx+6detmfI6PjydPnjwpilHkbRIeHs65c+eoUKEC8OitrVy5cnHo0CGcnJxo1aoVAHnz5qVChQrs3buXa9euERsbywcffADApUuX+PXXX7l48aIe1IiIiPyD+qEi8k9jxoxh2bJlbNiwAUdHR2P/okWLGDRoEBs3biR79uzG/rx58xIdHU22bNkAOH36NLVr137udezt7Rk/frzxeeTIkRQrViwVWyIiIumREhmSpkqWLEm1atXw9vamRo0afPzxxzRq1IgHDx5w5swZ2rVrZ/bQ/sGDBy89+uGf9u3bx40bN3BzczPbf/v2bSIjI43PY8aMoUSJEixevJi9e/dib2//Stf9ZwwnT57E2dnZbP+dO3fMYihevDjW1tbG55w5c3L48OGn1mtnZ2ckZ0Tk/+TJk4ezZ89y7NgxihQpwsmTJ4mMjMTT05PmzZuzdu1aYzHB3bt307t3b/z9/blw4YJRR1BQEKVKlaJz584WbImIiEj6pH6oiDxp3LhxLFiwgA0bNpitX7l48WL69evHhg0byJs3r9k5jRs3ZurUqYSGhhIVFcWWLVuSjORITnx8PDY2Njg6OhIVFcX3339vrK0hIiJvLyUyJE1ZW1uzfv16tm/fzu+//87kyZPp27cvv/76KwAzZsygTJkySc55FQkJCeTMmZOwsLAkZU92sE6dOsW5c+dISEjg9OnT+Pj4vNJ1/xnD+++/z/z585OUPX77BCBDhgxmZSaTyVgITUReXI4cOZg+fTqNGjXCysqKxMREpk2bxnvvvcfw4cNp27atsQZPnz598Pf3t3DEIiIiIiJvprNnz9K9e3cKFChAlSpVgEfJzl27dtGyZUvc3d2pX7++cfzGjRtxc3OjZ8+eBAcHU6hQIaysrJg6dSpZsmQBICwsjFatWhEfH09iYiILFy5k2rRp1KtXj1OnTtGkSRNsbGywsbFh/Pjx+Pr6WqLpIiKShpTIkDRnMpmoUKECFSpUYMCAAeTLl49t27bx3nvvcerUKVq2bJnium1tbXn48KHZPn9/f86fP4+NjQ0eHh7Jnnfv3j1atmxJ06ZNKVq0KO3atePw4cPkyJHjqfW+DH9/fxYtWmQsNi4ir1/z5s1p3rx5kv1Zs2Y1kqfPEhoa+hqiEhERERF5u+TOnfup61vcv3//qedlzJiRRYsWJVsWEBDA2bNnky3z9fXl+PHjLx+oiIi80awsHYC8W3bt2sXw4cPZu3cvMTExLFu2jIsXL+Ll5UVISAgjRoxg4sSJHD9+nMOHDzN79mzGjRv3wvV7eHgQFRVFeHg4ly5d4u7du1SvXp1y5coRGBjIunXriI6OZvv27fTr14+9e/cC0LdvX+Li4pg0aRLffvstXl5etGvX7pn1voyWLVuSNWtW6tevz59//mkMm/3666+f2jkTERERERERERERESUyJI25uLjwxx9/ULt2bTw9PenXrx9jx46lVq1afP755/z000+Ehobi7e1N5cqVCQ0NJX/+/C9c/6effkrNmjWpUqUK2bJlY8GCBZhMJlavXk2lSpUIDg7G09OTZs2aER0dTY4cOQgLC2PChAnMmzcPFxcXrKysmDdvHlu3buX7779/ar0vw9HRkT/++IO8efPSsGFDvLy8CA4O5vbt2xqhISIiIiIiIiIiIvIMpsSnjf8TkTdOfHw8rq6utBq9CluHjJYOR+S1mtkpwNIhiIiIyP963A+Nm1IQF4dXW+NORNKh4GOWjkBERN5xGpEhIiIiIiIiIiIiIiLplhIZIikwf/58nJyckt2KFy9u6fBERERERERERERE3ho2lg5A5E1Ur149ypQpk2xZhgwZ0jgaERERERERERERkbeXEhkiKeDs7Iyzs7OlwxARERERERERERF562lqKRERERERERERERERSbdMiYmJiZYOQkRSR3x8PK6ursTFxeHi4mLpcERERETkHaF+qIiIiIi8ThqRISIiIiIiIiIiIiIi6ZYSGSIiIiIiIiIiIiIikm4pkSEiIiIiIiIiIiIiIumWEhkiIiIiIiIiIiIiIpJuKZEhIiIiIiIiIiIiIiLplo2lAxCR1Nfpxz+xdcj4yvXM7BTw6sGIiIiIyLtjnj84WFs6ChEIPmbpCERERCQVaUSGiIiIiIiIiIiIiIikW0pkiIiIiIiIiIiIiIhIuqVEhoiIiIiIiIiIiIiIpFtKZIiIiIiIiIiIiIiISLqlRIaIiIiIiIiIiIiIiKRbSmSIiIiIiIiIiIiIiEi6pUSGiIiIiIiIiIiIiIikW0pkyHOFhYVhMpm4du3aM4/z8PBgwoQJaRLT6xIUFERgYKClw3hjrFu3jvfffx8/Pz9KlCjBnDlzAAgICKBAgQL4+vri6+vL+PHjLRypiIiIiIjI/+nSpQseHh6YTCaOHDmSpHzOnDmYTCZWrVpl7AsKCiJ37tzG95yePXsaZX///TcNGzbEx8eHokWLmn03vnPnDkFBQXh7e1OiRAnq1avHpUuXXmv7RERE3jZKZEgSAQEBfPPNN8bn8uXLExsbi6urKwChoaFkypTJMsGlkujoaEwmE+Hh4Wb7J06cSGhoqEVi+ieTycSKFSssHcZTJSYm0qJFC2bPns2BAwdYtWoVX3zxBdevXwdg0qRJhIeHEx4eTteuXS0crYiIiIiIyP9p1KgRW7duJV++fEnKzp49y/Tp0ylbtmySst69exvfc0aPHm3s79atG97e3hw6dIi9e/cya9Ys9uzZA8D06dO5ceMGhw4d4siRI+TIkYNRo0a9vsaJiIi8hZTIkOeytbXF3d0dk8lk6VBeO1dX1zc+SZPWHo/UiY+Px83NDTs7O8sGJCIiIiIi8hyVKlUid+7cyZZ16NCB8ePHv9R3m4MHD1KnTh0AnJycqFy5MvPmzTPKb926xf3793nw4AE3btx46rVFREQkeUpkiJmgoCC2bNnCxIkTMZlMmEwmQkNDjamlwsLCaNu2LXFxcUZ5SEhIsnXFxcXRoUMHsmfPjouLC1WrVuXgwYMvFMfBgwepUqUKzs7OuLi48P7777N3716jfPv27VSqVAkHBwfy5MlDly5duHnzplHu4eHB8OHDCQ4OxtnZmbx58/Ljjz8a5fnz5wfAz88Pk8lEQECA0f4np5YKCAjgq6++4ptvviFz5szkyJGDH3/8kZs3b9K2bVucnZ0pWLAga9asMYv/6NGj1K5dGycnJ3LkyMFnn31mNnQ4ICCALl268O2335IlSxbc3d3N7qOHhwcADRo0wGQyGZ//6e7du8THx5ttacVkMrF48WIaNmxIvnz5+PDDD5kzZw62trYA9OzZE29vb5o2bcqpU6fSLC4RERERef0s2Q8VeZ2+//57ihcvTpkyZZItHzduHD4+PtStW9dshH/p0qX5z3/+Q0JCAhcuXGDdunVER0cD8MUXX+Di4kL27NnJkSMHcXFxdO7cOQ1aIyIi8vZQIkPMTJw4kXLlytG+fXtiY2OJjY0lT548Rnn58uWZMGECLi4uRnmPHj2S1JOYmEidOnU4f/48q1evZt++ffj7+1OtWjWuXLny3DhatmxJ7ty52bNnD/v27aN3795kyJABgMOHD1OjRg0aNmzIoUOHWLRoEVu3bk3SERw7diylSpXiwIEDfPnll/zrX//iv//9LwC7d+8GYMOGDcTGxrJs2bKnxjJnzhyyZs3K7t27+eqrr/jXv/5F48aNKV++PPv376dGjRp89tln3Lp1C4DY2FgqV66Mr68ve/fuZe3atfz99980adIkSb0ZM2Zk165djBo1isGDB7N+/XoAYwjy7NmziY2NNT7/04gRI3B1dTW2J39Xr9uDBw8YMWIEK1eu5PTp02zcuJE2bdpw5coV5s2bR0REBIcOHaJixYrUrVs3zeISERERkdfPkv1QkdclKiqKGTNmMHjw4GTLhw0bxsmTJzl06BDt2rWjVq1a3LhxA3j0/TM+Ph5/f39at25N1apVje+wGzZswGQycf78eWJjY8mUKdNTryEiIiLJUyJDzLi6umJra4ujoyPu7u64u7tjbW1tlNva2uLq6orJZDLKnZycktSzefNmDh8+zJIlSyhVqhSFCxdmzJgxZMqUiaVLlz43jpiYGKpXr07RokUpXLgwjRs3pmTJkgCMHj2aFi1a8M0331C4cGHKly/PpEmTmDt3Lnfu3DHqqF27Nl9++SWFChWiV69eZM2albCwMACyZcsGgJubG+7u7mTJkuWpsZQsWZJ+/fpRuHBh+vTpg4ODA1mzZqV9+/YULlyYAQMGcPnyZQ4dOgQ8eoPH39+f4cOHU7RoUfz8/Jg1axabN2/m+PHjRr0+Pj4MHDiQwoUL07p1a0qVKsXGjRvN4suUKRPu7u7G53/q06cPcXFxxnbmzJnn3tvUEh4ezrlz56hQoQLw6A2kXLlycfDgQeOLrMlkonPnzpw6dYrLly+nWWwiIiIi8npZsh8q8rrs2LGDc+fO4eXlhYeHBzt37qRdu3bMmDEDgPfeew8rq0ePURo0aICLiwvHjh0DIEuWLMyaNYvw8HDWrl0LQLFixQD44YcfaNCgAfb29tja2tKyZUs2b95sgRaKiIi8uWwsHYC8nfbt28eNGzdwc3Mz23/79m0iIyOfe363bt34/PPPmTdvHtWrV6dx48YULFjQqPvkyZPMnz/fOD4xMZGEhASioqLw8vICHiUKHnuceLlw4cJLt+XJeqytrXFzc8Pb29vYlyNHDgCj7n379rF58+ZkEzyRkZF4enomqRcgZ86cLx2fnZ2dxdakyJMnD2fPnuXYsWMUKVKEkydPEhkZSYECBfj777+N+/Lzzz+TI0eOJH8LIiIiIvLmsmQ/VOR1adGiBS1atDA+BwQE0KNHD2OE+dmzZ421LXbu3Mnly5cpVKgQAJcvX8bFxYUMGTKwf/9+VqxYwYEDBwAoUKAA69ato3HjxgCsWrWKEiVKpGXTRERE3nhKZMhrkZCQQM6cOY0REE96kcW0Q0JCaNGiBb/99htr1qxh4MCBLFy4kAYNGpCQkMAXX3xBly5dkpyXN29e4+fHw3gfM5lMJCQkvHRbkqvnyX2PF0F/XHdCQgKffPIJ3333XZK6cubMmerxWUqOHDmYPn06jRo1wsrKisTERKZNm0bWrFmpXLkyd+/excrKiqxZs/LLL79YOlwRERERERFDp06dWLlyJefPn6d69eo4OTlx8uTJZ54TFBTE33//jbW1NQ4ODixZsgRXV1cAYyriDBky4OzszOLFi43vfyEhIXTo0IHixYtjMpkoVqwY06dPf+1tFBEReZsokSFJ2Nra8vDhwxSXA/j7+3P+/HlsbGyeulD183h6euLp6UnXrl1p3rw5s2fPpkGDBvj7+/PXX38Zb76kxOMFqZ/XjpTw9/fn559/xsPDAxublP9fLEOGDK8lvtTUvHlzmjdvnmT/kwuzi4iIiIiIpDdTp05l6tSpzzzmny/mbdiw4anH1qpV66mJkCxZsrzQFMsiIiLydFojQ5Lw8PBg165dREdHc+nSpSSjBDw8PLhx4wYbN27k0qVLxiLXT6pevTrlypUjMDCQdevWER0dzfbt2+nXr99zH3Lfvn2bzp07ExYWxunTp9m2bRt79uwxpozq1asXO3bsoFOnToSHh3PixAl++eUXvvrqqxduY/bs2XFwcDAW4o6Li3vhc5+nU6dOXLlyhebNm7N7925OnTrF77//TnBw8EslJjw8PNi4cSPnz5/n6tWrqRafiIiIiIiIiIiIyJtEiQxJokePHlhbW1OsWDGyZctGTEyMWXn58uXp2LEjTZs2JVu2bIwaNSpJHSaTidWrV1OpUiWCg4Px9PSkWbNmREdHG2snPI21tTWXL1+mdevWeHp60qRJE2rVqsWgQYOAR2tLbNmyhRMnTlCxYkX8/Pzo37+/2bRNz2NjY8OkSZOYPn06uXLlon79+i987vPkypWLbdu28fDhQ2rUqEGJEiX4+uuvcXV1NRaGexFjx45l/fr15MmTBz8/v1SLT0RERERERERERORNYkpMTEy0dBAikjri4+NxdXWl1ehV2DpkfOX6ZnYKePWgREREROSt97gfGjelIC4O1pYORwSCj1k6AhEREUlFGpEhIiIiIiIiIiIiIiLplhIZYhHFixfHyckp2W3+/PmWDk9ERERERERERERE0gkbSwcg76bVq1dz//79ZMuet4aGiIiIiIiIiIiIiLw7lMgQi8iXL5+lQxARERERERERERGRN4CmlhIRERERERERERERkXTLlJiYmGjpIEQkdcTHx+Pq6kpcXBwuLi6WDkdERERE3hHqh4qIiIjI66QRGSIiIiIiIiIiIiIikm4pkSEiIiIiIiIiIiIiIumWEhkiIiIiIiIiIiIiIpJuKZEhIiIiIiIiIiIiIiLplhIZIiIiIiIiIiIiIiKSbtlYOgARSX2dfvwTW4eMqVLXzE4BqVKPiIiIiLwD5vmDg7Wlo5D0IviYpSMQERGRt4RGZIiIiIiIiIiIiIiISLqlRIaIiIiIiIiIiIiIiKRbSmSIiIiIiIiIiIiIiEi6pUSGiIiIiIiIiIiIiIikW0pkiIiIiIiIiIiIiIhIuqVEhoiIiIiIiIiIiIiIpFtKZIiIiIiIiIiIiIiISLqlRIakWEBAAN98843F60hPwsLCMJlMXLt2zdKhiIiIiIiIiIiIiLwVlMiQFFu2bBlDhgyxdBhvJQ8PDyZMmGDpMF7I2rVrKVWqFD4+PpQtW5aDBw8CMHz4cIoUKYKVlRWrVq2ycJQiIiIiIpKedOnSBQ8PD0wmE0eOHDH2P+t7RKNGjfD19TU2KysrfvnlFwAuX75MYGAgPj4+eHl50aZNG27fvg3AokWL8PPzo0SJEnh7ezN58uS0a6iIiIikCiUyJMWyZMmCs7OzpcMQC7p69SqtWrVi3rx5HDp0iO+++46WLVsCUK1aNVavXk2lSpUsHKWIiIiIiKQ3jRo1YuvWreTLl89s/7O+RyxdupTw8HDCw8P56aefyJIlCzVq1ABg6NChFChQgEOHDnHkyBH+/vtvZs+eDUDu3LlZs2YNR44cYevWrUycOJFt27a9/kaKiIhIqlEiQ1LsyWmhpk2bRuHChbG3tydHjhw0atQoRXWuXbsWV1dX5s6dC0BQUBCBgYGMGTOGnDlz4ubmRqdOnbh//75xztWrV2ndujWZM2fG0dGRWrVqceLECQASExPJli0bP//8s3G8r68v2bNnNz7v2LGDDBkycOPGDQBMJhM//fQTDRo0wNHRkcKFCxtv+byobdu2UbJkSezt7SlTpgyHDx82K//5558pXrw4dnZ2eHh4MHbsWKMsICCA06dP07VrV0wmEyaT6aWunZYiIyPJnj07Xl5eAFSuXJnTp0+zf/9+ypQpQ8GCBS0coYiIiIiIpEeVKlUid+7cSfa/6PeIWbNm0apVK+zs7Ix9169fJyEhgXv37nHr1i2j/goVKuDu7g6Aq6srRYsWJSoqKpVaIiIiImlBiQx5ZXv37qVLly4MHjyYY8eOsXbt2hS9hb9w4UKaNGnC3Llzad26tbF/8+bNREZGsnnzZubMmUNoaCihoaFGeVBQEHv37uWXX35hx44dJCYmUrt2be7fv4/JZKJSpUqEhYUBj5IeR48e5f79+xw9ehR4tK7F+++/j5OTk1HnoEGDaNKkCYcOHaJ27dq0bNmSK1euvHBbevbsyZgxY9izZw/Zs2enXr16RvJl3759NGnShGbNmnH48GFCQkLo37+/0aZly5aRO3duBg8eTGxsLLGxsU+9zt27d4mPjzfb0lLhwoW5ePEiO3fuBGD58uXcuHGD6OjoNI1DRERERNKWpfuh8m67c+cOCxYsoF27dsa+/v37c/LkSdzd3Y2XrerVq5fk3KNHj7Jjxw6qVq2aliGLiIjIK1IiQ15ZTEwMGTNmpG7duuTLlw8/Pz+6dOnyUnVMmzaNjh07snLlSurXr29WljlzZqZMmULRokWpW7cuderUYePGjQCcOHGCX375hZ9++omKFStSsmRJ5s+fz//8z/+wYsUK4NEIh8eJjD/++IOSJUtStWpVY19YWBgBAQFm1wwKCqJ58+YUKlSI4cOHc/PmTXbv3v3C7Rk4cCAfffQR3t7ezJkzh7///pvly5cDMG7cOKpVq0b//v3x9PQkKCiIzp07M3r0aODRlF3W1tY4Ozvj7u5uvDmUnBEjRuDq6mpsefLkeeEYU4Orqys///wzvXv35v333ycsLIxixYqRIUOGNI1DRERERNKWpfuh8m77+eefKVy4MN7e3sa+JUuW4OPjQ2xsLOfOneP48eNmL8ABnD17lvr16/PDDz+QK1euNI5aREREXoUSGfLKPvroI/Lly0eBAgX47LPPmD9/Prdu3Xrh83/++We++eYbfv/9d6pUqZKkvHjx4lhbWxufc+bMyYULFwCIiIjAxsaGMmXKGOVubm4UKVKEiIgI4FEi46+//uLSpUts2bKFgIAAAgIC2LJlCw8ePGD79u1UrlzZ7Jo+Pj7GzxkzZsTZ2dm45osoV66c8XOWLFnM4omIiKBChQpmx1eoUIETJ07w8OHDF74GQJ8+fYiLizO2M2fOvNT5qeHxiJd9+/YxatQozp07Z0w1JSIiIiJvp/TQD5V318yZM81GYwBMnjyZli1bGi+FNWrUiM2bNxvl586do3r16vTr14/GjRundcgiIiLyipTIkFfm7OzM/v37WbBgATlz5mTAgAGULFmSa9euvdD5vr6+ZMuWjdmzZ5OYmJik/J9v95tMJhISEgCSPf7x/sdrS5QoUQI3Nze2bNliJDIqV67Mli1b2LNnD7dv3+bDDz984Wum1ON4noztyXhTws7ODhcXF7MtrT059dWQIUOoWrUqhQoVSvM4RERERCTtpId+qLyboqKi2L17N82bNzfbX6BAAdasWQPA/fv3Wbt2LSVKlAAefWepVq0avXr1ok2bNmkes4iIiLw6JTIkVdjY2FC9enVGjRrFoUOHiI6OZtOmTS90bsGCBdm8eTMrV67kq6++eqnrFitWjAcPHrBr1y5j3+XLlzl+/LgxKuDxOhkrV67kyJEjVKxYEW9vb+7fv88PP/yAv78/zs7OL3Xd53m8ZgQ8Wpfj+PHjFC1a1Ih569atZsdv374dT09PY+SJra3tS4/OsJT+/ftTtGhRChUqxOnTp5k5cybwaLqB3Llzs2PHDoKCgsidOzcXL160cLQiIiIiIpIedOrUidy5c3P27FmqV69uvAz1vO8Rs2bN4tNPP02SPJs4cSLbt2+nRIkSlCxZEnd3d2PK4wEDBhATE8PEiRPx9fXF19eX2bNnp11jRURE5JXZWDoAefOtWrWKU6dOUalSJTJnzszq1atJSEigSJEiL1yHp6cnmzdvJiAgABsbGyZMmPBC5xUuXJj69evTvn17pk+fjrOzM7179+a9994zW2sjICCArl274ufnZ3R4K1WqxPz58+nWrdtLtfdFDB48GDc3N3LkyEHfvn3JmjUrgYGBAHTv3p3SpUszZMgQmjZtyo4dO5gyZQrTpk0zzvfw8OCPP/6gWbNm2NnZkTVr1lSPMbX89NNPye7v06cPffr0SeNoRERERETkTTB16lSmTp2aZP/zvkcMGTIk2f358+dn3bp1yZbNmDGDGTNmpCxQERERSRc0IkNeWaZMmVi2bBlVq1bFy8uLH374gQULFlC8ePGXqqdIkSJs2rSJBQsW0L179xc+b/bs2bz//vvUrVuXcuXKkZiYyOrVq82mh6pSpQoPHz40W9S7cuXKPHz4MMn6GKlh5MiRfP3117z//vvExsbyyy+/YGtrC4C/vz+LFy9m4cKFlChRggEDBjB48GCCgoKM8wcPHkx0dDQFCxYkW7ZsqR6fiIiIiIiIiIiIyJvClJjSyflFJN2Jj4/H1dWVVqNXYeuQMVXqnNkpIFXqEREREZG31+N+aNyUgrg4WFs6HEkvgo9ZOgIRERF5S7zSiIy//vqLZs2aUbBgQezs7Ni/fz8Affv2NRbZEhERERERERERERERSakUJzLWr1+Pn58f0dHRNGvWjPv37xtlGTJkMJvvX95NMTExODk5PXWLiYmxdIgvrWPHjk9tT8eOHS0dnoiIiIiIiIiIiMhbJ8WLfffp04dmzZoxd+5cHjx4wIgRI4wyPz+/py4ALO+OXLlyER4e/szyN83gwYPp0aNHsmWPFxEXERERERERERERkdST4kTGkSNHjOSFyWQyK8uUKROXLl16tcjkjWdjY0OhQoUsHUaqyp49O9mzZ7d0GCIiIiIiIiIiIiLvjBRPLZUlSxbOnTuXbNnx48fJmTNnioMSERERERERERERERGBVxiRERgYyMCBAylbtqzx1r3JZOL8+fOMGTOGTz/9NNWCFJGXM7VDRU11JSIiIiJp77P9oH6oiIiIiKSyFI/IGDFiBNmyZcPHx4cyZcoAEBwcTJEiRXB1dSUkJCS1YhQRERERERERERERkXdUikdkuLq6sn37dv7973+zfv16smTJQpYsWejUqROtW7fG1tY2NeMUEREREREREREREZF3kCkxMTHxZU+6c+cOTZo0oXv37lSuXPl1xCUiKRAfH4+rqytxcXGaWkpERERE0oz6oSIiIiLyOqVoail7e3u2bNlCQkJCascjIiIiIiIiIiIiIiJiSPEaGR9//DHr169PzVhERERERERERERERETMpHiNjLZt29KxY0du3LhBrVq1yJ49OyaTyewYf3//Vw5QRERERERERERERETeXSlaIwPAysp8MMeTSYzExERMJhMPHz58tehE5KU8npu41ehV2DpkfOHzZnYKeH1BiYiIiMhbz1gjY0pBXBysLR3O2yv4mKUjEBEREbGIFI/I2Lx5c2rGISIiIiIiIiIiIiIikkSKExmVK1dOzThERERERERERERERESSSPFi3yIiIiIiIiIiIiIiIq9bikdkWFlZJVnc+5+0RoaIiIiIiIiIiIiIiLyKFCcyRo0alSSRceXKFdavX8/ff//NV1999crBiYiIiIiIiIiIiIjIuy3FiYwePXoku3/YsGG0atWK+Pj4FAclIiIiIiIiIiIiIiICr2mNjNatW/Pjjz++jqpFREREREREREREROQd8loSGcePH9f6GOlQdHQ0JpOJ8PBwY9+2bdvw9vYmQ4YMBAYGWiy29CK5eyRw9+5dOnfuTOHChSlevDitWrUC4MKFC9SsWZPChQtTokQJtm7dauFIRURERETeTdeuXcPX19fYPD09sbGx4cqVK+zdu5dy5crh5+eHl5cXo0aNMs6LjIykWrVq+Pr6UrRoUbp3705CQgIAf//9Nw0bNsTHx4eiRYsyYcIEC7VORERE3nUpnlpq3LhxSfbdu3ePiIgIlixZQosWLV4pMEkb3bp1w9fXlzVr1uDk5ERISAgrVqxI9Qf5r6veVxEUFMS1a9dYsWKFsS9PnjzExsaSNWtWywX2v9LTPevduzdWVlYcP34ck8lEbGyssb9s2bKsXbuWPXv20KhRIyIjI7GxSfF/WkREREREJAUyZcpk9t1hzJgxbNmyhSxZslCtWjUGDRpEvXr1uHLlCkWLFqVu3boUK1aMHj16UL9+fbp06cKdO3coXbo01apVo3bt2nTr1g1vb2+WLVvGjRs3KF++PBUqVKB06dKWa6iIiIi8k1J1jQw7Ozty587N119/Tf/+/V8pMEkbkZGRdOzYkdy5c1s6lHTB2toad3d3S4eRrty8eZPZs2dz9uxZTCYTADlz5gRg8eLFREVFAVC6dGly5MjB1q1bCQgIsFS4IiIiIiICzJ49m2HDhhmfr127Bjzq39va2pIlSxajLC4uDoDbt29z//59o79/8OBBvv76awCcnJyoXLky8+bNUyJDRERE0lyKp5ZKSEhIst2+fZsTJ04wYsQIHB0dUzNOecLSpUvx9vbGwcEBNzc3qlevzs2bN4FHnVUvLy/s7e0pWrQo06ZNS7aOx1MoXb58meDgYEwmE6GhoQwaNIiDBw9iMpmMffCoY9uhQweyZ8+Oi4sLVatW5eDBgwBcvHgRd3d3hg8fbtS/a9cubG1t+f33359Z77OEhISQN29e7OzsyJUrF126dDHK7t27x7fffst7771HxowZKVOmDGFhYUZ5aGgomTJlYt26dXh5eeHk5ETNmjWNkQQhISHMmTOHlStXGjGFhYUlmVoqLCwMk8nEunXr8PPzw8HBgapVq3LhwgXWrFmDl5cXLi4uNG/enFu3bhnXT0xMZNSoURQoUAAHBwdKlizJ0qVLjfLH9W7cuJFSpUrh6OhI+fLlOXbsmBH/i9yzu3fvEh8fb7altsjISNzc3Bg6dCilSpWiYsWKbNy4kcuXL5OQkEC2bNmMYz08PIiJiUn1GEREREQkfUmLfqik3I4dO7h8+TJ169YFHn1P7N+/P3nz5sXT05MRI0YYL3BNmDCBJUuWkCtXLnLlykXr1q3x8/MDHr2s9J///IeEhAQuXLjAunXriI6OtlSzRERE5B2W4kTG3LlzuXz5crJlV65cYe7cuSkOSp4uNjaW5s2bExwcTEREBGFhYTRs2JDExERmzJhB3759GTZsGBEREQwfPpz+/fszZ86cJPU8nkLJxcWFCRMmEBsbS9OmTenevTvFixcnNjbW2JeYmEidOnU4f/48q1evZt++ffj7+1OtWjWuXLlCtmzZmDVrFiEhIezdu5cbN27QqlUrvvzySz7++OOn1vssS5cuZfz48UyfPp0TJ06wYsUKvL29jfK2bduybds2Fi5cyKFDh2jcuDE1a9bkxIkTxjG3bt1izJgxzJs3jz/++IOYmBhjJFGPHj1o0qSJkdyIjY2lfPnyT40nJCSEKVOmsH37ds6cOUOTJk2YMGEC//nPf/jtt99Yv349kydPNo7v168fs2fP5vvvv+evv/6ia9eutGrVii1btpjV27dvX8aOHcvevXuxsbEhODgY4IXv2YgRI3B1dTW2PHnyPPO+psT9+/c5deoUxYoVY+/evUyZMoVmzZrx4MEDY4TGY4mJial+fRERERFJf9KiHyopN2vWLFq3bm1M+Tp69GhGjx5NTEwMf/31F3379jVeopo+fTqfffYZ586d4/Tp0/znP/9h06ZNAIwdO5b4+Hj8/f1p3bo1VatWJUOGDBZrl4iIiLy7Ujy1VNu2bdmxYwdubm5JyqKiomjbti2tW7d+peAkqdjYWB48eEDDhg3Jly8fgPGAf8iQIYwdO5aGDRsCkD9/fo4ePcr06dNp06aNWT2Pp1AymUy4uroab+M4OTlhY2NjNr3Spk2bOHz4MBcuXMDOzg54NN/qihUrWLp0KR06dKB27dq0b9+eli1bUrp0aezt7Rk5ciQADg4Oydb7LDExMbi7u1O9enUyZMhA3rx5+eCDD4BHIwQWLFjA2bNnyZUrF/AoMbF27Vpmz55tjAy5f/8+P/zwAwULFgSgc+fODB482Ging4MDd+/efaGYhg4dSoUKFQBo164dffr0ITIykgIFCgDQqFEjNm/eTK9evbh58ybjxo1j06ZNlCtXDoACBQqwdetWpk+fTuXKlY16hw0bZnzu3bs3derU4c6dOy98z/r06UO3bt2Mz/Hx8an+JTJfvnxYWVnRsmVLAEqWLEn+/PmJiIgAHo3IeTwq4/Tp0+TNmzdVry8iIiIi6U9a9EMlZW7evMmiRYvYvXs3AJcuXWL58uXMnz8fePTdpEyZMmzfvp0iRYowadIkTp06BUD27NmpVasWW7ZsoWrVqmTJkoVZs2YZdXfs2JFixYqlfaNERETknZfiERnPevP66tWrODs7p7RqeYaSJUtSrVo1vL29ady4MTNmzODq1atcvHiRM2fO0K5dO5ycnIxt6NChREZGvtI19+3bx40bN3BzczOrOyoqyqzuMWPG8ODBAxYvXsz8+fOxt7dP8TUbN27M7du3KVCgAO3bt2f58uU8ePAAgP3795OYmIinp6dZPFu2bDGLx9HR0UhiwKN1HS5cuJCieHx8fIyfc+TIgaOjo5HEeLzvcd1Hjx7lzp07fPTRR2bxzZ07N8nv4sl6H89D+zIx2tnZ4eLiYraltqxZs1KtWjXWrVsHPEpWREVFUaRIERo3bszUqVMB2LNnD+fPn+fDDz9M9RhEREREJH1Ji36opMySJUvw8fGhaNGiAGTOnBl7e3tjdPilS5fYuXMnJUqUAB4lNtasWQM8SoJs2rTJKLt8+TL3798HHn0PW7FiBV9++WVaN0lERETk5UZkrFmzxujgwKNhpjly5DA75s6dO2zatAlfX99UCVDMWVtbs379erZv387vv//O5MmT6du3L7/++isAM2bMoEyZMknOeRUJCQnkzJnTbA2KxzJlymT8fOrUKc6dO0dCQgKnT582e0j/svLkycOxY8dYv349GzZs4Msvv2T06NFs2bKFhIQErK2t2bdvX5K2OTk5GT//c8izyWRK8dRHT9ZlMpmSrTshIQHA+N/ffvuN9957z+y4xyNanlbvk+enJz/88APBwcH06tULa2trfvzxR3LmzMl3333HZ599RuHChbG1tWXevHnG8HUREREREUl7M2fOpF27dsZna2trFi9eTLdu3Xjw4AH379+nR48exoLdc+bMoXPnzowdO5b79+8TGBhIo0aNANi9ezdfffUVGTJkwNnZmcWLFxsvYImIiIikpZd64nj8+HHjgbnJZOLPP/9M8mDW1taWEiVKmC38LKnLZDJRoUIFKlSowIABA8iXLx/btm3jvffe49SpU8YUQClha2vLw4cPzfb5+/tz/vx5bGxs8PDwSPa8e/fu0bJlS5o2bUrRokVp164dhw8fNhJdydX7PA4ODtSrV4969erRqVMnihYtyuHDh/Hz8+Phw4dcuHCBihUrpqidKY3pRRQrVgw7OztiYmLMppF6Wa8rvpQoUKBAsomsHDly8Pvvv6d9QCIiIiIikqw///wzyb7q1auzb9++ZI/38/Nj27ZtyZbVqlWLkydPpmp8IiIiIinxUomMr7/+mq+//hp4tP7CihUrKFmy5GsJTJK3a9cuNm7cyMcff0z27NnZtWsXFy9exMvLi5CQELp06YKLiwu1atXi7t277N27l6tXr5rNX/ssHh4eREVFER4eTu7cuXF2dqZ69eqUK1eOwMBAvvvuO4oUKcK5c+dYvXo1gYGBlCpVir59+xIXF8ekSZNwcnJizZo1tGvXjlWrVj213n8mwZ4UGhrKw4cPKVOmDI6OjsybNw8HBwfy5cuHm5sbLVu2pHXr1owdOxY/Pz8uXbrEpk2b8Pb2pnbt2i/c1nXr1nHs2DHc3NxwdXV9ofOex9nZmR49etC1a1cSEhL48MMPiY+PZ/v27Tg5OSVZr+RZ8b3MPRMRERERERERERF5G6V4jYyoqCglMSzAxcWFP/74g9q1a+Pp6Um/fv0YO3YstWrV4vPPP+enn34iNDQUb29vKleuTGhoKPnz53/h+j/99FNq1qxJlSpVyJYtGwsWLMBkMrF69WoqVapEcHAwnp6eNGvWjOjoaHLkyEFYWBgTJkxg3rx5uLi4YGVlxbx589i6dSvff//9U+t9lkyZMjFjxgwqVKiAj48PGzdu5NdffzUWl589ezatW7eme/fuFClShHr16rFr166XWmCwffv2FClShFKlSpEtW7anvoWUEkOGDGHAgAGMGDECLy8vatSowa+//vrKvwsRERERERERERGRd40pMaWLBvyvkydPcvz4ce7cuZOkrGHDhq9StYi8pPj4eFxdXWk1ehW2Dhlf+LyZnQJeX1AiIiIi8tZ73A+Nm1IQF4dXW6NPniH4mKUjEBEREbGIFK/KGx8fT8OGDdm8eTOAsYjy4wWLgXQzv7+IiIiIiIiIiIiIiLyZUjy1VK9evYiNjeXPP/8kMTGR5cuXExYWRrt27cifPz87d+5MzTjlLTN//nycnJyS3YoXL27p8EREREREREREREQknUjxiIy1a9cybNgwypQpA0CuXLkoXbo0lSpVokePHowdO5aFCxemWqDydqlXr57xt/NPGTJkSONoRERERERERERERCS9SnEi48KFC+TJkwdra2syZszI5cuXjbJatWrx6aefpkqA8nZydnbG2dnZ0mGIiIiIiIiIiIiISDqX4qml8uTJw6VLlwAoXLgwv/zyi1G2fft27O3tXz06ERERERERERERERF5p6V4RMZHH33Ehg0baNCgAV27dqVNmzbs2rULW1tbdu/eTffu3VMzThF5CVM7VMTFxcXSYYiIiIjIu+az/aB+qIiIiIikMlNiYmJiSk68desWt27dImvWrAAsX76cpUuXcvv2bT766CO++OILrKxSPOBDRFIgPj4eV1dX4uLilMgQERERkTSjfqiIiIiIvE4pTmSISPqjL5AiIiIiYgnqh4qIiIjI65TiqaUei4iIYO/evZw5c4bg4GDc3d05efIkOXLk0GLOIiIiIiIiIiIiIiLySlKcyLh16xaff/45ixcvBiAxMZGaNWvi7u5Onz59yJ8/P6NGjUq1QEVERERERERERERE5N2T4kUsevTowaZNm1i1ahVxcXE8OUNV7dq1Wbt2baoEKCIiIiIiIiIiIiIi764Uj8hYunQpo0ePpmbNmjx8+NCszMPDg+jo6FeNTURSqNOPf2LrkNHSYQAws1OApUMQERERkbQyzx8crC0dxdsh+JilIxARERFJN1I8IuPGjRvkzJkz2bKbN2+mOCAREREREREREREREZHHUpzI8PHx4eeff0627LfffqNUqVIpDkpERERERERERERERAReYWqp/v37U79+fW7dukXjxo0xmUzs3r2bBQsWMGvWLFavXp2acYqIiIiIiIiIiIiIyDsoxSMy6tSpw8KFC9m6dSuBgYEkJiby5ZdfsmjRIubPn0+1atVSM04REREREREREREREXkHvdSIjGLFirFo0SK8vb0BaNSoEXfu3MHT05MHDx6QJUsWihYt+loCFRERERERERERERGRd89Ljcj473//y+3bt43PDx8+pE2bNtjY2FC+fHklMUREREREREREREREJFWleGqpxxITE1MjDhERERERERERERERkSReOZEh6V9YWBgmk4lr16498zgPDw8mTJiQKtcMCQnB19c3Vep605hMJlasWGHpMN4YXbp0wcPDA5PJxJEjR4z9iYmJhISE4OnpSYkSJQgICDDKGjVqhK+vr7FZWVnxyy+/WCB6EREREZG0d+3aNbP+sKenJzY2Nly5csU4Zs6cOZhMJlatWmXsCwoKInfu3MZ5PXv2NKv3559/xtvbm+LFi1OsWDGio6PTqkkiIiIiz/RSa2TAo4e0L7JPLCcgIABfX18jKVG+fHliY2NxdXUFIDQ0lG+++ea5iQ2RtNCoUSO+/fZbPvzwQ7P9kyZN4vDhwxw5cgRbW1tiY2ONsqVLlxo/7927l5o1a1KjRo00i1lERERExJIyZcpEeHi48XnMmDFs2bKFLFmyAHD27FmmT59O2bJlk5zbu3dvOnfunGT/gQMH6NevHxs3biRXrlzEx8djY/PSjwxEREREXouX7pVUqVIFKyvzgRwVK1ZMss9kMhEXF/dq0UmqsLW1xd3d3dJhyCu4d+8etra2lg7jtahUqVKy+0ePHk1YWJjR7pw5cyZ73KxZs2jVqhV2dnavLUYRERERkfRs9uzZDBs2zPjcoUMHxo8fT69evV64jrFjx9K9e3dy5coFgIuLS6rHKSIiIpJSLzW11MCBA+nZsyfdu3c3tuT2de/enW7dur2umOUZgoKC2LJlCxMnTsRkMmEymQgNDTWmlgoLC6Nt27bExcUZ5SEhIcnWFRcXR4cOHciePTsuLi5UrVqVgwcPvlQ88+bNw8PDA1dXV5o1a8b169eNsrVr1/Lhhx+SKVMm3NzcqFu3LpGRkUb5vXv36Ny5Mzlz5sTe3h4PDw9GjBjxQtc1mUz89NNPNGjQAEdHRwoXLmw29VBoaCiZMmUyO2fFihVmo4seT481a9Ys8ubNi5OTE//61794+PAho0aNwt3dnezZs5t9YXgsNjaWWrVq4eDgQP78+VmyZIlZ+f/8z//QtGlTMmfOjJubG/Xr1zcbth0UFERgYCAjRowgV65ceHp6JtvOu3fvEh8fb7a9DeLj47l48SLLly+nbNmylC1blkWLFiU57s6dOyxYsIB27dpZIEoRERGRd9fb2g99E+3YsYPLly9Tt25dAL7//nuKFy9OmTJlkj1+3Lhx+Pj4ULduXbNRHUePHiUmJobKlSvj5+dH//79efjwYVo0QUREROS5XmpExsCBA19XHJJKJk6cyPHjxylRogSDBw8G4K+//jLKy5cvz4QJExgwYADHjh0DwMnJKUk9iYmJ1KlThyxZsrB69WpcXV2ZPn061apV4/jx48aQ5WeJjIxkxYoVrFq1iqtXr9KkSRNGjhxpPPi/efMm3bp1w9vbm5s3bzJgwAAaNGhAeHg4VlZWTJo0iV9++YXFixeTN29ezpw5w5kzZ174XgwaNIhRo0YxevRoJk+eTMuWLTl9+vQLxf5kG9asWcPatWuJjIykUaNGREVF4enpyZYtW9i+fTvBwcFUq1bNbNh2//79GTlyJBMnTmTevHk0b96cEiVK4OXlxa1bt6hSpQoVK1bkjz/+wMbGhqFDh1KzZk0OHTpkjEDYuHEjLi4urF+/nsTExGTjGzFiBIMGDXrh9rwp7t+/z71797h9+zY7d+4kJiaGcuXKUbx4cUqUKGEc9/PPP1O4cGG8vb0tGK2IiIjIu+dt7Ye+iWbNmkXr1q2xsbEhKiqKGTNmsG3btmSPHTZsGDlz5sTKyorly5dTq1YtTpw4gZOTE/fv32ffvn2sXbuWxMRE6tWrx/Tp0/nyyy/TuEUiIiIiSWmx77eMq6srtra2ODo64u7ujru7O9bW1ka5ra0trq6umEwmozy5RMbmzZs5fPgwS5YsoVSpUhQuXJgxY8aQKVMms/UJniUhIYHQ0FBKlChBxYoV+eyzz9i4caNR/umnn9KwYUMKFy6Mr68vM2fO5PDhwxw9ehSAmJgYChcuzIcffki+fPn48MMPad68+Qvfi6CgIJo3b06hQoUYPnw4N2/eZPfu3S98/uM2zJo1i2LFivHJJ59QpUoVjh07xoQJEyhSpAht27alSJEihIWFmZ3XuHFjPv/8czw9PRkyZAilSpVi8uTJACxcuBArKyt++uknvL298fLyYvbs2cTExJjVkzFjRn766ackD++f1KdPH+Li4oztZRI96ZmbmxtOTk60atUKgLx581KhQgX27t1rdtzMmTM1GkNERETEAt7Wfuib5ubNmyxatIjg4GDg0eiMc+fO4eXlhYeHBzt37qRdu3bMmDEDgPfee8+YFrpBgwa4uLgYL7jly5ePTz/9FAcHBxwdHWnYsOFLf38SEREReV2UyJBk7du3jxs3bhgPlB9vUVFRZtM/PYuHhwfOzs7G55w5c3LhwgXjc2RkJC1atKBAgQK4uLiQP39+4FECAx4lIsLDwylSpAhdunTh999/f6k2+Pj4GD9nzJgRZ2dns+unpA05cuSgWLFiZmvC5MiRI0m95cqVS/I5IiICeHRvT548ibOzs3Ffs2TJwp07d8zurbe393PXxbCzs8PFxcVse1s0b96ctWvXAnD16lV2795t9juNiopi9+7dL5XcEhEREZHU8Tb3Q98kS5YswcfHh6JFiwLQokULzp8/T3R0NNHR0ZQtW5aZM2fSvn174NEi4I/t3LmTy5cvU6hQIePc33//nYSEBB4+fMj69espWbJk2jdKREREJBkvvdi3vBsSEhLImTNnkpEGQJK1JZ4mQ4YMZp9NJhMJCQnG508++YQ8efIwY8YMcuXKRUJCAiVKlODevXsA+Pv7ExUVxZo1a9iwYQNNmjShevXqLzwi5FnXt7KySjJd0/3791+ojue162ker7+RkJDA+++/z/z585Mcky1bNuPnjBkzPrfOt0GnTp1YuXIl58+fp3r16jg5OXHy5EmGDx9O27ZtmTZtGvDorT9/f3/jvFmzZvHpp5/qS7OIiIiIvLNedoRyUFAQf//9N9bW1jg4OLBkyRJcXV0BaNasGXv37qV48eJYW1tTqVIlOnfu/LpCFxEREXkpSmS8hWxtbZ+5KNvzyuFREuH8+fPY2Njg4eGRyhHC5cuXiYiIYPr06VSsWBGArVu3JjnOxcWFpk2b0rRpUxo1akTNmjW5cuXKS61zkZxs2bJx/fp1bt68aSQMnlzo7lXt3LmT1q1bm3328/MDHt3bRYsWGYuov+umTp3K1KlTk+zPmjUrv/7661PPGzJkyOsMS0REREQk3fvzzz+fWf7PF9M2bNjw1GOtrKwYN24c48aNS43QRERERFKVppZ6C3l4eLBr1y6io6O5dOlSktECHh4e3Lhxg40bN3Lp0iVu3bqVpI7q1atTrlw5dNqP7wAAc8NJREFUAgMDWbduHdHR0Wzfvp1+/folWacgJTJnzoybmxs//vgjJ0+eZNOmTXTr1s3smPHjx7Nw4UL++9//cvz4cZYsWYK7u/sLjwh5ljJlyuDo6Mj/+3//j5MnT/Kf//yH0NDQV673sSVLljBr1iyOHz/OwIED2b17t/E2U8uWLfn/7d15eE1X+//xz4lIkImYkhCJKZpRTDUVMVXNtErVlKKalqrWUL6tmuehKJ6q1vCgNRQdFDUGNU8pKcWDCG2UGpKaQpL9+8Pl/HqahNAk5yTer+vaV529117r3nvlNOvkPmvtIkWKqHXr1tqxY4fOnj2rbdu26Z133rGY6g0AAAAAAAAAIJGRKw0YMEB58uRRQECAihYtan7mxAO1atVSRESEOnTooKJFi2rixImp6jCZTFq7dq3q1q2r7t27y8/PT6+88opiYmJUvHjxfx2jnZ2dli5dqoMHDyooKEjvvvuuJk2aZFHG2dlZEyZMUNWqVVWtWjXFxMRo7dq1Fs+neFLu7u5avHix1q5dq+DgYH311VcaPnz4v673gREjRmjp0qUKCQnRwoULtWTJEgUEBEiSChQooO3bt6tUqVJ68cUX5e/vr+7du+v27dvM0AAAAAAAAACAfzAZ/3xQAIAcKyEhQW5ubuo8aY0c8tvGMza+6B1m7RAAAACQxR6MQ+NnlpVr/jzWDid36H7C2hEAAADYDGZkAAAAAAAAAAAAm0UiA08kMDBQzs7OaW5LlizJ0raXLFmSbtuBgYFZ2jYAAAAAAAAAIHvZWzsA5Exr167VvXv30jyWGc/QeJhWrVqpevXqaR7LmzdvlrYNAAAAAAAAAMheJDLwRHx8fKzWtouLi1xcXKzWPgAAAAAAAAAg+7C0FAAAAAAAAAAAsFkmwzAMawcBIHMkJCTIzc1N8fHxcnV1tXY4AAAAeEowDgUAAEBWYkYGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtlb+0AAGS+3p/tkEN+J2uHgb/5oneYtUMAAADIeosqS/nzWDuKnKX7CWtHAAAAYPOYkQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMpAtwsLC1K9fP2uHAQAAAAAAAADIYUhkIFusWrVKo0aN+ld1ZFUyxBaTLLYYE7LHiBEjZDKZFB0dLUmqVauWQkNDFRoaqqCgIJlMJh05ckSSNG/ePAUHB8ve3l4zZ860ZtgAAADIIomJierTp4/Kly+vwMBAde7cWZK0f/9+1a5dWyEhIQoNDdWWLVvM53zwwQcKDg42jyOXLVtmPjZr1izzseDgYM2YMSPbrwkAAOBx2Vs7ADwd3N3drR0CYPMOHTqkPXv2qFSpUuZ9u3btMv/766+/1ogRIxQSEiJJqlKlipYvX65x48Zle6wAAADIHoMHD5adnZ1Onjwpk8mkuLg4GYahtm3batGiRapfv75+/fVXNW7cWCdPnlT+/Pk1cOBAjRkzRpL0+++/65lnntHzzz+vQoUKqXPnzurdu7ckKSEhQUFBQQoLCzOPMQEAAGwRMzKQLf4+w2D27NkqX7688uXLp+LFi6tdu3aPPD88PFzbtm3T9OnTZTKZZDKZFBMTI0k6duyYmjVrJmdnZxUvXlxdunTRn3/+KUmKjIyUg4ODduzYYa5rypQpKlKkiOLi4h5ab3oiIyNlMpn0ww8/qGLFisqXL5+qV6+uo0ePWpRbuXKlAgMD5ejoKF9fX02ZMsXieHr34UliQs6XmJio3r17a/bs2TKZTGmWmTdvnnr06GF+XbFiRfn7+8vOjv+VAwAA5EY3b97U/PnzNXbsWPMY0dPTU1euXNHVq1dVv359SdIzzzyjggULat26dZKkggULmuv466+/ZDKZlJKSIklyc3MzH7t165aSkpLSHX8CAADYCv76hWx14MAB9e3bVyNHjtSJEye0fv161a1b95HnTZ8+XTVr1tTrr7+uuLg4xcXFydvbW3FxcapXr55CQ0N14MABrV+/Xn/88Yfat28v6f8nULp06aL4+Hj9/PPP+uCDDzR37lx5enqmW29GDBw4UJMnT9b+/ftVrFgxtWrVSvfu3ZMkHTx4UO3bt9crr7yio0ePavjw4Ro6dKgWLFjwyPvwODElJiYqISHBYkPO9NFHH6lz584qXbp0msd/++03RUZGmpcSAAAAsCbGodnj9OnTKly4sEaPHq2qVauqTp062rx5s4oUKaLixYtr5cqVkqS9e/fq5MmTFl+AmjFjhipUqKDKlSvrs88+U+HChc3Hvv76awUGBsrHx0cDBw5UcHBwdl8aAADAY2FpKWSr2NhYOTk5qUWLFnJxcZGPj48qVar0yPPc3Nzk4OCgAgUKyMPDw7z/P//5jypXrqyxY8ea982bN0/e3t46efKk/Pz8NHr0aG3atEm9evXSL7/8oi5duqht27YPrTcjhg0bpsaNG0uSFi5cqJIlS2r16tVq3769pk6dqoYNG2ro0KGSJD8/Px07dkyTJk1SeHj4Q+/D48Q0btw4jRgx4rHihu3ZvXu39u/fr/Hjx6dbZsGCBWrRooWKFCmSjZEBAACkjXFo9rh3757OnDmjgIAAjR8/Xj///LMaNWqkY8eO6dtvv9X777+vMWPGKDg4WM8995zy5s1rPrdv377q27evfv75Z3Xu3FmNGjUyJzPatWundu3aKSYmRm3btlWzZs1UoUIFa10mAADAIzEjA9mqcePG8vHxUZkyZdSlSxctWbJEt27deuL6Dh48qK1bt8rZ2dm8PfPMM5Luf3tJkhwcHLR48WKtXLlSt2/f1rRp0zLjUlSzZk3zv93d3VWhQgUdP35cknT8+HHVrl3bonzt2rV16tQpJScnZ9p9GDJkiOLj483b+fPn/91FwSq2bdumX3/9VaVLl5avr68uXLigJk2amJcGMAxD8+fPt1hWCgAAwJoYh2YPHx8f2dnZqVOnTpLuLy1aunRp/fLLLwoJCdG6det06NAhLVy4UL///rsCAgJS1VGxYkWVKFFCkZGRqY75+vqqevXqWrNmTVZfCgAAwL9CIgPZysXFRYcOHdJXX30lT09PffTRR6pYsaKuX7/+RPWlpKSoZcuWioqKsthOnTplsWTVgwcmX716VVevXs2MS0nTg7VlDcNItc6sYRjmf2fWfXB0dJSrq6vFhpxn8ODB+v333xUTE6OYmBiVLFlSP/74o5o2bSrpfqLj7t275hlAAAAA1sY4NHsUKVJEDRs21I8//ihJOnfunM6ePasKFSro4sWL5nJz586Vk5OTGjRoIEnmL1hJ97/gdfjwYXOS4+/HLl++rM2bN/OgbwAAYPNIZCDb2dvbq1GjRpo4caKOHDmimJgYbdmy5ZHnOTg4KDk52WJf5cqV9csvv8jX11flypWz2JycnCTdH7i/++67mjt3rmrUqKGuXbuaH3SXXr0ZsWfPHvO/r127ppMnT5pngwQEBOinn36yKL9r1y75+fkpT548j7wPTxoTcqcvvvhCr732WqqHei9evFglS5bUihUrNHToUJUsWVKHDx+2UpQAAADICp9++qkmTpyo4OBgtW7dWp999pk8PT01Z84c+fn5qXz58vr++++1evVq85epBg8erMDAQIWGhqpDhw6aOXOm/P39JUmffPKJ+VijRo307rvv8oUZAABg83hGBrLVmjVrdObMGdWtW1eFChXS2rVrlZKSkqH1WH19fbV3717FxMTI2dlZ7u7u6t27t+bOnauOHTtq4MCBKlKkiP73v/9p6dKlmjt3riSpS5cuev755/Xaa6+padOmCg4O1pQpUzRw4MB06/3nH4zTMnLkSBUuXFjFixfXBx98oCJFiqhNmzaSpP79+6tatWoaNWqUOnTooN27d2vmzJmaPXt2hu7Dk8aE3OHvD2mUpEWLFqVZrnPnzjz8GwAAIJcrU6ZMmstCDRs2TMOGDUvznG+//Tbd+h58JgEAAMhJ+MsoslXBggW1atUqNWjQQP7+/vr000/11VdfKTAw8JHnDhgwQHny5FFAQICKFi2q2NhYeXl5aefOnUpOTlaTJk0UFBSkd955R25ubrKzs9OYMWMUExOjzz77TJLk4eGhzz//XB9++KGioqLSrTcjxo8fr3feeUdVqlRRXFycvvvuOzk4OEi6P1Nk+fLlWrp0qYKCgvTRRx9p5MiRCg8Pz9B9eNKYAAAAAAAAACC3MRl/X7gfwCNFRkaqfv36unbtmgoWLGjtcCwkJCTIzc1NnSetkUN+J2uHg7/5oneYtUMAAADIMg/GofEzy8o1fx5rh5OzdD9h7QgAAABsHjMyAAAAAAAAAACAzSKRAZsQGxsrZ2fndLfsXFopIiIi3TgiIiKyLQ4AAAAAAAAAAA/7ho3w8vIyP7MivePZZeTIkRowYECax1xdXVWsWDGxIhsAAAAAAAAAZA8SGbAJ9vb2KleunLXDkCQVK1ZMxYoVs3YYAAAAAAAAAACxtBQAAAAAAAAAALBhJoM1coBcIyEhQW5uboqPj5erq6u1wwEAAMBTgnEoAAAAshIzMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLHtrBwAAAAAAyCUWVZby57F2FFmn+wlrRwAAAPBUYkYGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0RGFggLC1O/fv2sHQasICYmRiaTSVFRUdYOJV137txRmzZt5Ofnp9DQUL3wwguKiYmxdlgAAABAjufr66tnnnlGoaGhCg0N1bJlyyRJly5d0gsvvKDy5csrKChIP/30k/mc8PBwlSxZ0nzOwIEDzceuXLmiNm3aKCQkRP7+/urWrZtu376d7dcFAABgbfbWDiA3WrVqlfLmzWvtMJDFwsPDdf36dX3zzTfWDuWx9erVS02bNpXJZNLMmTPVq1cvbdiwwdphAQAAADne119/raCgIIt9gwcPVo0aNbR+/Xrt379f7dq10+nTp2Vvb28+3qdPn1R1jR49WmXKlNE333yj5ORkNW/eXPPnz9dbb72VLdcCAABgK5iRkQXc3d3l4uJi7TCQi9y9ezfT6sqXL5+aNWsmk8kkSapRo4bOnDmTafUDAAAAsLR8+XL17t1bklStWjUVL17cYlbGw/z1119KSUnR3bt3devWLZUsWTIrQwUAALBJJDKywN+Xlpo9e7bKly+vfPnyqXjx4mrXrl2G6li/fr2ee+45FSxYUIULF1aLFi10+vRp8/EHSxitWrVK9evXV4ECBVSxYkXt3r3bop6VK1cqMDBQjo6O8vX11ZQpUyyO+/r6auzYserevbtcXFxUqlQpffbZZ+bjDRo0SPXNoCtXrsjR0VFbtmwx1zF69Gh17dpVzs7O8vHx0bfffqvLly+rdevWcnZ2VnBwsA4cOPBYsZlMplSzHQoWLKgFCxZIuv/H/T59+sjT01P58uWTr6+vxo0bl6H7O3XqVAUHB8vJyUne3t566623dOPGDfPx4cOHKzQ01OKcadOmydfX13x84cKF+vbbb2UymWQymRQZGWkue+bMmX/dL6NHj1Z4eLjc3Nz0+uuvp3kdiYmJSkhIsNge14wZM9SyZcvHPg8AAABPr8wYh+ZWnTp1UnBwsHr27KnLly/rypUrSklJUdGiRc1lfH19FRsba349depUhYSEqEWLFhbL1A4dOlT/+9//5OHhoWLFisnf31+tWrXKzssBAACwCSQystCBAwfUt29fjRw5UidOnND69etVt27dDJ178+ZNvffee9q/f782b94sOzs7tW3bVikpKRblPvjgAw0YMEBRUVHy8/NTx44dlZSUJEk6ePCg2rdvr1deeUVHjx7V8OHDNXToUHMi4IEpU6aoatWqOnz4sN566y29+eab+vXXXyVJPXv21JdffqnExERz+SVLlsjLy0v169c37/v4449Vu3ZtHT58WM2bN1eXLl3UtWtXde7cWYcOHVK5cuXUtWtXGYbxWLE9zIwZM/Tdd99p+fLlOnHihBYvXmxONDyKnZ2dZsyYoejoaC1cuFBbtmzRoEGDMtz2gAED1L59e73wwguKi4tTXFycatWqZT6eGf0yadIkBQUF6eDBgxo6dGiacYwbN05ubm7mzdvbO8PXIEljx47VqVOnNGbMmMc6DwAAAE+3fzsOza22b9+un3/+WYcOHVLhwoXVrVs3STLPhn7gweciSRozZoz+97//6ciRI+rRo4eaNm1q/pLVihUrFBISori4OP3+++86efLkY31mAgAAyC1Mxt9HUMgUYWFhCg0NVd26dfXaa6/pwoUL/3qpqcuXL6tYsWI6evSogoKCFBMTo9KlS+vzzz9Xjx49JEnHjh1TYGCgjh8/rmeeeUadOnXS5cuXLZ59MGjQIP3www/65ZdfJN3/JlCdOnW0aNEiSfcH1B4eHhoxYoQiIiKUmJgoLy8v/ec//1H79u0lSZUqVVKbNm00bNiwNOu4ePGiPD09NXToUI0cOVKStGfPHtWsWVNxcXHy8PDIUGwmk0mrV69WmzZtzGUKFiyoadOmKTw8XH379tUvv/yiTZs2pfpg8LhWrFihN998U3/++aek+zMuvvnmG4tvQ02bNk3Tpk0zPxg7rWdkZGa/VKpUSatXr35o3ImJiRZJpoSEBHl7eys+Pl6urq4PPXfy5MlaunSpNm3apIIFCz7qFgEAAABm6Y5DZ5aVa/48Vowsi3U/keGicXFx8vPz019//SUnJyfFxMSYZ2U8++yzmjhxosLCwlKdV6FCBX355ZeqUqWKgoKCNG/ePD377LOSpFmzZmnfvn1auHBhplwOAABATsGMjCzUuHFj+fj4qEyZMurSpYuWLFmiW7duZejc06dP69VXX1WZMmXk6uqq0qVLS5LF9GNJCgkJMf/b09NTknTp0iVJ0vHjx1W7dm2L8rVr19apU6eUnJycZh0mk0keHh7mOhwdHdW5c2fNmzdPkhQVFaWff/5Z4eHh6cZRvHhxSVJwcHCqfY8b28OEh4crKipKFSpUUN++fR/rYdVbt25V48aNVaJECbm4uKhr1666cuWKbt68meE6HiYz+qVq1aqPbMfR0VGurq4WW0ZMnTpVX331lTZu3EgSAwAAAI/tScehudnNmzd1/fp18+uvvvpKlSpVkiS9/PLLmjVrliRp//79unjxop577jlJ0oULF8zn7NmzR1euXFG5cuUkSWXKlNG6deskSffu3dP69etTPUgcAADgaWBv7QByMxcXFx06dEiRkZHasGGDPvroIw0fPlz79+9/5B+PW7ZsKW9vb82dO1deXl5KSUlRUFBQqoc+582b1/zvB7MSHiw/ZRjGQ6cwp1XHg3r+voRVz549FRoaqgsXLmjevHlq2LChfHx8HhnHv43NZDKl2nfv3j3zvytXrqyzZ89q3bp12rRpk9q3b69GjRrp66+/TnWNf3fu3Dk1a9ZMERERGjVqlNzd3fXTTz+pR48e5vrt7Owe2vajZEa/ODk5Zbi9x3HhwgX1799fZcqUMS8P5ujoqL1792ZJewAAAMDT4I8//tBLL72k5ORkGYahMmXK6L///a8kacKECerSpYvKly8vBwcHLVq0SPb29z+Oh4eH648//lCePHmUP39+rVixQm5ubpKk6dOnKyIiQkFBQUpJSVHt2rXVt29fq10jAACAtZDIyGL29vZq1KiRGjVqpGHDhqlgwYLasmWLXnzxxXTPuXLlio4fP645c+aoTp06kqSffvrpsdsOCAhIdd6uXbvk5+enPHkyPt07ODhYVatW1dy5c/Xll1/qk08+eexYniS2okWLKi4uznz81KlTqWa0uLq6qkOHDurQoYPatWunF154QVevXpW7u3u6bR84cEBJSUmaMmWK7OzuT0pavny5RZmiRYvq4sWLFkmHvy8zJUkODg4Znj3yd5nVL0+qZMmSaSZOAAAAADy5MmXK6PDhw2keK168eLozyDdt2pRunaVLl9aPP/6YKfEBAADkZCQystCaNWt05swZ1a1bV4UKFdLatWuVkpKiChUqPPS8QoUKqXDhwvrss8/k6emp2NhYDR48+LHb79+/v6pVq6ZRo0apQ4cO2r17t2bOnKnZs2c/dl09e/ZUnz59VKBAAbVt2/axz3+S2Bo0aKCZM2eqRo0aSklJ0fvvv28x0+Hjjz+Wp6enQkNDZWdnpxUrVsjDw+ORs13Kli2rpKQkffLJJ2rZsqV27typTz/91KJMWFiYLl++rIkTJ6pdu3Zav3691q1bZzFl3tfXVz/++KNOnDihwoULm781lRnXDgAAAAAAAAC4j2dkZKGCBQtq1apVatCggfz9/fXpp5/qq6++UmBg4EPPs7Oz09KlS3Xw4EEFBQXp3Xff1aRJkx67/cqVK2v58uVaunSpgoKC9NFHH2nkyJGpnm+RER07dpS9vb1effVV5cuX77HPf5LYpkyZIm9vb9WtW1evvvqqBgwYoAIFCpiPOzs7a8KECapataqqVaummJgYrV271jzLIj2hoaGaOnWqJkyYoKCgIC1ZskTjxo2zKOPv76/Zs2dr1qxZqlixovbt26cBAwZYlHn99ddVoUIFVa1aVUWLFtXOnTsz7doBAAAAAAAAAPeZDNaYQQacP39evr6+2r9/vypXrmztcJCOhIQEubm5KT4+ngcuAgAAINuYx6Ezy8o1f9Yvl2o13U9YOwIAAICnEktL4aHu3bunuLg4DR48WDVq1CCJAQAAAAAAAADIViwtZQWxsbFydnZOd4uNjbV2iGY7d+6Uj4+PDh48mOo5ErZqyZIl6d7bRy3rBQAAAAAAAACwLczIsAIvLy9FRUU99LitCAsLU05bfaxVq1aqXr16msf+/rBwAAAAAAAAAIDtI5FhBfb29ipXrpy1w8i1XFxc5OLiYu0wAAAAAAAAAACZgEQGAAAAACBzdDkkubpaOwoAAADkMjwjAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABslr21AwCQ+Xp/tkMO+Z2sHcYT+aJ3mLVDAAAAwJNaVFnKnyd72+x+InvbAwAAQLZjRgYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyECWCwsLU79+/awdhtlnn30mb29v2dnZadq0adYOx0JMTIxMJpOioqKsHYpNunPnjtq0aSM/Pz+FhobqhRdeUExMjCSpe/fuqlChgkJDQ1W3bl2Lezhv3jwFBwfL3t5eM2fOtE7wAAAAyHYPGz8ahqHhw4fLz89PQUFBCgsLszh39uzZ8vf3V1BQkEJCQnTnzh1JUkpKit5++22VLVtW5cqV0+zZs7P5qgAAAJ4+9tYOAMhOCQkJ6tOnj6ZOnaqXXnpJbm5u1g4Jj6lXr15q2rSpTCaTZs6cqV69emnDhg1q06aNPvvsM9nb22vNmjVq3769Tp48KUmqUqWKli9frnHjxlk5egAAAGS39MaPM2bM0NGjRxUdHS0HBwfFxcWZz/n222+1ZMkS7dmzR25ubrp06ZLy5s0rSVq8eLGOHTumkydPKj4+XpUrV1aDBg30zDPPWOsSAQAAcj1mZOCpEhsbq3v37ql58+by9PRUgQIFrB0SHkO+fPnUrFkzmUwmSVKNGjV05swZSVKrVq1kb29v3n/u3DmlpKRIkipWrCh/f3/Z2fG/PAAAgKfJw8aPkyZN0oQJE+Tg4CBJ8vT0NJ83adIkjRgxwvzFp2LFiilPnjySpGXLlikiIkJ58uSRu7u72rdvr6VLl2bnZQEAADx1+KseMtXNmzfVtWtXOTs7y9PTU1OmTLE4vnjxYlWtWlUuLi7y8PDQq6++qkuXLkm6P7W7XLlymjx5ssU50dHRsrOz0+nTpx/ZfmxsrFq3bi1nZ2e5urqqffv2+uOPPyRJCxYsUHBwsCSpTJkyMplM5mnlaYmPj1eePHl08OBBc3zu7u6qVq2aucxXX31l8YHnt99+U4cOHVSoUCEVLlxYrVu3TtXG/Pnz5e/vr3z58umZZ5556FT0lJQUvf766/Lz89O5c+dSHU9MTFRCQoLF9jSZMWOGWrZsmWr/9OnT1axZMxIXAAAAWSSnjkMfjB8TEhJ0+fJlrV69WjVq1FCNGjW0bNkyc7ljx47pwIEDql27tqpWraoZM2aYj8XGxsrHx8f82tfXV7Gxsdl6HQAAAE8b/sqHTDVw4EBt3bpVq1ev1oYNGxQZGWlOBEjS3bt3NWrUKP3888/65ptvdPbsWYWHh0uSTCaTunfvrvnz51vUOW/ePNWpU0dly5Z9aNuGYahNmza6evWqtm3bpo0bN+r06dPq0KGDJKlDhw7atGmTJGnfvn2Ki4uTt7d3uvW5ubkpNDRUkZGRkqQjR46Y//vgg1pkZKTq1asnSbp165bq168vZ2dnbd++XT/99JOcnZ31wgsv6O7du5KkuXPn6oMPPtCYMWN0/PhxjR07VkOHDtXChQtTtX/37l21b99eBw4c0E8//WTxYemBcePGyc3Nzbw97Hpym7Fjx+rUqVMaM2aMxf7Fixdr+fLlmjNnjpUiAwAAyP1y4jj07+PHe/fu6e7du7p9+7b27Nmj5cuX67333lN0dLQkKSkpSadPn9b27du1YcMGzZ07V2vXrjXX9WCGh3T/cwgAAACyFokMZJobN27oiy++0OTJk9W4cWMFBwdr4cKFSk5ONpfp3r27mjZtqjJlyqhGjRqaMWOG1q1bpxs3bkiSXnvtNZ04cUL79u2TJN27d0+LFy9W9+7dH9n+pk2bdOTIEX355ZeqUqWKqlevrkWLFmnbtm3av3+/8ufPr8KFC0uSihYtKg8PD/P08PSEhYWZExmRkZFq2LChgoKC9NNPP5n3PXgo4NKlS2VnZ6fPP/9cwcHB8vf31/z58xUbG2uuY9SoUZoyZYpefPFFlS5dWi+++KLefffdVH90v3Hjhpo3b66LFy8qMjJSxYoVSzO+IUOGKD4+3rydP3/+kfcpN5g8ebJWrVqldevWWSwPtmzZMo0YMUIbN25M954BAADg38tp49B/jh8LFy4sZ2dnde7cWZJUqlQp1a5dWwcOHDC/7tixo3n5qKZNm5o/o5QqVcpi1vW5c+dUqlSpbL8mAACApwmJDGSa06dP6+7du6pZs6Z5n7u7uypUqGB+ffjwYbVu3Vo+Pj5ycXExJwEeTMX29PRU8+bNNW/ePEnSmjVrdOfOHb388suPbP/48ePy9va2+DZYQECAChYsqOPHjz/RNYWFhWnHjh1KSUnRtm3bFBYWprCwMG3btk0XL17UyZMnzTMyDh48qP/9739ycXGRs7OznJ2d5e7urjt37uj06dO6fPmyzp8/rx49epiPOzs7a/To0amWzerYsaNu3LihDRs2PPSB5I6OjnJ1dbXYcrupU6fqq6++0saNG1WwYEHz/uXLl+vDDz/Upk2b+CAJAACQxXLSODS98WPHjh21fv16SdK1a9e0b98+hYSESJJeffVV87E7d+5o27ZtqlixoiTp5Zdf1pw5c5ScnKyrV69q2bJl5lngAAAAyBokMpBpHjWl+ubNm3r++efl7OysxYsXa//+/Vq9erUkmZdekqSePXtq6dKlun37tubPn68OHTpk6KHchmFYTPF+1P6MqFu3rv766y8dOnRIO3bsUFhYmOrVq6dt27Zp69atKlasmPz9/SXdf55FlSpVFBUVZbGdPHlSr776qvnB03PnzrU4Hh0drT179li026xZMx05ciTV/qfdhQsX1L9/f12/fl3169dXaGioqlevLknq1KmT7ty5o9atWys0NFShoaG6cuWKpPvLTZUsWVIrVqzQ0KFDVbJkSR0+fNialwIAAIBs8LDx49ixY7Vu3ToFBQWpTp06GjJkiCpXrixJevfdd3Xx4kUFBASoSpUqatq0qdq2bStJ6tKliypUqCA/Pz9Vq1ZNAwcONH8mAAAAQNawt3YAyD3KlSunvHnzas+ePeZvxF+7ds08a+HXX3/Vn3/+qfHjx5tnTTyYuv13zZo1k5OTk/7zn/9o3bp12r59e4baDwgIUGxsrM6fP2+u/9ixY4qPj3/iDxYPnpMxc+ZMmUwmBQQEyMvLS4cPH9aaNWvMszEkqXLlylq2bJmKFSuW5jfS3NzcVKJECZ05c0adOnV6aLtvvvmmgoKC1KpVK/3www8W7TzNSpYsmW7C7N69e+me17lzZ/OyAQAAAHh6PGz8WKRIEX3//fdpHsufP7/++9//pnksT548mjVrVqbFCAAAgEdjRgYyjbOzs3r06KGBAwdq8+bNio6OVnh4uOzs7v+YlSpVSg4ODvrkk0905swZfffddxo1alSqevLkyaPw8HANGTJE5cqVs1iq6mEaNWqkkJAQderUSYcOHdK+ffvUtWtX1atXT1WrVn3i6woLC9PixYtVr149mUwmFSpUSAEBAVq2bJl5aSzp/oyAIkWKqHXr1tqxY4fOnj2rbdu26Z133tGFCxckScOHD9e4ceM0ffp0nTx5UkePHtX8+fM1derUVO2+/fbbGj16tFq0aGF+JgcAAAAAAAAAPG1IZCBTTZo0SXXr1lWrVq3UqFEjPffcc6pSpYqk+w/YXrBggVasWKGAgACNHz9ekydPTrOeHj166O7duxl6yPcDJpNJ33zzjQoVKqS6deuqUaNGKlOmjJYtW/avrql+/fpKTk62SFrUq1dPycnJFjMlChQooO3bt6tUqVJ68cUX5e/vr+7du+v27dvmGRo9e/bU559/rgULFig4OFj16tXTggULVLp06TTb7tevn0aMGKFmzZpp165d/+o6AAAAAAAAACAnMhmPerABYAU7d+5UWFiYLly4oOLFi1s7nBwjISFBbm5u6jxpjRzyO1k7nCfyRe8wa4cAAACAx/RgHBo/s6xc8+fJ3sa7n8je9gAAAJDteEYGbEpiYqLOnz+voUOHqn379iQxAAAAAAAAAOApx9JSsClfffWVKlSooPj4eE2cONHi2JIlS+Ts7JzmFhgY+ETtBQYGplvnkiVLMuOSAAAAAAAAAAD/AjMyYFPCw8MVHh6e5rFWrVqpevXqaR7LmzfvE7W3du1a3bt3L81jzAYBAAAAAAAAAOsjkYEcw8XFRS4uLplap4+PT6bWBwAAAAAAAADIXCwtBQAAAAAAAAAAbJbJMAzD2kEAyBwJCQlyc3NTfHy8XF1drR0OAAAAnhKMQwEAAJCVmJEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGbZWzsAAJmv92c75JDfyaoxfNE7zKrtAwAAwAoWVZby53ny87ufyLxYAAAAkGswIwMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZCBLhYWFqV+/ftYO44l89tln8vb2lp2dnaZNm/bY5w8fPlyhoaGZHhcAAAAAAAAAPE1IZABpSEhIUJ8+ffT+++/rt99+U69evawdUq7St29f+fr6ymQyKTo62rw/LCxMZcqUUWhoqEJDQ/Xxxx+bj4WHh6tkyZLmYwMHDrRG6AAAALCiJxlHPhAZGak8efJo5syZFvtXrlyp4OBgBQYGKiAgQDExMVl9GQAAAHhM9tYOAMhsd+/elYODw7+qIzY2Vvfu3VPz5s3l6emZSZHhgXbt2mnQoEF67rnnUh2bMWOGWrRokeZ5gwcPVp8+fbI6PAAAANioJx1H/vXXX3r//ffVtGlTi/2HDx/Whx9+qM2bN8vLy0sJCQmyt+djMgAAgK1hRgayXEpKigYNGiR3d3d5eHho+PDh5mOxsbFq3bq1nJ2d5erqqvbt2+uPP/4wHw8PD1ebNm0s6uvXr5/CwsLMr8PCwtSnTx+99957KlKkiBo3bvzImB7W7oIFCxQcHCxJKlOmjEwmU4a+lTV+/HgVL15cLi4u6tGjh+7cuWNxfP/+/WrcuLGKFCkiNzc31atXT4cOHTIf7969e6oPXklJSfLw8NC8efMe2X5OUrduXZUsWdLaYQAAACCHedJx5HvvvaeBAweqSJEiFvunTJmi/v37y8vLS5Lk6uqqAgUKZEqsAAAAyDwkMpDlFi5cKCcnJ+3du1cTJ07UyJEjtXHjRhmGoTZt2ujq1avatm2bNm7cqNOnT6tDhw5P1Ia9vb127typOXPmPLTso9rt0KGDNm3aJEnat2+f4uLi5O3t/dA6ly9frmHDhmnMmDE6cOCAPD09NXv2bIsyf/31l7p166YdO3Zoz549Kl++vJo1a6a//vpLktSzZ0+tX79ecXFx5nPWrl2rGzduqH379mm2m5iYqISEBIstpxs4cKCCg4PVoUMHnTlzxuLY1KlTFRISohYtWigqKso6AQIAAMAmx6HpjSPXrVun69evq127dqnOOXbsmGJjY1WvXj1VqlRJQ4cOVXJycnaGDQAAgAxgziyyXEhIiIYNGyZJKl++vGbOnKnNmzdLko4cOaKzZ8+aEwWLFi1SYGCg9u/fr2rVqmW4jXLlymnixIkZKrtp06ZHtlu4cGFJUtGiReXh4fHIOqdNm6bu3burZ8+ekqTRo0dr06ZNFrMyGjRoYHHOnDlzVKhQIW3btk0tWrRQrVq1VKFCBS1atEiDBg2SJM2fP18vv/yynJ2d02x33LhxGjFiRIauOydYtGiRvL29ZRiGZs2apRYtWujYsWOSpDFjxsjT01N2dnZavXq1mjZtqlOnTqV7bwAAAJB1bG0cmt448vr16xo8eLA2btyY5nn37t3TwYMHtX79ehmGoVatWmnOnDl66623svkKAAAA8DDMyECWCwkJsXjt6empS5cu6fjx4/L29raY7RAQEKCCBQvq+PHjj9VG1apVM1w2M9v9e501a9a02PfP15cuXVJERIT8/Pzk5uYmNzc33bhxQ7GxseYyPXv21Pz5883lf/jhB3Xv3j3ddocMGaL4+Hjzdv78+SeK31Y86BOTyaQ+ffrozJkzunLliiSpRIkSsrO7/7+stm3bytXVVSdOnLBarAAAAE8zWxuHpjeOjI6OVlxcnJ599ln5+vrq66+/1rBhw8xftPLx8dFLL72k/Pnzq0CBAnrxxRe1b98+a14KAAAA0sCMDGS5vHnzWrw2mUxKSUmRYRgymUypyv99v52dnQzDsDh+7969VOc4OTllOJ6MtJsVwsPDdfnyZU2bNk0+Pj5ydHRUzZo1dffuXXOZrl27avDgwdq9e7d2794tX19f1alTJ906HR0d5ejomGUxZ6ekpCRduXJFxYsXlyStXLlSxYsXN8+OuXDhgnk95D179ujKlSsqV66c1eIFAAB4mtnSOPRh48jnnntOly5dMpcNDw9X1apV1adPH0nSq6++qu+++07h4eEyDEMbN25U3bp1rXIdAAAASB+JDFhNQECAYmNjdf78efM3qI4dO6b4+Hj5+/tLur+0U3R0tMV5UVFRqZIjmd3u4/L399eePXvUtWtX8749e/ZYlNmxY4dmz56tZs2aSZLOnz+vP//806JM4cKF1aZNG82fP1+7d+/Wa6+99kTx2LrevXvr22+/1cWLF9WoUSM5Ozvr559/VvPmzZWYmCg7OzsVKVJE3333nfmc8PBw/fHHH8qTJ4/y58+vFStWyM3NzYpXAQAAgOz2JOPIh3nllVd04MABBQYGKk+ePKpbt645yQEAAADbQSIDVtOoUSOFhISoU6dOmjZtmpKSkvTWW2+pXr165qWiGjRooEmTJum///2vatasqcWLFys6OlqVKlXK0nYf1zvvvKNu3bqpatWqeu6557RkyRL98ssvKlOmjLlMuXLltGjRIlWtWlUJCQkaOHCg8ufPn6qunj17qkWLFkpOTla3bt2e+Dpt2axZszRr1qxU+w8cOJDuOQ8ewA4AAICn15OMI/9uwYIFFq/t7Ow0depUTZ06NTPCAwAAQBbhGRmwGpPJpG+++UaFChVS3bp11ahRI5UpU0bLli0zl2nSpImGDh2qQYMGqVq1avrrr78sZj1kVbuPq0OHDvroo4/0/vvvq0qVKjp37pzefPNNizLz5s3TtWvXVKlSJXXp0kV9+/ZVsWLFUtXVqFEjeXp6qkmTJvLy8nrimAAAAAAAAAAgNzAZ/3wAAQCrunXrlry8vDRv3jy9+OKLj3VuQkKC3Nzc1HnSGjnkz/hzQ7LCF73DrNo+AAAAss+DcWj8zLJyzZ/nySvqfiLzggIAAECuwdJSgI1ISUnRxYsXNWXKFLm5ualVq1bWDgkAAAAAAAAArI6lpZDrLFmyRM7OzmlugYGBT1RnYGBgunUuWbIkU+KOjY1ViRIltHz5cs2bN0/29uQZAQAAAAAAAIC/lCLXadWqlapXr57msbx58z5RnWvXrtW9e/fSPFa8ePEnqvOffH19xUpvAAAAAAAAAGCJRAZyHRcXF7m4uGRqnT4+PplaHwAAAAAAAAAgY1haCgAAAAAAAAAA2CyTwVo2QK6RkJAgNzc3xcfHy9XV1drhAAAA4CnBOBQAAABZiRkZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGyWvbUDAAAAAADkEosqS/nzZLx89xNZFwsAAAByDWZkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMPJbIyEiZTCZdv379oeV8fX01bdq0TGlz+PDhCg0NzZS6HuWfcZtMJn3zzTfZ0jYAAAAAAAAAIDUSGXiosLAw9evXz/y6Vq1aiouLk5ubmyRpwYIFKliwYJbGMGDAAG3evDlL23ia3LlzR23atJGfn59CQ0P1wgsvKCYmxtphAQAAAKn07dtXvr6+MplMio6ONu8fO3asKlSoIDs7O61Zs8binFOnTqlx48aqWLGiAgMDtWzZMov6QkNDzVu+fPk0Y8aMbLseAAAAPBkSGXgsDg4O8vDwkMlkyrY2nZ2dVbhw4Wxr72nQq1cvnThxQlFRUWrRooV69epl7ZAAAACAVNq1a6effvpJPj4+FvsbNmyotWvXqm7duqnOCQ8PV6dOnfTzzz9ry5YtGjhwoH777TdJ0owZMxQVFaWoqCitX79eJpNJ7du3z5ZrAQAAwJMjkYF0hYeHa9u2bZo+fbpMJpNMJpMWLFhgXloqMjJSr732muLj483Hhw8fnmZd8fHx6tWrl4oVKyZXV1c1aNBAP//8c4bi+OfSUpGRkXr22Wfl5OSkggULqnbt2jp37twj6zl9+rRat26t4sWLy9nZWdWqVdOmTZsyFMMDFy5c0CuvvCJ3d3c5OTmpatWq2rt3b4br9/X11ahRo/Tqq6/K2dlZXl5e+uSTT1Jdb6lSpeTo6CgvLy/17dv3sWJ8lHz58qlZs2bmZFSNGjV05syZTG0DAAAAyAx169ZVyZIlU+2vXr26ypYtm+Y5P//8s5o1ayZJKl68uCpWrGgxK+OB//73v2rSpIk8PDwyN2gAAABkOhIZSNf06dNVs2ZNvf7664qLi1NcXJy8vb3Nx2vVqqVp06bJ1dXVfHzAgAGp6jEMQ82bN9fFixe1du1aHTx4UJUrV1bDhg119erVx4opKSlJbdq0Ub169XTkyBHt3r1bvXr1ytAMkRs3bqhZs2batGmTDh8+rCZNmqhly5aKjY3NUNs3btxQvXr19Pvvv+u7777Tzz//rEGDBiklJeWx6p80aZJCQkJ06NAhDRkyRO+++642btwoSfr666/18ccfa86cOTp16pS++eYbBQcHpxtTYmKiEhISLLbHNWPGDLVs2fKxzwMAAMDTKzPGoVmlWrVqWrx4saT7XzbatWtXmkupzps3Tz169Mjm6AAAAPAk7K0dAGyXm5ubHBwcVKBAAfO3lH799VfzcQcHB7m5uclkMj30W0xbt27V0aNHdenSJTk6OkqSJk+erG+++UZff/31Yy1rlJCQoPj4eLVo0cL8DSx/f/8MnVuxYkVVrFjR/Hr06NFavXq1vvvuO/Xp0+eR53/55Ze6fPmy9u/fL3d3d0lSuXLlHrv+2rVra/DgwZIkPz8/7dy5Ux9//LEaN26s2NhYeXh4qFGjRsqbN69KlSqlZ599Nt2Yxo0bpxEjRmTo+tMyduxYnTp1Sp9++ukT1wEAAICnz78dh2alBQsWaMCAAQoNDVWZMmXMY+u/27lzpxISEswzNwAAAGDbmJGBLHfw4EHduHFDhQsXlrOzs3k7e/asTp8+/Vh1ubu7Kzw83DzbYfr06YqLi8vQuTdv3tSgQYMUEBCgggULytnZWb/++muGZ2RERUWpUqVK5iTGk9Zfs2bNVK+PHz8uSXr55Zd1+/ZtlSlTRq+//rpWr16tpKSkdGMaMmSI4uPjzdv58+czdC3S/WTSqlWrtG7dOhUoUCDD5wEAAAD/Zhya1Xx8fLRixQpFRUVp1apVio+PV0BAgEWZL774Qt26dVOePHmsFCUAAAAeBzMykOVSUlLk6empyMjIVMcKFiz42PXNnz9fffv21fr167Vs2TJ9+OGH2rhxo2rUqPHQ8wYOHKgff/xRkydPVrly5ZQ/f361a9dOd+/ezVC7+fPnz7L6HyyN5e3trRMnTmjjxo3atGmT3nrrLU2aNEnbtm1L9S0ySXJ0dDTPcnkcU6dO1VdffaVNmzY9UR8AAADg6fak49Ds8Mcff6hYsWIymUz68ccfdezYMb366qvm4zdu3NDXX3+tgwcPWjFKAAAAPA4SGXgoBwcHJScnP/FxSapcubIuXrwoe3t7+fr6ZkpclSpVUqVKlTRkyBDVrFlTX3755SMTGTt27FB4eLjatm0r6f4HmLTWyk1PSEiIPv/8c129ejXNWRkZrX/Pnj2pXj/zzDPm1/nz51erVq3UqlUr9e7dW88884yOHj2qypUrZzjWh7lw4YL69++vMmXKqH79+pLufxB98NByAAAAwFb07t1b3377rS5evKhGjRrJ2dlZ//vf/zRu3DjNmjVLly9fVnh4uPLly6fDhw+raNGi+v777zV+/HjZ29vL09NTa9eutfhS0rJly1SpUiWVL1/eilcGAACAx0EiAw/l6+urvXv3KiYmRs7OzuYHW//9+I0bN7R582ZVrFhRBQoUSLVMUaNGjVSzZk21adNGEyZMUIUKFfT7779r7dq1atOmjapWrZrheM6ePavPPvtMrVq1kpeXl06cOKGTJ0+qa9eujzy3XLlyWrVqlVq2bCmTyaShQ4emup6H6dixo8aOHas2bdpo3Lhx8vT01OHDh+Xl5aWaNWtmuP6dO3dq4sSJatOmjTZu3KgVK1bohx9+kHR/Pd/k5GRVr15dBQoU0KJFi5Q/f375+PhkOM5HKVmypAzDyLT6AAAAgKwya9YszZo1K9X+IUOGaMiQIWme07NnT/Xs2TPdOnv06MFDvgEAAHIYnpGBhxowYIDy5MmjgIAAFS1aNNXzHmrVqqWIiAh16NBBRYsW1cSJE1PVYTKZtHbtWtWtW1fdu3eXn5+fXnnlFcXExKh48eKPFU+BAgX066+/6qWXXpKfn5969eqlPn366I033njkuR9//LEKFSqkWrVqqWXLlmrSpMljzXJwcHDQhg0bVKxYMTVr1kzBwcEaP368eV3djNbfv39/HTx4UJUqVdKoUaM0ZcoUNWnSRNL9pbbmzp2r2rVrKyQkRJs3b9b333+vwoULZzhOAAAAAAAAAMhNTAZfzQayja+vr/r166d+/fplSf0JCQlyc3NTfHy8XF1ds6QNAAAA4J/M49CZZeWa/zEeoN39RNYFBQAAgFyDGRkAAAAAAAAAAMBmkciA1QUGBsrZ2TnNbcmSJdleDwAAAAAAAADAdvCwb1jd2rVrde/evTSPPc4zNDKrnqwUExNj7RAAAAAAAAAAIEchkQGr8/Hxsal6AAAAAAAAAAC2g6WlAAAAAAAAAACAzWJGBgAAAAAgc3Q5JLm6WjsKAAAA5DLMyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm2Vv7QAAAAAAALnEospS/jyp93c/kf2xAAAAINdgRgYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyECuEBYWpn79+lk7DLOMxLNgwQIVLFgwW+L5u759+8rX11cmk0nR0dHZ3j4AAADwT4mJierTp4/Kly+vwMBAde7cWZJkGIaGDx8uPz8/BQUFKSwszHxOeHi4SpYsqdDQUIWGhmrgwIFWih4AAABZzd7aAQA5WWRkpOrXr69r165ZJCVWrVqlvHnzml/7+vqqX79+NpFsadeunQYNGqTnnnvO2qEAAAAAkqTBgwfLzs5OJ0+elMlkUlxcnCRpxowZOnr0qKKjo+Xg4GDe//fz+vTpY42QAQAAkI1IZABZwN3d3dohpKtu3brWDgEAAAAwu3nzpubPn68LFy7IZDJJkjw9PSVJkyZNUmRkpBwcHCz2AwAA4OnC0lLINVJSUjRo0CC5u7vLw8NDw4cPNx+bOnWqgoOD5eTkJG9vb7311lu6ceOG+fi5c+fUsmVLFSpUSE5OTgoMDNTatWsf2l5MTIzq168vSSpUqJBMJpPCw8MlWS4tFRYWpnPnzundd9+VyWQyfzhLy/fff68qVaooX758KlOmjEaMGKGkpKR0yycmJiohIcFiAwAAALJaZo5DT58+rcKFC2v06NGqWrWq6tSpo82bNyshIUGXL1/W6tWrVaNGDdWoUUPLli2zOHfq1KkKCQlRixYtFBUV9S+vCgAAALaKRAZyjYULF8rJyUl79+7VxIkTNXLkSG3cuFGSZGdnpxkzZig6OloLFy7Uli1bNGjQIPO5vXv3VmJiorZv366jR49qwoQJcnZ2fmh73t7eWrlypSTpxIkTiouL0/Tp01OVW7VqlUqWLKmRI0cqLi4u1XT4B3788Ud17txZffv21bFjxzRnzhwtWLBAY8aMSTeGcePGyc3Nzbx5e3s/8j4BAAAA/1ZmjkPv3bunM2fOKCAgQAcOHNDMmTP1yiuv6Pbt27p7965u376tPXv2aPny5XrvvffMz3kbM2aM/ve//+nIkSPq0aOHmjZtavFlJQAAAOQeJDKQa4SEhGjYsGEqX768unbtqqpVq2rz5s2SpH79+ql+/foqXbq0GjRooFGjRmn58uXmc2NjY1W7dm0FBwerTJkyatGixSOXYMqTJ495CalixYrJw8NDbm5uqcq5u7srT548cnFxkYeHhzw8PNKsb8yYMRo8eLC6deumMmXKqHHjxho1apTmzJmTbgxDhgxRfHy8eTt//vwj7xMAAADwb2XmONTHx0d2dnbq1KmTJKlixYoqXbq0jh8/LmdnZ/ODv0uVKqXatWvrwIEDkqQSJUrIzu7+R9q2bdvK1dVVJ06c+JdXBgAAAFtEIgO5RkhIiMVrT09PXbp0SZK0detWNW7cWCVKlJCLi4u6du2qK1eu6ObNm5Kkvn37avTo0apdu7aGDRumI0eOZHv8Bw8e1MiRI+Xs7GzeXn/9dcXFxenWrVtpnuPo6ChXV1eLDQAAAMhqmTkOLVKkiBo2bKgff/xR0v1lX8+ePasKFSqoY8eOWr9+vSTp2rVr2rdvn3ncf+HCBXMde/bs0ZUrV1SuXLl/cVUAAACwVSQykGvkzZvX4rXJZFJKSorOnTunZs2aKSgoSCtXrtTBgwc1a9YsSfensUtSz549debMGXXp0kVHjx5V1apV9cknn2Rr/CkpKRoxYoSioqLM29GjR3Xq1Cnly5cv09rp3bu3SpYsqQsXLqhRo0Z82AMAAIDVffrpp5o4caKCg4PVunVrffbZZ/L09NTYsWO1bt06BQUFqU6dOhoyZIgqV64sSQoPD1dwcLBCQ0P17rvvasWKFWnOkAYAAEDOZ2/tAICsduDAASUlJWnKlCnmqed/X1bqAW9vb0VERCgiIkJDhgzR3Llz9fbbbz+0bgcHB0lScnLyI8s9qkzlypV14sSJLE8szJo1y5zIAQAAAGxBmTJlFBkZmWp/kSJF9P3336d5zqZNm7I4KgAAANgKZmQg1ytbtqySkpL0ySef6MyZM1q0aJE+/fRTizL9+vXTjz/+qLNnz+rQoUPasmWL/P39H1m3j4+PTCaT1qxZo8uXL6f7cEFfX19t375dv/32m/788880y3z00Uf673//q+HDh+uXX37R8ePHtWzZMn344YePf9EAAAAAAAAAkEuQyECuFxoaqqlTp2rChAkKCgrSkiVLNG7cOIsyycnJ6t27t/z9/fXCCy+oQoUKmj179iPrLlGihEaMGKHBgwerePHi6tOnT5rlRo4cqZiYGJUtW1ZFixZNs0yTJk20Zs0abdy4UdWqVVONGjU0depU+fj4PP5FAwAAAAAAAEAuYTIMw7B2EAAyR0JCgtzc3BQfH8+DvwEAAJBtzOPQmWXlmj9P6gLdT2R/UAAAAMg1mJEBAAAAAAAAAABsFokM4CEiIiLk7Oyc5hYREWHt8AAAAAAAAAAg17O3dgCALRs5cqQGDBiQ5jGWbgIAAAAAAACArEciA3iIYsWKqVixYtYOAwAAAAAAAACeWiwtBQAAAAAAAAAAbBYzMgAAAAAAmaPLIYklWAEAAJDJmJEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyMjlwsLC1K9fP2uHkekWLFigggULWjuMdEVGRspkMun69evWDgUAAAAAAAAAcjQSGcC/lFayqFatWoqLi5Obm5t1ggIAAAAAAACAXMLe2gEAuZGDg4M8PDysHQYAAAAAAAAA5HjMyHgKpKSkaNCgQXJ3d5eHh4eGDx9uPjZ16lQFBwfLyclJ3t7eeuutt3Tjxg3z8XPnzqlly5YqVKiQnJycFBgYqLVr12ao3WPHjqlZs2ZydnZW8eLF1aVLF/3555+S7i+95ODgoB07dpjLT5kyRUWKFFFcXJwk6fr16+rVq5eKFy+ufPnyKSgoSGvWrEmzrdOnT6t169YqXry4nJ2dVa1aNW3atMmijK+vr0aPHq2uXbvK2dlZPj4++vbbb3X58mW1bt1azs7OCg4O1oEDB8znXLlyRR07dlTJkiVVoEABBQcH66uvvjIfDw8P17Zt2zR9+nSZTCaZTCbFxMSkubTUypUrFRgYKEdHR/n6+mrKlCmp4hs7dqy6d+8uFxcXlSpVSp999tlD73FiYqISEhIsNgAAACCrMQ4FAABAdiKR8RRYuHChnJyctHfvXk2cOFEjR47Uxo0bJUl2dnaaMWOGoqOjtXDhQm3ZskWDBg0yn9u7d28lJiZq+/btOnr0qCZMmCBnZ+dHthkXF6d69eopNDRUBw4c0Pr16/XHH3+offv2kv7/ckxdunRRfHy8fv75Z33wwQeaO3euPD09lZKSoqZNm2rXrl1avHixjh07pvHjxytPnjxptnfjxg01a9ZMmzZt0uHDh9WkSRO1bNlSsbGxFuU+/vhj1a5dW4cPH1bz5s3VpUsXde3aVZ07d9ahQ4dUrlw5de3aVYZhSJLu3LmjKlWqaM2aNYqOjlavXr3UpUsX7d27V5I0ffp01axZU6+//rri4uIUFxcnb2/vVPEdPHhQ7du31yuvvKKjR49q+PDhGjp0qBYsWGBRbsqUKapataoOHz6st956S2+++aZ+/fXXdO/zuHHj5ObmZt7SahsAAADIbIxDAQAAkJ1MxoO/2CJXCgsLU3JyssXMh2effVYNGjTQ+PHjU5VfsWKF3nzzTfPMiZCQEL300ksaNmzYY7X70Ucfae/evfrxxx/N+y5cuCBvb2+dOHFCfn5+unv3rmrUqKHy5cvrl19+Uc2aNTV37lxJ0oYNG9S0aVMdP35cfn5+qepfsGCB+vXr99CHaQcGBurNN99Unz59JN2f8VCnTh0tWrRIknTx4kV5enpq6NChGjlypCRpz549qlmzpuLi4tJdGqp58+by9/fX5MmTJd2/x6GhoZo2bZq5TGRkpOrXr69r166pYMGC6tSpky5fvqwNGzaYywwaNEg//PCDfvnllzTjMwxDHh4eGjFihCIiItKMJTExUYmJiebXCQkJ8vb2Vnx8vFxdXdO9NwAAAMC/wTgUAAAA2YlnZDwFQkJCLF57enrq0qVLkqStW7dq7NixOnbsmBISEpSUlKQ7d+7o5s2bcnJyUt++ffXmm29qw4YNatSokV566aVU9aXl4MGD2rp1a5qzN06fPi0/Pz85ODho8eLFCgkJkY+Pj0UiICoqSiVLlkwziZGWmzdvasSIEVqzZo1+//13JSUl6fbt26lmZPw99uLFi0uSgoODU+27dOmSPDw8lJycrPHjx2vZsmX67bffzB/YnJycMhTXA8ePH1fr1q0t9tWuXVvTpk1TcnKyeabJ3+MzmUzy8PAw91VaHB0d5ejo+FixAAAAAP8W41AAAABkJ5aWegrkzZvX4rXJZFJKSorOnTunZs2aKSgoSCtXrtTBgwc1a9YsSdK9e/ckST179tSZM2fUpUsXHT16VFWrVtUnn3zyyDZTUlLUsmVLRUVFWWynTp1S3bp1zeV27dolSbp69aquXr1q3p8/f/7HusaBAwdq5cqVGjNmjHbs2KGoqCgFBwfr7t276d4Lk8mU7r6UlBRJ95d6+vjjjzVo0CBt2bJFUVFRatKkSap6H8UwDHPdf9/3T+n1FQAAAAAAAAA8rUhkPMUOHDigpKQkTZkyRTVq1JCfn59+//33VOW8vb0VERGhVatWqX///ublnx6mcuXK+uWXX+Tr66ty5cpZbA9mM5w+fVrvvvuu5s6dqxo1aqhr167mP9qHhITowoULOnnyZIauZceOHQoPD1fbtm0VHBwsDw8PxcTEZPxmPKTe1q1bq3PnzqpYsaLKlCmjU6dOWZRxcHBQcnLyQ+sJCAjQTz/9ZLFv165d8vPzS/e5HwAAAAAAAAAAEhlPtbJlyyopKUmffPKJzpw5o0WLFunTTz+1KNOvXz/9+OOPOnv2rA4dOqQtW7bI39//kXX37t1bV69eVceOHbVv3z6dOXNGGzZsUPfu3ZWcnKzk5GR16dJFzz//vF577TXNnz9f0dHRmjJliiSpXr16qlu3rl566SVt3LhRZ8+e1bp167R+/fo02ytXrpxWrVqlqKgo/fzzz3r11VczZSZDuXLltHHjRu3atUvHjx/XG2+8oYsXL1qU8fX11d69exUTE6M///wzzXb79++vzZs3a9SoUTp58qQWLlyomTNnasCAAf86RgAAAAAAAADIzUhkPMVCQ0M1depUTZgwQUFBQVqyZInGjRtnUSY5OVm9e/eWv7+/XnjhBVWoUEGzZ89+ZN1eXl7auXOnkpOT1aRJEwUFBemdd96Rm5ub7OzsNGbMGMXExOizzz6TJHl4eOjzzz/Xhx9+qKioKEnSypUrVa1aNXXs2FEBAQEaNGhQujMfPv74YxUqVEi1atVSy5Yt1aRJE1WuXPnf3SBJQ4cOVeXKldWkSROFhYXJw8NDbdq0sSgzYMAA5cmTRwEBASpatGiq53JI92eoLF++XEuXLlVQUJA++ugjjRw5UuHh4f86RgAAAAAAAADIzUxGWgv1A8iREhIS5Obmpvj4eLm6ulo7HAAAADwlGIcCAAAgKzEjAwAAAAAAAAAA2CwSGXgiERERcnZ2TnOLiIiwdngAAAAAAAAAgFyCpaXwRC5duqSEhIQ0j7m6uqpYsWLZHBEkpvQDAADAOhiHAgAAICvZWzsA5EzFihUjWQEAAAAAAAAAyHIsLQUAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMvCvhYWFqV+/ftYOw6YMHz5coaGh1g4DAAAAAAAAAHI8EhnAv2QymfTNN99Y7BswYIA2b95snYAAAAAAAAAAIBext3YAQG7k7OwsZ2dna4cBAAAAAAAAADkeMzKQKVJSUjRo0CC5u7vLw8NDw4cPNx+bOnWqgoOD5eTkJG9vb7311lu6ceOG+fi5c+fUsmVLFSpUSE5OTgoMDNTatWsz1O7atWvl5+en/Pnzq379+lqwYIFMJpOuX78uKe0lnqZNmyZfX1+LffPnz5e/v7/y5cunZ555RrNnzzYfu3v3rvr06SNPT0/ly5dPvr6+GjdunCSZ62nbtq1MJpP59T/bTUlJ0ciRI1WyZEk5OjoqNDRU69evNx+PiYmRyWTSqlWrVL9+fRUoUEAVK1bU7t27M3QfAAAAAAAAACC3IpGBTLFw4UI5OTlp7969mjhxokaOHKmNGzdKkuzs7DRjxgxFR0dr4cKF2rJliwYNGmQ+t3fv3kpMTNT27dt19OhRTZgwIUOzGc6fP68XX3xRzZo1U1RUlHr27KnBgwc/duxz587VBx98oDFjxuj48eMaO3ashg4dqoULF0qSZsyYoe+++07Lly/XiRMntHjxYnPCYv/+/ZLuJ0Li4uLMr/9p+vTpmjJliiZPnqwjR46oSZMmatWqlU6dOmVR7oMPPtCAAQMUFRUlPz8/dezYUUlJSenGnpiYqISEBIsNAAAAyGqMQwEAAJCdWFoKmSIkJETDhg2TJJUvX14zZ87U5s2b1bhxY4sHgZcuXVqjRo3Sm2++aZ71EBsbq5deeknBwcGSpDJlymSozf/85z8qU6aMPv74Y5lMJlWoUMGcCHkco0aN0pQpU/Tiiy+aYzx27JjmzJmjbt26KTY2VuXLl9dzzz0nk8kkHx8f87lFixaVJBUsWFAeHh7ptjF58mS9//77euWVVyRJEyZM0NatWzVt2jTNmjXLXG7AgAFq3ry5JGnEiBEKDAzU//73Pz3zzDNp1jtu3DiNGDHisa4XAAAA+LcYhwIAACA7MSMDmSIkJMTitaenpy5duiRJ2rp1qxo3bqwSJUrIxcVFXbt21ZUrV3Tz5k1JUt++fTV69GjVrl1bw4YN05EjRzLU5vHjx1WjRg2ZTCbzvpo1az5W3JcvX9b58+fVo0cP83MtnJ2dNXr0aJ0+fVqSFB4erqioKFWoUEF9+/bVhg0bHquNhIQE/f7776pdu7bF/tq1a+v48eMW+/5+Hz09PSXJfB/TMmTIEMXHx5u38+fPP1ZsAAAAwJNgHAoAAIDsRCIDmSJv3rwWr00mk1JSUnTu3Dk1a9ZMQUFBWrlypQ4ePGiegXDv3j1JUs+ePXXmzBl16dJFR48eVdWqVfXJJ588sk3DMB5Zxs7OLlW5B+1K959dId1fXioqKsq8RUdHa8+ePZKkypUr6+zZsxo1apRu376t9u3bq127do9s+5/+nnB5EP8/9/39Pj449iDGtDg6OsrV1dViAwAAALIa41AAAABkJxIZyFIHDhxQUlKSpkyZoho1asjPz0+///57qnLe3t6KiIjQqlWr1L9/f82dO/eRdQcEBJiTDQ/883XRokV18eJFi2RGVFSU+d/FixdXiRIldObMGZUrV85iK126tLmcq6urOnTooLlz52rZsmVauXKlrl69Kul+8iE5OTndOF1dXeXl5aWffvrJYv+uXbvk7+//yOsEAAAAAAAAgKcZz8hAlipbtqySkpL0ySefqGXLltq5c6c+/fRTizL9+vVT06ZN5efnp2vXrmnLli0Z+gN/RESEpkyZovfee09vvPGGDh48qAULFliUCQsL0+XLlzVx4kS1a9dO69ev17p16yy+MTZ8+HD17dtXrq6uatq0qRITE3XgwAFdu3ZN7733nj7++GN5enoqNDRUdnZ2WrFihTw8PFSwYEFJkq+vrzZv3qzatWvL0dFRhQoVShXrwIEDNWzYMJUtW1ahoaGaP3++oqKitGTJkse/qQAAAAAAAADwFGFGBrJUaGiopk6dqgkTJigoKEhLlizRuHHjLMokJyerd+/e8vf31wsvvKAKFSqYHwT+MKVKldLKlSv1/fffq2LFivr00081duxYizL+/v6aPXu2Zs2apYoVK2rfvn0aMGCARZmePXvq888/14IFCxQcHKx69eppwYIF5hkZzs7OmjBhgqpWrapq1aopJiZGa9eulZ3d/bfPlClTtHHjRnl7e6tSpUppxtq3b1/1799f/fv3V3BwsNavX6/vvvtO5cuXz/C9BAAAAAAAAICnkcnIyIMGgBwiMjJS9evX17Vr18wzJp4mCQkJcnNzU3x8POsUAwAAINswDgUAAEBWYkYGAAAAAAAAAACwWSQyYLMiIiLk7Oyc5hYREWHt8AAAAAAAAAAA2YClpWCzLl26pISEhDSPubq6qlixYtkcke1jSj8AAACsgXEoAAAAspK9tQMA0lOsWDGSFQAAAAAAAADwlGNpKQAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWfbWDgBA5jEMQ5KUkJBg5UgAAABgK1xcXGQymbK0DcahAAAA+KfMHIeSyABykStXrkiSvL29rRwJAAAAbEV8fLxcXV2ztA3GoQAAAPinzByHksgAchF3d3dJUmxsrNzc3KwcDR4lISFB3t7eOn/+fJb/cQH/Hv2Vs9BfOQv9lbPQXzmPi4tLlrfBODTn472ds9F/OR99mLPRfzkffZg1MnMcSiIDyEXs7O4/9sbNzY3/6eYgrq6u9FcOQn/lLPRXzkJ/5Sz0F/6OcWjuwXs7Z6P/cj76MGej/3I++tB28bBvAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiA8hFHB0dNWzYMDk6Olo7FGQA/ZWz0F85C/2Vs9BfOQv9hbTwc5Hz0Yc5G/2X89GHORv9l/PRh7bPZBiGYe0gAAAAAAAAAAAA0sKMDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAcpHZs2erdOnSypcvn6pUqaIdO3ZYO6SnzvDhw2UymSw2Dw8P83HDMDR8+HB5eXkpf/78CgsL0y+//GJRR2Jiot5++20VKVJETk5OatWqlS5cuJDdl5Irbd++XS1btpSXl5dMJpO++eYbi+OZ1T/Xrl1Tly5d5ObmJjc3N3Xp0kXXr1/P4qvLfR7VX+Hh4anebzVq1LAoQ39lj3HjxqlatWpycXFRsWLF1KZNG504ccKiDO8v25GR/uL9hcfBGNQ6bGlcExsbq5YtW8rJyUlFihRR3759dffu3ay47FzD1n530oeP7z//+Y9CQkLk6uoqV1dX1axZU+vWrTMfp/9ylnHjxslkMqlfv37mffShbcuuv7/QfzbEAJArLF261MibN68xd+5c49ixY8Y777xjODk5GefOnbN2aE+VYcOGGYGBgUZcXJx5u3Tpkvn4+PHjDRcXF2PlypXG0aNHjQ4dOhienp5GQkKCuUxERIRRokQJY+PGjcahQ4eM+vXrGxUrVjSSkpKscUm5ytq1a40PPvjAWLlypSHJWL16tcXxzOqfF154wQgKCjJ27dpl7Nq1ywgKCjJatGiRXZeZazyqv7p162a88MILFu+3K1euWJShv7JHkyZNjPnz5xvR0dFGVFSU0bx5c6NUqVLGjRs3zGV4f9mOjPQX7y9kFGNQ67GVcU1SUpIRFBRk1K9f3zh06JCxceNGw8vLy+jTp0+W34OczJZ+d9KHT+a7774zfvjhB+PEiRPGiRMnjP/7v/8z8ubNa0RHRxuGQf/lJPv27TN8fX2NkJAQ45133jHvpw9tW3b9/YX+sx0kMoBc4tlnnzUiIiIs9j3zzDPG4MGDrRTR02nYsGFGxYoV0zyWkpJieHh4GOPHjzfvu3PnjuHm5mZ8+umnhmEYxvXr1428efMaS5cuNZf57bffDDs7O2P9+vVZGvvT5p8f+DOrf44dO2ZIMvbs2WMus3v3bkOS8euvv2bxVeVe6SUyWrdune459Jf1XLp0yZBkbNu2zTAM3l+27p/9ZRi8v5BxjEFtgzXHNWvXrjXs7OyM3377zVzmq6++MhwdHY34+Pgsud7cyJq/O+nDzFOoUCHj888/p/9ykL/++ssoX768sXHjRqNevXrmRAZ9aPuy4+8v9J9tYWkpIBe4e/euDh48qOeff95i//PPP69du3ZZKaqn16lTp+Tl5aXSpUvrlVde0ZkzZyRJZ8+e1cWLFy36ydHRUfXq1TP308GDB3Xv3j2LMl5eXgoKCqIvs1hm9c/u3bvl5uam6tWrm8vUqFFDbm5u9GEWiIyMVLFixeTn56fXX39dly5dMh+jv6wnPj5ekuTu7i6J95et+2d/PcD7C4/CGNR2Zef/d3fv3q2goCB5eXmZyzRp0kSJiYk6ePBgll5nbmLN35304b+XnJyspUuX6ubNm6pZsyb9l4P07t1bzZs3V6NGjSz204c5Q1b//YX+sy0kMoBc4M8//1RycrKKFy9usb948eK6ePGilaJ6OlWvXl3//e9/9eOPP2ru3Lm6ePGiatWqpStXrpj74mH9dPHiRTk4OKhQoULplkHWyKz+uXjxoooVK5aq/mLFitGHmaxp06ZasmSJtmzZoilTpmj//v1q0KCBEhMTJdFf1mIYht577z0999xzCgoKksT7y5al1V8S7y9kDGNQ25Wd/9+9ePFiqnYKFSokBwcHfg4yyNq/O+nDJ3f06FE5OzvL0dFRERERWr16tQICAui/HGLp0qU6dOiQxo0bl+oYfWj7suPvL/SfbbG3dgAAMo/JZLJ4bRhGqn3IWk2bNjX/Ozg4WDVr1lTZsmW1cOFC80NSn6Sf6Mvskxn9k1Z5+jDzdejQwfzvoKAgVa1aVT4+Pvrhhx/04osvpnse/ZW1+vTpoyNHjuinn35KdYz3l+1Jr794f+FxMAa1Xdn1/13e6/+OLfzupA+fTIUKFRQVFaXr169r5cqV6tatm7Zt22Y+Tv/ZrvPnz+udd97Rhg0blC9fvnTL0Ye2K7v+/kL/2Q5mZAC5QJEiRZQnT55Umd5Lly6lygojezk5OSk4OFinTp2Sh4eHJD20nzw8PHT37l1du3Yt3TLIGpnVPx4eHvrjjz9S1X/58mX6MIt5enrKx8dHp06dkkR/WcPbb7+t7777Tlu3blXJkiXN+3l/2ab0+istvL+QFsagtis7/7/r4eGRqp1r167p3r17/BxkgC387qQPn5yDg4PKlSunqlWraty4capYsaKmT59O/+UABw8e1KVLl1SlShXZ29vL3t5e27Zt04wZM2Rvb2++d/RhzpEVf3+h/2wLiQwgF3BwcFCVKlW0ceNGi/0bN25UrVq1rBQVJCkxMVHHjx+Xp6enSpcuLQ8PD4t+unv3rrZt22bupypVqihv3rwWZeLi4hQdHU1fZrHM6p+aNWsqPj5e+/btM5fZu3ev4uPj6cMsduXKFZ0/f16enp6S6K/sZBiG+vTpo1WrVmnLli0qXbq0xXHeX7blUf2VFt5fSAtjUNuVnf/frVmzpqKjoxUXF2cus2HDBjk6OqpKlSpZep05mS397qQPM49hGEpMTKT/coCGDRvq6NGjioqKMm9Vq1ZVp06dFBUVpTJlytCHOUxW/P2F/rMxWfYYcQDZaunSpUbevHmNL774wjh27JjRr18/w8nJyYiJibF2aE+V/v37G5GRkcaZM2eMPXv2GC1atDBcXFzM/TB+/HjDzc3NWLVqlXH06FGjY8eOhqenp5GQkGCuIyIiwihZsqSxadMm49ChQ0aDBg2MihUrGklJSda6rFzjr7/+Mg4fPmwcPnzYkGRMnTrVOHz4sHHu3DnDMDKvf1544QUjJCTE2L17t7F7924jODjYaNGiRbZfb073sP7666+/jP79+xu7du0yzp49a2zdutWoWbOmUaJECfrLCt58803Dzc3NiIyMNOLi4szbrVu3zGV4f9mOR/UX7y88Dsag1mMr45qkpCQjKCjIaNiwoXHo0CFj06ZNRsmSJY0+ffpk383IgWzpdyd9+GSGDBlibN++3Th79qxx5MgR4//+7/8MOzs7Y8OGDYZh0H85Ub169Yx33nnH/Jo+tG3Z9fcX+s92kMgAcpFZs2YZPj4+hoODg1G5cmVj27Zt1g7pqdOhQwfD09PTyJs3r+Hl5WW8+OKLxi+//GI+npKSYgwbNszw8PAwHB0djbp16xpHjx61qOP27dtGnz59DHd3dyN//vxGixYtjNjY2Oy+lFxp69athqRUW7du3QzDyLz+uXLlitGpUyfDxcXFcHFxMTp16mRcu3Ytm64y93hYf926dct4/vnnjaJFixp58+Y1SpUqZXTr1i1VX9Bf2SOtfpJkzJ8/31yG95fteFR/8f7C42IMah22NK45d+6c0bx5cyN//vyGu7u70adPH+POnTtZefk5nq397qQPH1/37t3N/+8rWrSo0bBhQ3MSwzDov5zon4kM+tC2ZdffX+g/22EyDMPI2jkfAAAAAAAAAAAAT4ZnZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAkAHDhw+XyWRKtT3zzDOZ3ta0adO0du3aTK/3SYWFhalFixbWDuOxDB8+XLt27bJ2GP/KmjVr5OXlpcTExCxtJyYmRiaTSV9//XWWnBcZGamxY8em2r948WL5+/srOTn5sdoFAOBpwziUcWh2YxwKwBaRyAAAIIPy58+v3bt3W2zLli3L9HZs7QNkTjRixIgc/QHSMAx98MEHeu+99+To6JilbXl6emr37t1q0KBBltSf3gfIjh076s6dO1q4cGGWtAsAQG7CODTnYByacYxDATwOe2sHAABATmFnZ6caNWpYO4zHdvv2beXPn9/aYWSL3HKtW7du1bFjxxQeHp7lbTk6Olrl5zpPnjzq2rWrpk+fru7du2d7+wAA5CSMQ21fbrlWxqEAbBUzMgAAyCQ//PCDqlevrvz586to0aJ68803dfPmTfPxmzdvqk+fPqpQoYIKFCggX19fRUREKD4+3lzG19dX586d06xZs8zLBixYsECSZDKZNHnyZIs2J0+eLJPJZH4dGRkpk8mkH374Qe3atZOrq6tefvllSdL169f11ltvydPTU46OjqpSpYo2bNjw2Ne5YMECmUwm7du3Tw0bNlSBAgXk5+enH3/8USkpKRo6dKg8PDxUrFgxDRkyRCkpKeZzhw8fLmdnZ+3fv1/PPvus8uXLJ39/f61ZsyZVO5999pn8/f3l6OioUqVK6cMPP1RSUlKqOHbv3q3GjRvLyclJAwYMMN+PgQMHmu9hZGSkJGnKlCmqVq2a3NzcVKxYMbVo0UInT560aDc8PFxBQUGKjIxUpUqV5OTkpGeffVYHDx60KJeSkqKpU6eaY/Tw8NDLL79s0Z/Hjx9X69at5ebmJicnJzVv3lynT59+5D1euHCh6tWrpyJFipj3lS1bVh999JH59TfffCOTyaT33nvPvG/Tpk0ymUy6cOGCed+jfi7Tmpp/9+5d9e3bV+7u7nJzc1OPHj20cOFCmUwmxcTEWMR6584d9enTR4UKFZKnp6cGDBhg7qfhw4drxIgRunnzprkvwsLCzOe+/PLLOnLkiKKioh55TwAAQPoYhzIOZRzKOBTI7UhkAADwGJKSkiw2wzAkSV9//bVatWql4OBgrV69WhMnTtSqVavUo0cP87m3bt1ScnKyxowZo3Xr1mn06NHatm2b2rZtay6zevVqeXh4qF27duZlA5o3b/7Ycb7xxhsqV66cVq9erf79++vu3btq3Lix1qxZozFjxui7775TQECAmjdvrqNHjz7RvQgPD1ebNm20evVqlShRQu3atdM777yj2NhYLVy4UH369NH48eO1dOlSi/Pu3bunDh06qFu3blq1apXKlSuntm3bKjo62lzmk08+0RtvvKEGDRrou+++U0REhCZOnKg33ngjVRydOnVSw4YNtWbNGnXp0kW7d++WJL399tvme1i5cmVJ0oULF9SnTx99++23+vzzz5WSkqJatWrp6tWrFnVevHhRffv21cCBA7Vs2TLdunVLbdu21b1798xl3n77bQ0aNEgtWrTQ999/r1mzZsnFxUU3btyQJJ05c8Zc94IFC/Tll1/q8uXLatiw4SPXG968ebNq165tsa9u3bratm2b+fX27duVL1++VPtKly6tkiVLSsrYz2VaBg8erDlz5uj999/X8uXLJUkffvhhmmU/+OAD2dnZafny5XrjjTc0ZcoUff7555Kknj17qkePHhbLYcyePdt8bmBgoAoWLKiNGzc+NB4AAMA49O8YhzIOlRiHAk8dAwAAPNKwYcMMSam2RYsWGSkpKYaPj4/RsWNHi3N++OEHw2QyGdHR0WnWee/ePeOnn34yJBknTpww7/fx8TF69+6dqrwkY9KkSRb7Jk2aZPz91/nWrVsNScZbb71lUW7evHmGvb298csvv1jsf/bZZ42XX375odder149o3nz5ubX8+fPNyQZ//nPf8z7jh49akgyqlevbnFulSpVjDZt2phfP7iPX3zxhXlfUlKS4evra75/SUlJRpEiRVLFNXbsWMNkMhmnT5+2iGPixImpYk7rXv1TUlKScevWLcPZ2dmYM2eOeX+3bt1S9dvGjRsNScaOHTsMwzCMEydOGCaTyRg7dmy69Xft2tUoXbq0cfv2bfO+S5cuGU5OTsasWbPSPe/33383JBkrVqyw2D9v3jzD0dHRXF+VKlWMPn36GHZ2dsb169cNw7jfV926dTMMw8jwz+XZs2ct2rty5YqRL18+Y+TIkRbn1atXz5BknD171uK8f/ZT7dq1jYYNG5pfDxs2zHByckr3euvWrWu89NJL6R4HAOBpxziUcSjjUMahAAyDGRkAAGRQ/vz5tX//foutWbNmOnnypM6dO6f27dtbfEuuXr16MplMOnDggLmORYsWqVKlSnJ2dlbevHn13HPPSVKqaeX/VrNmzSxeb9iwQcHBwfLz87OIsWHDhtq/f/8TtdGoUSPzv/38/FLte7D//Pnzqc79+7f/8uTJo1atWmnPnj2SpF9//VV//vmnOnToYHFOx44dZRiGdu7cabH/n9f6MHv27FHjxo1VuHBh2dvbq0CBArpx40aq++/l5aXAwEDz64CAAEkyT5XfsmWLDMN46DfKNmzYoNatW8ve3t58vwsVKqSKFSs+9J7HxcVJkooWLWqxv27dukpMTNTevXv1119/KSoqShERESpcuLB++ukn3b17V3v37lXdunUl6bF+Lv/u6NGjunPnjlq1amWxv3Xr1mmWf/755y1eBwQEWCwp8ChFihTRxYsXM1weAICnEeNQS4xDGYdKjEOBpw0P+wYAIIPs7OxUtWrVVPuPHz8uyfJD0d89+AC1evVqde3aVb169dKYMWNUuHBhxcXFqW3btrpz506mxlqsWDGL13/++acOHz6svHnzpiqbJ0+eJ2qjYMGC5n87ODik2vdg/z+vLW/evCpUqFCqeB98cLp27ZokycPDw6LMg9f/nH7/z2tNT2xsrJ5//nlVrVpVc+bMkZeXlxwcHNS8efNUMaZ1HZLM5a5cuSJ7e/uHtv3nn39q2rRpmjZtWqpjD3sQ5IM2HB0dLfaXLVtWJUuW1Pbt23X79m0VKlRIAQEBqlOnjrZv3y43NzfduXNH9erVM7cvPfrn8p/S+wCb3rVmpM8fJl++fLp9+3aGywMA8DRiHGqJcSjjUIlxKPC0IZEBAMC/5O7uLkmaOXOmqlevnuq4l5eXJGnFihUKDQ3VnDlzzMf+vq7sozg6Ouru3bsW+/75YeqBvz948UGMISEh+uKLLzLcXla5d++erl27ZvEh8tKlS/L09JT0/+/nH3/8YXHeg29LPTj+wD+vNT3r16/XjRs3tGrVKvOHnqSkpHTv4cMULlxYSUlJunTpUrofrNzd3dW8eXO99dZbqY65uLikW/eD67t+/XqqY3Xq1NG2bdt0+/Zt1alTRyaTSXXr1tVXX30lNzc3eXl5qWzZshb1POrn8p8e9MPly5ctyly6dCndmP+Na9euqXDhwllSNwAAuR3j0MfDOJRx6N8xDgVyFhIZAAD8S88884xKliypM2fOqHfv3umWu337tvkbVQ8sWbIkVbn0vklUsmRJ87fuHti0aVOGYmzUqJHWrl0rLy+vdD84ZKfVq1ere/fukqTk5GR99913qlGjhiSpQoUKKlq0qJYvX64XX3zRfM6yZctkMpnMyyA8TN68eVPdw9u3b8tkMll8G3D58uVKSkp67PgbNGggk8mk+fPn6/3330+zTKNGjRQdHa1KlSo91rcNS5cuLQcHB509ezbVsbp166p///5KSEhQp06dJEn16tXTgAEDZG9vb57OL2X85/KfgoODlS9fPn377beqWLGief8333yT4Tr+zsHB4aEPlTx79myqpSAAAEDGMA59fIxD08c4FIAtI5EBAMC/ZDKZNHXqVL366qu6efOmmjdvLicnJ507d04//PCDxo4dKz8/PzVu3Fi9e/fWyJEjVatWLa1bt06bN29OVZ+/v7+2bNmijRs3qlChQipdurQKFy6sdu3aadq0aXr22Wfl5+en//73vxle07Vr166aM2eOwsLCNGDAAPn5+en69es6fPiw7t69q3HjxmX2bUmXg4ODRo8erTt37qh06dKaPXu2Lly4oCFDhki6v8TARx99pLfffltFixZVy5YtdejQIQ0bNkyvvfaaSpcu/cg2/P399e2336pOnTpycnJShQoV1KBBA0nSa6+9pjfeeEPHjh3T5MmTU01Jzwg/Pz9FREToww8/1NWrV9WwYUPdunVLP/zwg4YPH64SJUpoxIgRqlatmpo0aaJevXqpePHiunjxorZt26Y6deqoY8eOadbt6OioKlWq6ODBg6mO1a1bV7du3dL+/fvN36gMCQmRs7Ozdu7cqdmzZ5vLZvTn8p/c3d315ptvasyYMcqXL59CQ0O1bNkynTlzRtL9pS0eh7+/v5KSkjR9+nTVqlVLrq6uqlChgiQpISFBJ06c0IgRIx6rTgAAcB/j0MfDOJRxKONQIAez7rPGAQDIGYYNG2Y4OTk9tMyGDRuMevXqGU5OToaTk5MRGBho9O/f37h+/bphGIaRlJRk9O/f3yhatKjh4uJitGvXztizZ48hyVixYoW5nujoaKNOnTqGi4uLIcmYP3++YRiGcePGDeO1114z3N3djaJFixoffPCBMWHCBOPvv863bt1qSDL279+fKr74+Hjj3XffNUqVKmXkzZvX8PT0NJo1a2asWbPmoddVr149o3nz5ubX8+fPNyQZly9ftignyZg0aZLFvm7duhmBgYGp7uOePXuMKlWqGA4ODkaFChWMb7/9NlW7n376qVGhQgUjb968RsmSJY0PPvjAuHfv3iPjMAzD2LFjh1G5cmUjf/78hiRj69athmEYxsKFC40yZcoY+fLlM2rUqGHs27fP8PHxMXr37p1uzIZhGJcvX7boC8MwjOTkZGPixIlG+fLljbx58xoeHh5Ghw4djPj4eHOZkydPGu3btzcKFy5sODo6Gr6+vkbXrl2N6OjotG612ZQpU4wSJUoYKSkpqY4VLVrUcHNzM5KTk837WrRoYUhKs95H/VyePXs21c9gYmKi0adPH6NgwYKGq6ur0a1bN2P69OmGpIeeZxiG0bt3b8PHx8f8+t69e8Zbb71lFC9e3DCZTEa9evXMx5YtW2Y4OTkZCQkJD70fAAA8zRiHMg5lHMo4FIBhmAzDMLIraQIAAJ5uw4cP1+TJk3Xjxg1rh2LTLl++LG9vb23YsMFimr41de7cWTt37kxzqYEn9eKLL6pgwYKaN29eptUJAACQFsahGcM4FICtYmkpAAAAG1O0aFG9+eabmjJlilU+QG7btk07d+5UlSpVlJKSojVr1ujLL7/U1KlTM62NM2fOaN26dYqOjs60OgEAAPDvMA4FYKtIZAAAANig//u//9N//vMfJSYmytHRMVvbdnZ21po1azRx4kTdunVLpUuX1tSpU9WvX79Ma+O3337T3LlzVbZs2UyrEwAAAP8e41AAtoilpQAAAAAAAAAAgM2ys3YAAAAAAAAAAAAA6SGRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWf8PB3/iRfGLFgEAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1600x800 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feature importance plot saved.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "FEATURE_NAMES = [\n",
+    "    \"title_len\", \"has_question\", \"has_exclamation\", \"title_has_number\", \"title_is_allcaps\",\n",
+    "    \"has_title\", \"is_text_post\", \"selftext_len\",\n",
+    "    \"is_known_bot\", \"is_anonymous_author\",\n",
+    "    \"hour_of_day\", \"day_of_week\",\n",
+    "    \"author_post_count\", \"author_mean_score\",\n",
+    "    \"subreddit_post_count\", \"subreddit_median_score\", \"subreddit_median_comments\",\n",
+    "    \"title_sentiment\", \"selftext_sentiment\"\n",
+    "]\n",
+    "\n",
+    "def get_feature_importance(model, feature_names):\n",
+    "    # Extract the underlying sklearn booster from SparkXGBClassifierModel\n",
+    "    booster = model.get_booster()\n",
+    "    scores = booster.get_score(importance_type=\"weight\")\n",
+    "    # Map f0, f1, ... feature names to actual names\n",
+    "    importance = {feature_names[int(k[1:])]: v for k, v in scores.items()}\n",
+    "    # Fill missing features with 0\n",
+    "    return {name: importance.get(name, 0) for name in feature_names}\n",
+    "\n",
+    "importance_A = get_feature_importance(model_A, FEATURE_NAMES)\n",
+    "importance_B = get_feature_importance(model_B, FEATURE_NAMES)\n",
+    "\n",
+    "# Sort by Config B importance for consistent ordering\n",
+    "sorted_features = sorted(FEATURE_NAMES, key=lambda f: importance_B[f])\n",
+    "vals_A = [importance_A[f] for f in sorted_features]\n",
+    "vals_B = [importance_B[f] for f in sorted_features]\n",
+    "\n",
+    "# Plot\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(16, 8), sharey=True)\n",
+    "\n",
+    "for ax, vals, title, color in zip(\n",
+    "    axes,\n",
+    "    [vals_A, vals_B],\n",
+    "    [\"Config A (Conservative)\", \"Config B (Aggressive)\"],\n",
+    "    [\"steelblue\", \"darkorange\"]\n",
+    "):\n",
+    "    bars = ax.barh(sorted_features, vals, color=color, alpha=0.85)\n",
+    "    ax.set_title(title, fontsize=13, fontweight=\"bold\")\n",
+    "    ax.set_xlabel(\"Feature Importance (weight)\", fontsize=11)\n",
+    "    ax.spines[\"top\"].set_visible(False)\n",
+    "    ax.spines[\"right\"].set_visible(False)\n",
+    "    for bar, val in zip(bars, vals):\n",
+    "        if val > 0:\n",
+    "            ax.text(bar.get_width() + max(vals)*0.01, bar.get_y() + bar.get_height()/2,\n",
+    "                    f\"{int(val)}\", va=\"center\", fontsize=8)\n",
+    "\n",
+    "axes[0].set_ylabel(\"Feature\", fontsize=11)\n",
+    "plt.suptitle(\"XGBoost Feature Importance — 4-Class Engagement Classification\\n(Pushshift Reddit, 276M Training Rows)\",\n",
+    "             fontsize=14, fontweight=\"bold\", y=1.01)\n",
+    "plt.tight_layout()\n",
+    "\n",
+    "os.makedirs(\"../outputs/figures\", exist_ok=True)\n",
+    "plt.savefig(\"../outputs/figures/xgboost_4class_feature_importance.png\", dpi=150, bbox_inches=\"tight\")\n",
+    "plt.show()\n",
+    "print(\"Feature importance plot saved.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e10d6a8a-23f4-489f-9a57-411626f974d7",
+   "metadata": {},
+   "source": [
+    "### Feature Importance Analysis\n",
+    "\n",
+    "The feature importance rankings reveal a clear hierarchy of predictive signal across both configurations. Subreddit and author context features dominate overwhelmingly — `subreddit_post_count`, `author_mean_score`, and `author_post_count` are the top three features in both configs by a substantial margin. This is interpretable: knowing the community a post belongs to and the historical track record of its author encodes far more engagement signal than any property of the post itself. A veteran poster in a large, active subreddit operates in a fundamentally different engagement environment than a new user in a niche community, and the model learns this distinction readily.\n",
+    "\n",
+    "Structural title features (`has_question`, `has_exclamation`, and `title_is_allcaps`) contribute negligible weight in Config A and minimal weight in Config B. These features appear to carry little predictive value once community and author context is accounted for, suggesting that titling conventions matter far less than where and by whom a post is made. `has_question` and `has_exclamation` register zero weight in Config A, indicating they were never selected as useful split criteria across 200 boosting rounds.\n",
+    "\n",
+    "Config B's deeper trees (max_depth=8) surface meaningful signal from features that Config A's shallower trees could not reach. Sentiment features (`title_sentiment`, `selftext_sentiment`), post type (`is_text_post`), and temporal features (`hour_of_day`, `day_of_week`) all receive substantially more splits in Config B, contributing to its higher overall performance. This suggests these features carry real but weaker signal that requires more complex interactions to exploit which are interactions that depth-4 trees cannot represent.\n",
+    "\n",
+    "For Milestone 4, `has_question` and `has_exclamation` are candidates for removal as zero-contribution features. More importantly, the dominance of community context features motivates incorporating subreddit-level embedding features or Word2Vec title embeddings, which could capture the semantic content dimension that the current feature set lacks entirely."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b37ede5-07e3-43b5-a822-d9bcd4323e4d",
+   "metadata": {},
+   "source": [
+    "## Binary Label XGBoost Training\n",
+    "\n",
+    "We train two XGBoost configurations on the binary engagement label (`label_binary_idx`: 0 = low-engagement, 1 = high-engagement) using the same architecture and hyperparameter choices as the 4-class models. This provides a direct comparison baseline, the binary task collapses the four engagement tiers into a single high/low distinction, trading label granularity for a simpler decision boundary. The binary class split is near-balanced (55.7% high-engagement, 44.3% low-engagement), so class weights are close to 1.0 and their effect is minimal relative to the 4-class case.\n",
+    "\n",
+    "The same 16-partition, 16-worker setup is used, with binary-specific projections selecting `label_binary_idx` and `weight_binary` instead of their 4-class counterparts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d90e8158-115d-42d9-b50f-7534b65cf575",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "train_xgb_bin partitions: 16\n",
+      "Binary Config A and Config B defined.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "# Binary projections — same splits, different label and weight columns\n",
+    "train_xgb_bin = train_w.select(\"features\", \"label_binary_idx\", \"weight_binary\").repartition(16)\n",
+    "val_xgb_bin   = val_w.select(\"features\", \"label_binary_idx\", \"weight_binary\").repartition(16)\n",
+    "test_xgb_bin  = test_w.select(\"features\", \"label_binary_idx\", \"weight_binary\").repartition(16)\n",
+    "\n",
+    "print(f\"train_xgb_bin partitions: {train_xgb_bin.rdd.getNumPartitions()}\")\n",
+    "\n",
+    "COMMON_PARAMS_BIN = dict(\n",
+    "    features_col=\"features\",\n",
+    "    label_col=\"label_binary_idx\",\n",
+    "    weight_col=\"weight_binary\",\n",
+    "    num_workers=16,\n",
+    "    device=\"cpu\",\n",
+    "    seed=42,\n",
+    ")\n",
+    "\n",
+    "# Config A: conservative — shallow trees, strong regularization\n",
+    "config_A_bin = SparkXGBClassifier(\n",
+    "    **COMMON_PARAMS_BIN,\n",
+    "    max_depth=4,\n",
+    "    n_estimators=200,\n",
+    "    learning_rate=0.05,\n",
+    "    subsample=0.8,\n",
+    "    colsample_bytree=0.8,\n",
+    "    reg_lambda=5.0,\n",
+    "    reg_alpha=1.0,\n",
+    "    min_child_weight=50,\n",
+    ")\n",
+    "\n",
+    "# Config B: aggressive — deep trees, faster learning, light regularization\n",
+    "config_B_bin = SparkXGBClassifier(\n",
+    "    **COMMON_PARAMS_BIN,\n",
+    "    max_depth=8,\n",
+    "    n_estimators=300,\n",
+    "    learning_rate=0.1,\n",
+    "    subsample=0.7,\n",
+    "    colsample_bytree=0.7,\n",
+    "    reg_lambda=1.0,\n",
+    "    reg_alpha=0.0,\n",
+    "    min_child_weight=10,\n",
+    ")\n",
+    "\n",
+    "print(\"Binary Config A and Config B defined.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46defb63-cc68-4734-934d-4fb675a8cf51",
+   "metadata": {},
+   "source": [
+    "### Training Binary Configurations\n",
+    "\n",
+    "Both binary configurations are trained sequentially. Config A's conservative hyperparameters are expected to complete in roughly 1 hour based on 4-class training times; Config B's deeper trees and additional rounds should take approximately 2 hours."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d333050c-db22-4920-81dd-120f99a761bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training Binary Config A...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-14 00:18:13,998 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'binary:logistic', 'colsample_bytree': 0.8, 'device': 'cpu', 'learning_rate': 0.05, 'max_depth': 4, 'min_child_weight': 50, 'reg_alpha': 1.0, 'reg_lambda': 5.0, 'subsample': 0.8, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 200}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n",
+      "2026-05-14 00:34:20,739 INFO XGBoost-PySpark: _fit Finished xgboost training!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Binary Config A training time: 1036.8s\n",
+      "Binary Config A saved.\n",
+      "\n",
+      "Training Binary Config B...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-14 00:35:26,909 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'binary:logistic', 'colsample_bytree': 0.7, 'device': 'cpu', 'learning_rate': 0.1, 'max_depth': 8, 'min_child_weight': 10, 'reg_alpha': 0.0, 'reg_lambda': 1.0, 'subsample': 0.7, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 300}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n",
+      "----------------------------------------\n",
+      "Exception occurred during processing of request from ('127.0.0.1', 40024)\n",
+      "ERROR:root:Exception while sending command.\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\", line 516, in send_command\n",
+      "    raise Py4JNetworkError(\"Answer from Java side is empty\")\n",
+      "py4j.protocol.Py4JNetworkError: Answer from Java side is empty\n",
+      "\n",
+      "During handling of the above exception, another exception occurred:\n",
+      "\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py\", line 1038, in send_command\n",
+      "    response = connection.send_command(command)\n",
+      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\", line 539, in send_command\n",
+      "    raise Py4JNetworkError(\n",
+      "py4j.protocol.Py4JNetworkError: Error while sending or receiving\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/opt/conda/lib/python3.11/socketserver.py\", line 317, in _handle_request_noblock\n",
+      "    self.process_request(request, client_address)\n",
+      "  File \"/opt/conda/lib/python3.11/socketserver.py\", line 348, in process_request\n",
+      "    self.finish_request(request, client_address)\n",
+      "  File \"/opt/conda/lib/python3.11/socketserver.py\", line 361, in finish_request\n",
+      "    self.RequestHandlerClass(request, client_address, self)\n",
+      "  File \"/opt/conda/lib/python3.11/socketserver.py\", line 755, in __init__\n",
+      "    self.handle()\n",
+      "  File \"/usr/local/spark/python/pyspark/accumulators.py\", line 295, in handle\n",
+      "    poll(accum_updates)\n",
+      "  File \"/usr/local/spark/python/pyspark/accumulators.py\", line 267, in poll\n",
+      "    if self.rfile in r and func():\n",
+      "                           ^^^^^^\n",
+      "  File \"/usr/local/spark/python/pyspark/accumulators.py\", line 271, in accum_updates\n",
+      "    num_updates = read_int(self.rfile)\n",
+      "                  ^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/usr/local/spark/python/pyspark/serializers.py\", line 596, in read_int\n",
+      "    raise EOFError\n",
+      "EOFError\n",
+      "----------------------------------------\n"
+     ]
+    },
+    {
+     "ename": "ConnectionRefusedError",
+     "evalue": "[Errno 111] Connection refused",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mPy4JError\u001b[0m                                 Traceback (most recent call last)",
+      "File \u001b[0;32m/usr/local/spark/python/pyspark/rdd.py:1833\u001b[0m, in \u001b[0;36mRDD.collect\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1832\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mctx\u001b[38;5;241m.\u001b[39m_jvm \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m-> 1833\u001b[0m     sock_info \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mctx\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_jvm\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mPythonRDD\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollectAndServe\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_jrdd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrdd\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1834\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mlist\u001b[39m(_load_from_socket(sock_info, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_jrdd_deserializer))\n",
+      "File \u001b[0;32m/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py:1322\u001b[0m, in \u001b[0;36mJavaMember.__call__\u001b[0;34m(self, *args)\u001b[0m\n\u001b[1;32m   1321\u001b[0m answer \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mgateway_client\u001b[38;5;241m.\u001b[39msend_command(command)\n\u001b[0;32m-> 1322\u001b[0m return_value \u001b[38;5;241m=\u001b[39m \u001b[43mget_return_value\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   1323\u001b[0m \u001b[43m    \u001b[49m\u001b[43manswer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mgateway_client\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtarget_id\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1325\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m temp_arg \u001b[38;5;129;01min\u001b[39;00m temp_args:\n",
+      "File \u001b[0;32m/usr/local/spark/python/pyspark/errors/exceptions/captured.py:179\u001b[0m, in \u001b[0;36mcapture_sql_exception.<locals>.deco\u001b[0;34m(*a, **kw)\u001b[0m\n\u001b[1;32m    178\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 179\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mf\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43ma\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkw\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    180\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m Py4JJavaError \u001b[38;5;28;01mas\u001b[39;00m e:\n",
+      "File \u001b[0;32m/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/protocol.py:334\u001b[0m, in \u001b[0;36mget_return_value\u001b[0;34m(answer, gateway_client, target_id, name)\u001b[0m\n\u001b[1;32m    333\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 334\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m Py4JError(\n\u001b[1;32m    335\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAn error occurred while calling \u001b[39m\u001b[38;5;132;01m{0}\u001b[39;00m\u001b[38;5;132;01m{1}\u001b[39;00m\u001b[38;5;132;01m{2}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;241m.\u001b[39m\n\u001b[1;32m    336\u001b[0m             \u001b[38;5;28mformat\u001b[39m(target_id, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m.\u001b[39m\u001b[38;5;124m\"\u001b[39m, name))\n\u001b[1;32m    337\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
+      "\u001b[0;31mPy4JError\u001b[0m: An error occurred while calling z:org.apache.spark.api.python.PythonRDD.collectAndServe",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mConnectionRefusedError\u001b[0m                    Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[14], line 13\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124mTraining Binary Config B...\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     12\u001b[0m t0 \u001b[38;5;241m=\u001b[39m time\u001b[38;5;241m.\u001b[39mtime()\n\u001b[0;32m---> 13\u001b[0m model_B_bin \u001b[38;5;241m=\u001b[39m \u001b[43mconfig_B_bin\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtrain_xgb_bin\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     14\u001b[0m elapsed \u001b[38;5;241m=\u001b[39m time\u001b[38;5;241m.\u001b[39mtime() \u001b[38;5;241m-\u001b[39m t0\n\u001b[1;32m     15\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBinary Config B training time: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00melapsed\u001b[38;5;132;01m:\u001b[39;00m\u001b[38;5;124m.1f\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124ms\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "File \u001b[0;32m/usr/local/spark/python/pyspark/ml/base.py:205\u001b[0m, in \u001b[0;36mEstimator.fit\u001b[0;34m(self, dataset, params)\u001b[0m\n\u001b[1;32m    203\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcopy(params)\u001b[38;5;241m.\u001b[39m_fit(dataset)\n\u001b[1;32m    204\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 205\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_fit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdataset\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    206\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    207\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\n\u001b[1;32m    208\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mParams must be either a param map or a list/tuple of param maps, \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    209\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbut got \u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m.\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mtype\u001b[39m(params)\n\u001b[1;32m    210\u001b[0m     )\n",
+      "File \u001b[0;32m/opt/conda/lib/python3.11/site-packages/xgboost/spark/core.py:1136\u001b[0m, in \u001b[0;36m_SparkXGBEstimator._fit\u001b[0;34m(self, dataset)\u001b[0m\n\u001b[1;32m   1123\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m ret[\u001b[38;5;241m0\u001b[39m], ret[\u001b[38;5;241m1\u001b[39m]\n\u001b[1;32m   1125\u001b[0m get_logger(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mXGBoost-PySpark\u001b[39m\u001b[38;5;124m\"\u001b[39m)\u001b[38;5;241m.\u001b[39minfo(\n\u001b[1;32m   1126\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mRunning xgboost-\u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m on \u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m workers with\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m   1127\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\t\u001b[39;00m\u001b[38;5;124mbooster params: \u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   1134\u001b[0m     dmatrix_kwargs,\n\u001b[1;32m   1135\u001b[0m )\n\u001b[0;32m-> 1136\u001b[0m (config, booster) \u001b[38;5;241m=\u001b[39m \u001b[43m_run_job\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1137\u001b[0m get_logger(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mXGBoost-PySpark\u001b[39m\u001b[38;5;124m\"\u001b[39m)\u001b[38;5;241m.\u001b[39minfo(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mFinished xgboost training!\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m   1139\u001b[0m result_xgb_model \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_convert_to_sklearn_model(\n\u001b[1;32m   1140\u001b[0m     \u001b[38;5;28mbytearray\u001b[39m(booster, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mutf-8\u001b[39m\u001b[38;5;124m\"\u001b[39m), config\n\u001b[1;32m   1141\u001b[0m )\n",
+      "File \u001b[0;32m/opt/conda/lib/python3.11/site-packages/xgboost/spark/core.py:1122\u001b[0m, in \u001b[0;36m_SparkXGBEstimator._fit.<locals>._run_job\u001b[0;34m()\u001b[0m\n\u001b[1;32m   1113\u001b[0m rdd \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m   1114\u001b[0m     dataset\u001b[38;5;241m.\u001b[39mmapInPandas(\n\u001b[1;32m   1115\u001b[0m         _train_booster,  \u001b[38;5;66;03m# type: ignore\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   1119\u001b[0m     \u001b[38;5;241m.\u001b[39mmapPartitions(\u001b[38;5;28;01mlambda\u001b[39;00m x: x)\n\u001b[1;32m   1120\u001b[0m )\n\u001b[1;32m   1121\u001b[0m rdd_with_resource \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_try_stage_level_scheduling(rdd)\n\u001b[0;32m-> 1122\u001b[0m ret \u001b[38;5;241m=\u001b[39m \u001b[43mrdd_with_resource\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollect\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m   1123\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m ret[\u001b[38;5;241m0\u001b[39m], ret[\u001b[38;5;241m1\u001b[39m]\n",
+      "File \u001b[0;32m/usr/local/spark/python/pyspark/rdd.py:1831\u001b[0m, in \u001b[0;36mRDD.collect\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1803\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mcollect\u001b[39m(\u001b[38;5;28mself\u001b[39m: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mRDD[T]\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m List[T]:\n\u001b[1;32m   1804\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   1805\u001b[0m \u001b[38;5;124;03m    Return a list that contains all the elements in this RDD.\u001b[39;00m\n\u001b[1;32m   1806\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   1829\u001b[0m \u001b[38;5;124;03m    ['x', 'y', 'z']\u001b[39;00m\n\u001b[1;32m   1830\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 1831\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43;01mwith\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mSCCallSiteSync\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcontext\u001b[49m\u001b[43m)\u001b[49m\u001b[43m:\u001b[49m\n\u001b[1;32m   1832\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43;01massert\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mctx\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_jvm\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mis\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mnot\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\n\u001b[1;32m   1833\u001b[0m \u001b[43m        \u001b[49m\u001b[43msock_info\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mctx\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_jvm\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mPythonRDD\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollectAndServe\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_jrdd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrdd\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/spark/python/pyspark/traceback_utils.py:81\u001b[0m, in \u001b[0;36mSCCallSiteSync.__exit__\u001b[0;34m(self, type, value, tb)\u001b[0m\n\u001b[1;32m     79\u001b[0m SCCallSiteSync\u001b[38;5;241m.\u001b[39m_spark_stack_depth \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[1;32m     80\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m SCCallSiteSync\u001b[38;5;241m.\u001b[39m_spark_stack_depth \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0\u001b[39m:\n\u001b[0;32m---> 81\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_context\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_jsc\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msetCallSite\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py:1321\u001b[0m, in \u001b[0;36mJavaMember.__call__\u001b[0;34m(self, *args)\u001b[0m\n\u001b[1;32m   1314\u001b[0m args_command, temp_args \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_build_args(\u001b[38;5;241m*\u001b[39margs)\n\u001b[1;32m   1316\u001b[0m command \u001b[38;5;241m=\u001b[39m proto\u001b[38;5;241m.\u001b[39mCALL_COMMAND_NAME \u001b[38;5;241m+\u001b[39m\\\n\u001b[1;32m   1317\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcommand_header \u001b[38;5;241m+\u001b[39m\\\n\u001b[1;32m   1318\u001b[0m     args_command \u001b[38;5;241m+\u001b[39m\\\n\u001b[1;32m   1319\u001b[0m     proto\u001b[38;5;241m.\u001b[39mEND_COMMAND_PART\n\u001b[0;32m-> 1321\u001b[0m answer \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mgateway_client\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msend_command\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcommand\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1322\u001b[0m return_value \u001b[38;5;241m=\u001b[39m get_return_value(\n\u001b[1;32m   1323\u001b[0m     answer, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mgateway_client, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtarget_id, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mname)\n\u001b[1;32m   1325\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m temp_arg \u001b[38;5;129;01min\u001b[39;00m temp_args:\n",
+      "File \u001b[0;32m/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py:1036\u001b[0m, in \u001b[0;36mGatewayClient.send_command\u001b[0;34m(self, command, retry, binary)\u001b[0m\n\u001b[1;32m   1015\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msend_command\u001b[39m(\u001b[38;5;28mself\u001b[39m, command, retry\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m, binary\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m):\n\u001b[1;32m   1016\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Sends a command to the JVM. This method is not intended to be\u001b[39;00m\n\u001b[1;32m   1017\u001b[0m \u001b[38;5;124;03m       called directly by Py4J users. It is usually called by\u001b[39;00m\n\u001b[1;32m   1018\u001b[0m \u001b[38;5;124;03m       :class:`JavaMember` instances.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   1034\u001b[0m \u001b[38;5;124;03m     if `binary` is `True`.\u001b[39;00m\n\u001b[1;32m   1035\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 1036\u001b[0m     connection \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_get_connection\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1037\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m   1038\u001b[0m         response \u001b[38;5;241m=\u001b[39m connection\u001b[38;5;241m.\u001b[39msend_command(command)\n",
+      "File \u001b[0;32m/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py:284\u001b[0m, in \u001b[0;36mJavaClient._get_connection\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    281\u001b[0m     \u001b[38;5;28;01mpass\u001b[39;00m\n\u001b[1;32m    283\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m connection \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m connection\u001b[38;5;241m.\u001b[39msocket \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 284\u001b[0m     connection \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_create_new_connection\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    285\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m connection\n",
+      "File \u001b[0;32m/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py:291\u001b[0m, in \u001b[0;36mJavaClient._create_new_connection\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    287\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_create_new_connection\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[1;32m    288\u001b[0m     connection \u001b[38;5;241m=\u001b[39m ClientServerConnection(\n\u001b[1;32m    289\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mjava_parameters, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpython_parameters,\n\u001b[1;32m    290\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mgateway_property, \u001b[38;5;28mself\u001b[39m)\n\u001b[0;32m--> 291\u001b[0m     \u001b[43mconnection\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconnect_to_java_server\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    292\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mset_thread_connection(connection)\n\u001b[1;32m    293\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m connection\n",
+      "File \u001b[0;32m/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py:438\u001b[0m, in \u001b[0;36mClientServerConnection.connect_to_java_server\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    435\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mssl_context:\n\u001b[1;32m    436\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msocket \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mssl_context\u001b[38;5;241m.\u001b[39mwrap_socket(\n\u001b[1;32m    437\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msocket, server_hostname\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mjava_address)\n\u001b[0;32m--> 438\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msocket\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconnect\u001b[49m\u001b[43m(\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjava_address\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjava_port\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    439\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mstream \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msocket\u001b[38;5;241m.\u001b[39mmakefile(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mrb\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    440\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mis_connected \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n",
+      "\u001b[0;31mConnectionRefusedError\u001b[0m: [Errno 111] Connection refused"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR:root:Exception while sending command.\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\", line 516, in send_command\n",
+      "    raise Py4JNetworkError(\"Answer from Java side is empty\")\n",
+      "py4j.protocol.Py4JNetworkError: Answer from Java side is empty\n",
+      "\n",
+      "During handling of the above exception, another exception occurred:\n",
+      "\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py\", line 1038, in send_command\n",
+      "    response = connection.send_command(command)\n",
+      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/usr/local/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py\", line 539, in send_command\n",
+      "    raise Py4JNetworkError(\n",
+      "py4j.protocol.Py4JNetworkError: Error while sending or receiving\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "print(\"Training Binary Config A...\")\n",
+    "t0 = time.time()\n",
+    "model_A_bin = config_A_bin.fit(train_xgb_bin)\n",
+    "elapsed = time.time() - t0\n",
+    "print(f\"Binary Config A training time: {elapsed:.1f}s\")\n",
+    "model_A_bin.write().overwrite().save(\"../outputs/models/xgb_binary_config_A\")\n",
+    "print(\"Binary Config A saved.\")\n",
+    "\n",
+    "print(\"\\nTraining Binary Config B...\")\n",
+    "t0 = time.time()\n",
+    "model_B_bin = config_B_bin.fit(train_xgb_bin)\n",
+    "elapsed = time.time() - t0\n",
+    "print(f\"Binary Config B training time: {elapsed:.1f}s\")\n",
+    "model_B_bin.write().overwrite().save(\"../outputs/models/xgb_binary_config_B\")\n",
+    "print(\"Binary Config B saved.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4664fb89-c1c4-4f25-9959-e350d39b9948",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training Binary Config B...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-05-14 01:08:15,113 INFO XGBoost-PySpark: _fit Running xgboost-2.0.3 on 16 workers with\n",
+      "\tbooster params: {'objective': 'binary:logistic', 'colsample_bytree': 0.7, 'device': 'cpu', 'learning_rate': 0.1, 'max_depth': 8, 'min_child_weight': 10, 'reg_alpha': 0.0, 'reg_lambda': 1.0, 'subsample': 0.7, 'seed': 42, 'nthread': 1}\n",
+      "\ttrain_call_kwargs_params: {'verbose_eval': True, 'num_boost_round': 300}\n",
+      "\tdmatrix_kwargs: {'nthread': 1, 'missing': nan}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "print(\"Training Binary Config B...\")\n",
+    "t0 = time.time()\n",
+    "model_B_bin = config_B_bin.fit(train_xgb_bin)\n",
+    "elapsed = time.time() - t0\n",
+    "print(f\"Binary Config B training time: {elapsed:.1f}s\")\n",
+    "model_B_bin.write().overwrite().save(\"../outputs/models/xgb_binary_config_B\")\n",
+    "print(\"Binary Config B saved.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "638096e0-10f7-421a-8cd0-22515c16cfea",
+   "metadata": {},
+   "source": [
+    "### Reloading Persisted Binary Models\n",
+    "\n",
+    "Both binary configs trained and saved in the previous session. Loading directly from disk to proceed with evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8e5ee5d8-a7fa-47be-82bf-7cc753e484da",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Binary Config A and Config B loaded successfully.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from xgboost.spark import SparkXGBClassifierModel\n",
+    "\n",
+    "model_A_bin = SparkXGBClassifierModel.load(\"../outputs/models/xgb_binary_config_A\")\n",
+    "model_B_bin = SparkXGBClassifierModel.load(\"../outputs/models/xgb_binary_config_B\")\n",
+    "\n",
+    "print(\"Binary Config A and Config B loaded successfully.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd766f15-aa9d-4361-a79e-45385635d755",
+   "metadata": {},
+   "source": [
+    "### Binary Model Evaluation\n",
+    "\n",
+    "We evaluate both binary configurations across all three splits using the same metrics as the 4-class evaluation. For binary classification, per-class metrics reduce to precision, recall, and F1 for low-engagement (class 0) and high-engagement (class 1) respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "85a8890c-5408-4859-94f0-0b0c806a226d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "====== Binary Config A ======\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/spark/python/pyspark/sql/context.py:158: FutureWarning: Deprecated in 3.0.0. Use SparkSession.builder.getOrCreate() instead.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Train ---\n",
+      "  Weighted F1:    0.7087\n",
+      "  Accuracy:       0.7095\n",
+      "  W-Precision:    0.7188\n",
+      "  W-Recall:       0.7095\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.7693  R=0.643  F1=0.7005\n",
+      "    high-engagement      P=0.6621  R=0.7839  F1=0.7179\n",
+      "\n",
+      "--- Val ---\n",
+      "  Weighted F1:    0.7435\n",
+      "  Accuracy:       0.7413\n",
+      "  W-Precision:    0.7557\n",
+      "  W-Recall:       0.7413\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.827  R=0.7109  F1=0.7646\n",
+      "    high-engagement      P=0.6529  R=0.7852  F1=0.713\n",
+      "\n",
+      "--- Test ---\n",
+      "  Weighted F1:    0.7280\n",
+      "  Accuracy:       0.7260\n",
+      "  W-Precision:    0.7456\n",
+      "  W-Recall:       0.7260\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.8238  R=0.6779  F1=0.7438\n",
+      "    high-engagement      P=0.6346  R=0.7942  F1=0.7055\n",
+      "\n",
+      "====== Binary Config B ======\n",
+      "\n",
+      "--- Train ---\n",
+      "  Weighted F1:    0.7375\n",
+      "  Accuracy:       0.7381\n",
+      "  W-Precision:    0.7477\n",
+      "  W-Recall:       0.7381\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.8008  R=0.6713  F1=0.7304\n",
+      "    high-engagement      P=0.6882  R=0.8129  F1=0.7454\n",
+      "\n",
+      "--- Val ---\n",
+      "  Weighted F1:    0.7642\n",
+      "  Accuracy:       0.7623\n",
+      "  W-Precision:    0.7740\n",
+      "  W-Recall:       0.7623\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.8403  R=0.7379  F1=0.7858\n",
+      "    high-engagement      P=0.6782  R=0.7976  F1=0.7331\n",
+      "\n",
+      "--- Test ---\n",
+      "  Weighted F1:    0.7440\n",
+      "  Accuracy:       0.7420\n",
+      "  W-Precision:    0.7559\n",
+      "  W-Recall:       0.7420\n",
+      "  Per-class metrics:\n",
+      "    low-engagement       P=0.8257  R=0.7102  F1=0.7636\n",
+      "    high-engagement      P=0.6568  R=0.7872  F1=0.7161\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.ml.evaluation import MulticlassClassificationEvaluator\n",
+    "from pyspark.mllib.evaluation import MulticlassMetrics\n",
+    "\n",
+    "def evaluate_binary_model(model, df, label_col=\"label_binary_idx\", split_name=\"\"):\n",
+    "    preds = model.transform(df)\n",
+    "\n",
+    "    evaluator = MulticlassClassificationEvaluator(\n",
+    "        labelCol=label_col,\n",
+    "        predictionCol=\"prediction\",\n",
+    "    )\n",
+    "    metrics = {}\n",
+    "    for metric in (\"f1\", \"accuracy\", \"weightedPrecision\", \"weightedRecall\"):\n",
+    "        evaluator.setMetricName(metric)\n",
+    "        metrics[metric] = evaluator.evaluate(preds)\n",
+    "\n",
+    "    # Per-class metrics via confusion matrix\n",
+    "    preds_and_labels = preds.select(\"prediction\", label_col) \\\n",
+    "                            .rdd.map(lambda r: (float(r[0]), float(r[1])))\n",
+    "    mm = MulticlassMetrics(preds_and_labels)\n",
+    "\n",
+    "    per_class = {}\n",
+    "    for cls in range(2):\n",
+    "        per_class[cls] = {\n",
+    "            \"precision\": round(mm.precision(float(cls)), 4),\n",
+    "            \"recall\":    round(mm.recall(float(cls)), 4),\n",
+    "            \"f1\":        round(mm.fMeasure(float(cls)), 4),\n",
+    "        }\n",
+    "\n",
+    "    print(f\"\\n--- {split_name} ---\")\n",
+    "    print(f\"  Weighted F1:    {metrics['f1']:.4f}\")\n",
+    "    print(f\"  Accuracy:       {metrics['accuracy']:.4f}\")\n",
+    "    print(f\"  W-Precision:    {metrics['weightedPrecision']:.4f}\")\n",
+    "    print(f\"  W-Recall:       {metrics['weightedRecall']:.4f}\")\n",
+    "    print(f\"  Per-class metrics:\")\n",
+    "    for cls, m in per_class.items():\n",
+    "        label = {0: \"low-engagement\", 1: \"high-engagement\"}[cls]\n",
+    "        print(f\"    {label:20s} P={m['precision']}  R={m['recall']}  F1={m['f1']}\")\n",
+    "\n",
+    "    return metrics, per_class\n",
+    "\n",
+    "results_bin = {}\n",
+    "for name, model in [(\"A\", model_A_bin), (\"B\", model_B_bin)]:\n",
+    "    print(f\"\\n====== Binary Config {name} ======\")\n",
+    "    tr_m,  tr_pc  = evaluate_binary_model(model, train_xgb_bin, split_name=\"Train\")\n",
+    "    val_m, val_pc = evaluate_binary_model(model, val_xgb_bin,   split_name=\"Val\")\n",
+    "    te_m,  te_pc  = evaluate_binary_model(model, test_xgb_bin,  split_name=\"Test\")\n",
+    "    results_bin[name] = {\"train\": tr_m, \"val\": val_m, \"test\": te_m}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "70d09bec-e1b2-4d70-a61e-e28fddeb1add",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Binary results saved to ../outputs/xgboost_binary_evaluation_results.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Persist Results\n",
+    "\n",
+    "import json\n",
+    "\n",
+    "RESULTS_BIN_PATH = \"../outputs/xgboost_binary_evaluation_results.json\"\n",
+    "\n",
+    "results_bin_serializable = {\n",
+    "    config: {\n",
+    "        split: {\n",
+    "            metric: float(val)\n",
+    "            for metric, val in metrics.items()\n",
+    "        }\n",
+    "        for split, metrics in splits.items()\n",
+    "    }\n",
+    "    for config, splits in results_bin.items()\n",
+    "}\n",
+    "\n",
+    "with open(RESULTS_BIN_PATH, \"w\") as f:\n",
+    "    json.dump(results_bin_serializable, f, indent=2)\n",
+    "\n",
+    "print(f\"Binary results saved to {RESULTS_BIN_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a563f387-9f2a-4965-acd1-870e423b8bd1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Binary results loaded.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reload Results\n",
+    "\n",
+    "with open(\"../outputs/xgboost_binary_evaluation_results.json\", \"r\") as f:\n",
+    "    results_bin = json.load(f)\n",
+    "print(\"Binary results loaded.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ea47b70-a16f-4596-b9f1-371fcd97c5b0",
+   "metadata": {},
+   "source": [
+    "### Binary Model Feature Importance\n",
+    "\n",
+    "Feature importance scores for both binary configurations using the same weight metric as the 4-class analysis which is number of times each feature appears in a split across all trees. Comparing the binary and 4-class importance rankings reveals whether the predictive hierarchy of features shifts when the task is simplified from four engagement tiers to a single high/low distinction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "d5d7cdf6-4eb7-4921-9411-8e606f00b1d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABjIAAAMsCAYAAAD+vjuEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd1QU1/838PfSe1MBUZoFFRBBQbGLvSt2UQF7T+wlxRpLRL/GFkssxN6NJZbYsBuxgA2VKIomqCgqgijtPn/wML8dWKqFVd+vc/ac3bn3zr3TdmfnM3OvQgghQEREREREREREREREpIY0iroBREREREREREREREREOWEgg4iIiIiIiIiIiIiI1BYDGUREREREREREREREpLYYyCAiIiIiIiIiIiIiIrXFQAYREREREREREREREaktBjKIiIiIiIiIiIiIiEhtMZBBRERERERERERERERqi4EMIiIiIiIiIiIiIiJSWwxkEBERERERERERERGR2mIgg4iIiIiIPrnAwEAoFAooFAo0aNCgqJtD9MULDg6WjjmFQlHUzclVXt8PFy5cQPPmzWFhYQENDQ3ZMk2ZMkX67ODg8Gkbnk8ODg5SG6dMmVLUzSEiIvosMJBBRERfhLt378LIyEj6U9iyZctsedLT01G/fn0pj6mpKaKjo7Ple/78OebOnYtmzZrBxsYG+vr6MDExgZOTExo0aIApU6bgwoULEEJIZe7fvy+7OJD50tTUhLGxMSpVqoQ+ffrg4sWLH3U9fGjv+0db1TrJ+iqqiwxf2kWErBeoQkJCirpJn9yXtk0/ByEhISqPay0tLZiamqJKlSoYNmwY7ty5U9RNVSvq/N1IH9+HDCiEh4dj+PDhcHd3h4WFBXR1dWFnZ4e6detixowZuHv37gdqtfp4/PgxWrRogUOHDuHFixey8zF1wN8iIiKij0OrqBtARET0IZQtWxbz5s3DoEGDAAAHDhzAsmXLpM8AMH/+fJw8eVL6vGjRItjZ2cnms2rVKowYMQIJCQmy6W/fvsXr168RGRmJEydOYOrUqYiKisrzQlN6ejoSEhJw69Yt3Lp1C2vXrsXOnTvRtm3b91xiIiL1lZaWhvj4eFy9ehVXr17FmjVrEBISAi8vLylPt27d4OrqCgCwtbUtqqYSfZaSkpIwfPhwrFq1Klvaw4cP8fDhQ5w+fRrbtm1DWFjYp2/ge8rt++HgwYOIi4sDkBEUHDZsmOx8rmnTpjAyMgIAmJqafqIWF8z333+PV69eAQBq1apVxK0hIiL6PDCQQUREX4yBAwdiz5492L9/PwBgzJgxaNKkCcqWLYubN2/ihx9+kPL6+vrC399fVn7+/PkYNWqU9FmhUMDHxwc1atSAiYkJ4uLiEB4ejlOnTiEpKSnXtjRp0gRNmzZFeno6bt68ibVr10IIgbS0NEyaNOmrDGR4enqia9eu2aar60WGj+X169cwNjYu6mZ8Mbg+1UvXrl3h6emJ1NRUXLhwAbt27QIAvHnzBjNmzMAff/wh5W3evDmaN29eRC3Nn0+xf/G7kQoqLS0NnTp1ks53AMDMzAwdOnRA2bJlkZSUhLCwMBw+fLgIW/l+cvt+UH6atlSpUli4cKEsvVatWmofHOjfv39RN4GIiOjzI4iIiL4g//33nyhWrJgAIACIWrVqiaSkJFG1alVpmpWVlXj69KmsXEREhNDS0pLyFC9eXJw7d05lHYmJiWLFihUiNjZWmhYVFSWVBSAmT54sK9O6dWspTVdXV+V8t23bJlq0aCEsLS2FlpaWMDc3F3Xr1hVLliwR7969U1nm1q1bYuDAgaJcuXJCT09PGBgYiAoVKojhw4eLqKiobPljY2PF6NGjhbOzszAwMBDa2trCyspKeHl5iaFDh0rLHBAQIFseVa/8UM4fEBCQrzKpqakiODhYNGrUSBQvXlxoaWmJEiVKiLZt24pjx45ly//kyRMxZswY4ePjI+zs7ISRkZHQ1tYWlpaWokmTJmLdunUiPT1dyl+QZVOetmbNGlm99evXV7lsWfeFY8eOiSVLlghXV1ehq6sr6tevL5vPrl27ROvWrYW1tbXQ1tYW5ubmonHjxmLHjh35Wl+Z1qxZI6v3+PHjOaa9fPlSDB8+XFhbWwsDAwPRoEED8ffff0vt79SpkzAzMxNGRkaiWbNm4tq1a7K6si7j8ePHxdq1a0XVqlWFnp6eKFGihOjbt6948uSJyrZeuHBB9OzZU9jb2wsdHR1hZGQk3NzcxMSJE7Mdm0IIYW9vLzu2jhw5IurVqyeMjY2l9Z/fbbp161bh5+cnXFxcRIkSJYS2trYwNDQUzs7OYtiwYSqPm6zb+tatW6JTp07C3Nxc6OnpCW9vb9n6VhYbGysmT54svLy8hKmpqdDR0RGlS5cWLVu2FLt3786W/0PtD5/K8ePHcz1OKleuLKVVqFBBlqa83bIeF1nneeDAAVG3bl1hYGAgTE1Nha+vr7h//76sTFJSkvjuu+9Es2bNhKOjozAxMRFaWlqiWLFiom7dumLRokUiJSVFViY/x2vv3r2l9Hr16mVbB3/88YeUrq2tLfttyElhvhuzHgd///23aN68uTA2NhaGhoaicePGIjw8XGXZ3377TVqmUqVKiREjRoj4+Phs83yfdVnYujJdvnxZBAYGCkdHR6GrqyuMjIyEp6enmDdvnkhKSsp1Ha5Zs0asXbtWVKlSRejp6YmyZcuK//3vf0IIIVJSUsSMGTOEo6Oj0NHRERUrVhQrVqxQ2fakpCSxYMECUadOHWFubi60tbWFjY2N6N69u7h8+XK2/JMnT5baYG9vL168eCFGjBghSpcuLXR0dISTk5P49ddfpfxZ9zdVL1XrJqulS5fKytSsWVM8e/YsW77Y2FixePFi6XPW3wJlhw8fFr179xbu7u7CyspK6OjoCH19fVGuXDnRu3dvcfXq1WzzT0hIEFOnThUeHh7CyMhI+r2uUqWK6Nevnzhw4IAs/8mTJ0X79u2FjY2N9N1rb28vmjdvLiZPnixevnwp5VX1/ZD1+ybrKzNf1u2S1evXr8XcuXNl29na2lo0bNhQrF69Wsr3Mc8v8joe3vd3siDfD0RERJ8LBjKIiOiLs3XrVtmfRjc3N9nnPXv2ZCszaNAgWZ6CXjTMKZCRlpYmbt68Kezs7HL8U52amiq6dOmS6x/f6tWry/7gCyHEli1bhJ6eXo5ljI2NxaFDh6T8SUlJokKFCrnWM378eCFE0QUyEhMThY+PT671zpgxQ1YmNDQ0z7b27t1byv+pAxm1a9dWeaElLS1N+Pn55dqOAQMG5Gs9C1GwQEa1atWy1aWnpyf27NkjCwRmvooVKya7cJJ1GRs2bKiy/eXKlct2cW3+/PlCQ0Mjx2W2srLKdsFQ+QKNt7e30NTUzLZv5XebtmrVKtd8JiYm2S7YKW9rNzc3YWRklK2cjo6OuH79uqzc+fPnhaWlZY51Ke83H3p/+FRyCmSkpqaKc+fOCRMTk2z7fqb8BjJq1aqlcn2ULVtWdoE7NjY2z/2gcePGIjU1VSqTn+P18uXLsmm3b9+WtVV5u3Xo0CFf6y2n/SA3ysdB9erVZcH3zJeFhYV4/PixrNyECRNUrgsvLy9hZWUlfVa+mFqYdVnYuoQQYtGiRdmO66zls/4GKqer+k4DIH788Ufh6+urMm3VqlWy+T158kQWeMv60tLSEr///rusjPIF82LFiomKFSuqLJsZOPlQgQzl33I9PT3x77//5llGiNwDGUOHDs21XTo6OuLw4cOyMg0aNMi1TNeuXaW8R44cyXUbAxARERFS/o8VyIiMjBRly5bNcx5CfNzzi9wCGe/7O1mQ7wciIqLPCbuWIiKiL07nzp3Ro0cPbNiwAQBw9epVKa1v375o06ZNtjLHjh2T3pubm8PX1/e92jB16lRMnTpVZdr48eNln2fMmIGtW7dKn2vXro1GjRohLCwMe/bsAQBcuHABAwcOxObNmwEAkZGR8Pf3x7t37wAAJUqUQEBAAFJTU7F69WrEx8fj9evX6Ny5M+7cuQMrKyscP34ct2/fBgDo6emhb9++KFWqFB4/fox//vkHJ06ckNqQ2Tf1zJkz8eLFCwD/111WYd24cQNz587NNl25C4gRI0bg+PHjAABdXV34+fmhTJkyuHLlCnbu3Akgo19pT09PqS0aGhpwcXGBl5cXrKysYGZmhrdv3+LKlSvYu3cvhBBYs2YNBg0ahOrVq3+UZcvNmTNnUKZMGXTo0AF6enp48+YNAGD27NnYuHGjtAydO3eGq6srIiMjsWHDBqSlpWHFihWoVq0aBgwY8EHbdOXKFfTr1w/GxsZYtGgRUlNT8fbtW7Rt2xYGBgYYMWIEXrx4gd9//x0A8Pz5c6xatQoTJkxQOb9jx47Bx8cHdevWxZkzZ3D06FEAwD///IPx48dj5cqVAIATJ05g1KhR0sCsjo6O6NatG+Li4rBmzRokJyfjyZMn8PX1xe3bt6Grq5utrvPnz8PY2Bg9evSAjY0NLl68WKBtam5ujubNm6NChQowNzeHjo4Onjx5gp07d+Lhw4eIj4/H+PHjZV22KLt69SqKFy+OQYMG4cmTJ1i3bh0AIDk5GQsXLsTy5csBAPHx8Wjbti2ePn0qlW3SpAm8vb3x8uXLbIOxF+X+8CH17t0bvXv3zjZdQ0MDY8eOLdQ8z549C1dXV7Rr1w6nTp2Sxjq6e/cudu3ahe7duwPI6A6wXLlyqFGjBmxsbGBubo6UlBTcunUL27ZtQ2pqKo4cOYIdO3agS5cuKutSdbx6eHigVq1aOHv2LABg5cqVmDNnDgDg3bt32Lt3r2z5Cyo/341ZXbhwAfb29ujevTtu3LghtSEuLg6rV6/GxIkTAQChoaH4+eefpXKWlpYICAjA69evsXr1aiQnJ6ucf2HWZWHrOnPmDL755hvpe6FOnTpo3LgxXr58id9//x0vXrxAaGgoBg8eLB0jWV26dAk1a9ZE48aNsWXLFmlw+enTpwMAWrZsiapVq2LZsmV49uwZAGDOnDno06ePNI+ePXvi2rVrADK69erRowesra1x4sQJHD16FKmpqejXrx+qVasGFxeXbG14/vw5Xr58iT59+qBYsWJYsmSJ9H0/d+5c9O/fHxYWFggKCsLFixexZcsWqWxQUJD0Pq8ukf777z/ptxwAmjVrBhsbm1zL5IeRkRF8fHzg4uICCwsL6Ovr4/nz5/jzzz8RERGB5ORkfPPNN7h58yYAICIiQvoe09DQgL+/P5ycnPDs2TNERUVl+45bsWIF0tLSAAAVK1ZE586doaWlhejoaISFheHy5ct5trFs2bIICgrCX3/9JXWbZW5uju+++w5A3mPtpKWloX379rIB0L29vdGwYUO8fftWOsYzFcX5xYf4nczv9wMREdFnp0jDKERERB/JixcvRMmSJWV3opUuXVrEx8erzG9gYCC7k01ZTndQduzYMc88WV8DBw6UdUOQmpoqLCwspPQ6deqItLQ0Kb1Pnz5SmkKhEA8fPhRCCPHtt99K0zU0NMTNmzelMidPnpTV+dNPPwkhhNi5c6c0rVmzZtnWwdu3b8WjR49k0/Lq+iAv+VknmfN9/vy57G7NjRs3yubVrVs3Ka1JkybZ6nrw4IHYvn27WLx4sZg7d64ICgoSpUqVkspMmzatwMum3M7CPpFRvnx58erVK1nZtLQ02ZMPM2fOlKUr39Vcvnz5XNbw/ynIExmZ+4QQ8vUKQGzatElK8/LykqYr32medRmbNm0q7dfp6emiadOmUpqurq5ITEwUQgjRrl07abqxsbGsC561a9fK5rl+/XopTXlbaWlpqeziJGu+3PbX5ORkcfLkSbFq1Soxf/58ERQUJOs+SFdXVyQnJ0v5lbe1hoaGrHuO9u3bS2lVq1aVpi9YsEC2PLNnz87Wjnv37gkhPs7+8KnkdYd0TsskRP6fyLC3txcJCQlCiIxtp/yUy6hRo7LN98mTJ2L37t3i119/lb4LXF1dpTJ9+vSR8ubneBVCiI0bN0p5LC0tpf1j165d0nRra+scu1vKqiDfjZmU928jIyMRExMjpXl4eKg8VgcMGCDbd5WfGsr6vaDqmCnIuixsXcpPTDRr1kz2G3nw4EEpTfk3MOs6dHZ2lraJchkAonnz5lKZJUuWyNIyzwnCw8Nl08+ePSuVSU9PFzVr1pTS+vfvL6Up3/kPQNaN0y+//KKyLlXroyAuXLggK5v5JGV+5FVvWlqa+Pvvv0VwcLD45ZdfRFBQkBg1apSsTHR0tBBCyJ5UqlSpkmy7CZFxfqPc/Vvbtm1V/s5kiomJkX4rhMj9+yGvrqNySt+9e7dsWQYPHpyt3Xfv3s02v49xfpFTng/xO5nf7wciIqLPDZ/IICKiL9KjR48QFxcnmxYbG4vo6GiVd1IqUygU712/8mDf9+7dw9q1a5GUlITly5cjOTkZq1evBgDcvn1b1k4/Pz9oaGhInwMCAqS8QgicO3cOnTt3lt016OnpiUqVKkmf69atC0dHR0RFRQGAlNfLywu6urp49+4dDh06BBcXF7i5ucHJyQkeHh5o1KgRSpUq9d7LXlh///23dLcmkLEu/Pz8VOZVXv7nz58jICAAf/75Z67zf/To0YdpaAENGTIEJiYmsmm3b9/G8+fPpc/fffeddEdpVpGRkXj27BmKFy/+wdrUo0cP6b2Dg4P0XltbG506dZI+Ozk5ITQ0FACku0tV6dmzp3TcKBQK9OjRA3/99ReAjDvWr1+/jurVq8u2W4sWLWTL5Ofnh759+yIlJQVAxjZWbmemVq1aoXLlygVZXJkNGzZgxIgR0l3Zqrx79w7Pnj1DyZIls6XVrFkTbm5u0ucKFSpI75XX0ZkzZ6T3xsbGGDNmTLZ5OTo6Avjw+0N8fDxWrFiRY3p+de3aNc87nFWV8fT0RFpaGq5fv47NmzcjNTUV3333HVJSUjBp0qQCt6Nnz54wNDQEkLGPOjo6Sk+6KK/zpKQkDBkyBGvXrkV6enqO88vtu0DV8QoAnTp1wujRoxETE4OnT59iz5496NixI7Zt2ybl6dWrF7S0Ps3fq3bt2sHa2lr67OTkhCtXrgCQr5NLly5J77M+SdCzZ0/0798fqamp2eZfmHVZ2LqUj5VDhw7JfgOVCSFw/vx52XdUps6dO0NbWxuA/DsNyHjCMJOTk5Ms7cWLFzA2Npa1Acj9qYisd+1n0tTURN++faXPyt8NynW9L/H/79T/0A4fPox+/frJBtJW5dGjR7C1tUWlSpVQrFgxPH/+HBEREShXrhw8PDzg5OQENzc3NG7cGPb29lK5unXrSk+ZBgYGYvny5XByckKFChVQu3ZtVK9e/YOcf+Um63aeMmVKtjrLlCkjvS+K84sP8TuZ3+8HIiKizw0DGURE9MVJSUlBr169pG6XMr179w7+/v44f/68dMEjU6lSpRAZGQkg40KhEEL6c5vZFQQAWXcBualVq5bswqW3t7fU5ciaNWswcOBA1KhRI9u8LC0tZZ+trKxknzPzK5fLWiazXGYgIzNv6dKlERwcjOHDh+PZs2e4efOm1EUEkNGtxMqVK9G1a9c8l68wAgICEBwcnGN61sBTbhITE5GUlAR9fX307ds3z4sMALLtDwWV9eJRfueX9cIZULBlBTKCcB8ykKEcsFLulsLS0lJ2IVb5fW4XMz/EfqupqYlixYrh8ePH2fIqU7U+8+vy5cvw9/fPdVky5bR9lS/MAfL1pzxf5W1sa2sLTU3NHOv60PtDXFxcobtxUubp6VngQEbz5s0RGBgofS5btqzUzd706dOlLu0KIr/rfOLEibl+x2TK7djNaf/S1tbGgAEDpGVZuXIlWrVqJetWSnm5CyKv70ZV8rtOXr58Kb1XvrAJZBzfxYsXl445ZYVZl4WtqyD7f2xsrMrpOX2nZU3LGmjKXFcfog1WVlbQ09PLsR35+d7Jj9KlS8s+37p1673n+d9//6F9+/ZSV1i5ydzmenp62Lp1K3r37o3o6Gjcu3cP9+7dk/Lp6Ohg9uzZGDlyJICMriOvXr2KjRs34t27dwgJCZF1P+Xq6orDhw9n23c+JOXtbGBgoPL8SdmnOr9Q9iF+J/P7/UBERPS5YSCDiIi+OJMnT0ZYWJj0eciQIfj1118BZFzInDZtmtRvdqZGjRpJgYy4uDjs2bMH7dq1AwCYmJhIQYnFixcX6m626tWryz6fO3cONWrUgLm5uWy6cn/6APDkyRPZ58z8yuWylslaTjlvt27d0LFjR1y4cAHXrl1DZGQkjh8/jitXriAhIQF9+/ZF69atpbufP6Ws62Ls2LG5XmTQ0tJCYmIi9u3bJ03r1q0bgoKCYGNjAw0NDVSvXl16oqAwFAqFFMBISkqSpmc+aZMfBgYG2aZlXdZ+/fplu3tXWV4XWwoqayAvU2HvJs9rvzUzMwOQsdyZFwGzlklLS5M9lZB1HWVStT7za9u2bdJFHENDQ2zfvh3169eHvr4+9u/fj1atWuU5j6zrLqc7iC0sLKT3Dx8+RFpaWo7BjKLeHz4m5e++1NRUhIaGFjiQkd91rjzmgI+PD1asWAFHR0doamqiS5cusqcncpLb/jVw4EDMnDkTKSkp+Ouvv7BixQq8fv0aAFCjRg04OzvnZ3E+iPyuk8xjD8h+zKWmpub4ZFJh1mVh61L+XvDx8UHLli1V5gMynohSJafvNCB/32tZj8GZM2fmOM+c9pH8bpP3ZWNjgwoVKkjjZBw6dAgxMTEqnyDLr71790pBDIVCgfXr16NNmzYwNjbGzZs3c3yStWHDhoiKisLly5cRFhaGf/75B2fPnsWpU6eQnJyMMWPGoG3btihbtiy0tLSwdu1azJs3D2fPnsXt27dx+/Zt7Nq1Cy9evMD169cxYcKEAgf1CkL5e/nNmzeIjY1FiRIlVOb92OcXOfkQv5Ofal8kIiL61BjIICKiL8q5c+ekQVgBoH///liyZAkSEhKwdu1aAMCsWbPQunVr1KhRQ8o3bNgw/Pbbb1LXRoMGDYKdnR08PDw+SLuy/tnNrKdChQqwsLCQ7hLcuHEjBg4cKHWtkTnYMpDxR9Tb2xtAxhMfmfO8ePEiIiIipO6lTp06JT2NkZkXyAjQvH79Gvb29qhduzZq164NIOOOvsw/94mJibh16xaqVasGQP5nOD93ar6PGjVqQFNTU1o3+vr6KrvjuXnzJuLi4qCtrY3Y2FhZd1SdO3eW7laNiIhAeHh4jvXlZ9nMzMykwNXff/+NIUOGAACCg4NVBpDyq2LFilKXHEDG3ZyqljU6OhoREREoVqxYoev6FNavXy91LyWEwIYNG6Q0HR0dqSuoWrVqYffu3QCAgwcPyrpI2rhxo9RdRmbegsprmypfACpTpgyaN28ufd68eXOB68tN7dq1sXXrVgDA69evMX/+/Gzb+MGDB7C3t//g+4ODg8NH636moHL67vsYlLdv69atUa5cOQAZFwOPHz/+3vMvWbIkOnbsiM2bNyM9PR3jx4+X0gozyPen4OXlJXX5dPHiRfzzzz/Selm/fr3Krp6Awq3Lwtal/L3w+PFjDB48OFswPT4+HgcOHIC7u3t+FrvAsn7fWFtbq9ymFy5cUDm4ckFlvdD85s2bAgVpv/nmGwwdOhQA8PbtW3Tu3Bl79uyRXagHgGfPnmHLli1S3pwob29TU1N069ZNOg/J6bvx7du3iIqKQqVKleDp6QlPT08AGU8vmpub49WrV0hPT0dYWBjKli2L27dvw9bWFiVKlJBuFAEynsQYNWoUAHn3ZB9D5nlPpqlTp2Lx4sWyaZnfy69evfqo5xc5+di/k0RERJ8zBjKIiOiLkZiYCH9/f+mPp6OjI/73v/8BABYtWoSQkBBER0cjLS0N/v7+uHLlinThwMXFBdOnT5f6pX/8+DG8vLzQvHlzVKtWDbq6unjw4EG2O81zcvbsWcydOxdCCGmMDGWZfz41NTXxzTffYMqUKQCA06dPo169emjcuDHCwsKkP7NARh/tmd28DBkyBEuXLkVycjLS09NRv359BAQEIDU1VRpTA8jom79fv34AgDt37qBmzZrw8vJClSpVYGNjAy0tLRw8eFDWNuW7akuVKoV//vkHQMbFez09PZiYmKBs2bLw9fXN17rIr2LFiiEwMBCrVq0CAEybNg3nz5+Ht7c3tLW1ER0djTNnzuDmzZuYPHky6tSpA0tLS5iZmUldmnz77bfS0yXBwcFITk7Osb78LJunpycOHz4MAFi7di0eP34MbW1tHDhw4L2WVUNDAyNGjMCPP/4IAFi3bh0iIyPRsGFDGBoa4r///sP58+elrpCaNWv2XvV9bH/99RcaNWqEevXq4fTp0zh69KiU1qNHD+k4GzFihLRPx8fHo3r16ujWrRtevHgh229tbW3RsWPHArcjr22q/JTDtWvX0LVrV7i6uiIkJATHjh0r1LLnJDAwEDNmzJACXmPHjsXhw4fh7e2NhIQEnDp1Cs7OzggODv6i9ofMC29paWm4efMmNm7cKKVpamrKAsgfWoUKFXD9+nUAwE8//YQnT55AoVBg3bp1uY6JUhDDhw+XLuy+ffsWQEbQVXkchoK6ceMG5s6dm2N973PhvG/fvli+fDmEEEhLS0P9+vXRq1cvxMfHS9+1qhRmXRa2rtGjR2PPnj0QQiAiIgKurq7o0KEDihcvjri4OISFheHUqVOwtrb+aF0furu7o1GjRtJ3V//+/bF3714pcBIVFYUTJ04gKioKa9asQZUqVd6rvqxPJfn5+aFWrVrQ0NBAr169snXPl9WAAQOwZ88eHDp0CEDG2A/lypVDhw4dULZsWbx58wbh4eH466+/ULFixTwDGcrfjS9fvkSLFi1Qt25dXLp0CX/88YfKMi9fvoSzszNcXFxQvXp12NjYQF9fH6dPn8arV6+kfJnnFPPnz8e6devQqFEjODo6wsrKCnFxcbLzI+Xzj4+hVatWcHFxwY0bNwAAS5YsweXLl+Hj4yM9MSaEwPHjxz/6+UVOPvbvJBER0WetKEYYJyIi+hgGDhwoAAgAQkNDQ5w8eVKWfvz4caFQKKQ8w4YNyzaPhQsXCj09PSlPbq8BAwZI5aKiovJVBoDo3bu3rM6UlBTRoUOHXMtUq1ZNxMXFycpt2rRJ6Orq5ljG0NBQ7N+/X8p/7ty5PNvWoUMHWR0LFixQma9Vq1b52ibKZQICAvLMn5CQIHx8fPJs5+TJk6Uys2fPVpnH1dVVVKtWLcf687NsBw8elO0zmS97e3tRoUIFlfPOui8cP35c5bKmpqaK7t2757ms+VlvQgixZs2aHOvNmqZs8uTJsuVSFhAQIKXVr18/x2Vs1aqVyraXKVNGxMbGyuY5d+5coaGhkePylihRQly8eFFWxt7eXuW2zyqvbfr8+XNhY2OT43pW/hwVFSXNt379+jluj9zW3/nz54WlpWW+tu2H3h8+lePHj+fZ5szX1KlTZWVz2r+EkH93rFmzRpaW0/bYtGmTynpLliwpmjRpkq99OafjVVnVqlVlZfz8/Aq41kS+19mLFy+kMrkdB7mtywkTJqicd9WqVYWVlZXK7VOYdVnYuoTI+O3V1NTMdV1kPb5y2kdy26ZZ91fl4/zx48eicuXKeW4T5bpyO/5zq+vt27eiZMmSKucfGhoq8iMhIUEEBgbm2d4qVapIZXL6LUhOTs5x2bN+N2auz5iYmDzrrl69ukhJSRFCyM/RVL00NDTErl27pDbltk/ntt7zSo+MjBRlypTJsR3KdX3M84vcjucP/TuZ27okIiL6nGQ8L0pERPSZO3jwIJYvXy59HjVqFOrWrSvL06BBA2nQSSDjTrwjR47I8gwfPhxRUVGYNm0a6tWrB0tLS2hra0NfXx+2trZo3LgxJk2ahNDQUFl9udHW1oaNjQ1atWqFzZs3Z7szVUtLC9u3b8fmzZvRrFkzFC9eHFpaWjAzM0Pt2rWxcOFCnDlzJltfyN26dcOVK1fQv39/lC1bFnp6etDT04OTkxOGDh2Kq1evokWLFlL+ChUqYN68eejQoQOcnJxgamoKTU1NmJubo3bt2liwYEG2LiSGDh2KKVOmoEyZMoUeP6EgDA0NceTIEaxduxZNmzZFiRIloK2tjeLFi6NKlSoIDAzErl27ZF26jB8/HkuWLIGTkxO0tbVhbW2N/v3748SJEzAyMsqxrvwsW7NmzbBt2zZUqVIFOjo6sLS0RP/+/XHhwoX3HpBUU1MTGzduxO7du9GuXTvY2NhAW1sb5ubmcHV1RdeuXbFhwwYsWLDgver5FMaMGYNNmzahWrVq0NPTQ/HixdGnTx+cPXs226DUo0ePxtmzZ+Hn5wdbW1vo6OjAwMAAlStXxvjx43Ht2jWpa7OCymubWlhY4PTp0+jQoQNMTEygr68PLy8v7Ny5s9ADNeemRo0auH79OiZNmoRq1arBxMRE2kebNWsmuzP3S9ofMunq6sLe3h6dOnXCwYMHMWnSpI9aX7du3bB161ZUqVIF2traKFasGLp27Yrz58/Dxsbmg9UzbNgw2ec+ffp8sHl/DLNmzcKKFSvg4uICHR0dlCxZEsOGDcPRo0elMT4A+d3whV2XhakLyPjtvXjxIvr27Yty5cpBT08PhoaGKF++PJo3b44FCxbg5MmTH2ydqGJlZYULFy5g0aJFqF+/PiwsLKClpQVra2tUq1YNgwcPxqFDh9CjR4/3rktXVxf79+9HkyZNYGJiUqh5GBoaYs2aNbh06RKGDh0KNzc3mJqaQltbG6VLl0bt2rUxffp07NixI895aWtr49ixYwgMDESxYsWgq6sLV1dXrFixQnpiNCtzc3MsXrwY3bt3h7OzMywsLKCpqQkTExN4enpi+vTpOHr0qPRd3LdvX4wfPx716tWDra0t9PT0oKOjA1tbW3Tu3BknTpxA+/btC7UuCqJcuXIIDw9HUFAQatWqBTMzM2hpaaFEiRKoV68e/P39pbwf8/wiNx/zd5KIiOhzphBCTTrQJSIiIqLPwv379+Ho6Ch9Pn78OBo0aFB0DSL6hM6dOyd1D2hnZ4f79++r9WC6SUlJ0NfXzzZ93759aNOmjfT5zJkz793n/qesi4iIiIi+Lhwjg4iIiIiIKBdv377F+fPn8eLFC0yfPl2aPmTIELUOYgDAd999h7CwMLRp0waOjo7SWABLly6V8nh6eqJmzZqfVV1ERERE9HVhIIOIiIiIiCgXjx8/ho+Pj2xauXLlsnUzpY6EEAgJCUFISIjK9HLlymHbtm0fJCDzKesiIiIioq8LAxlERERERET5VKJECTRu3Bg///wzDA0Ni7o5eWrfvj2ePHmCv//+G7GxsXj79i3MzMzg6uoKX19f9OvXDwYGBp9dXURERET0deEYGUREREREREREREREpLY0iroBREREREREREREREREOWEgg4iIiIiIiIiIiIiI1BYDGURERETIGKTWy8sLCoUC+vr6iImJKeom5cv9+/ehUCikV06D7L4vBwcHqY4pU6Z8kLalpKRg8uTJcHJygo6OToHn/zkJDg6WrYv8mjJlilTGwcFBllaYbUJfnpCQENm+df/+/feeJ/ct9SCEgLu7OxQKBYyNjfH48eOibhIRERFRkWEgg4iIiAjAunXrcPHiRQBAv379ULJkSSkt60Vo5ZexsTHc3d0xceJEPH36tKia/1maMmUKpk2bhsjISKSkpGRLDwwMlNZzgwYNCjz/Bg0aqNxmenp6sLW1Rdu2bbFz584PsCTq52NeiD5z5gwmTZoEHx8flC1bFoaGhtDX14eTkxMGDx6Mf/75J1sZ5W2Z10uVtLQ0BAcHo1mzZrC0tISOjg4sLS1RtWpVjBgxQnaBN2sATaFQoEaNGirne/To0Wx5AwMD81wHOe1bub2Cg4PztX4pf76G41uhUOCHH34AACQkJOD7778v4hYRERERFR2tom4AERERUVFLS0vDpEmTpM8jRozId9mEhASEh4cjPDwcK1euxNGjR+Hm5vYRWvn5sbCwQFBQkPS5bNmysvQNGzZI7ytXrgw/Pz9oaWmhVq1aH7Vd7969w6NHj/Do0SPs3bsX3333HWbMmPFR6/wYvv/+e7x69QoAPvo6U9a3b1/cvn072/TIyEhERkbi999/x759+9CwYcMPUl9sbCzatm2L8+fPZ5seGxuLK1euoFOnTrC2ts5xHhcuXMCFCxdQvXp12fTFixd/kDYWpbJly8qOMwsLi/eeZ1HtWx/Cl3J8Z+rYsSPs7e3x4MEDBAcHY8KECShfvnxRN4uIiIjok2Mgg4iIiL56+/btw4MHDwBkXLTLesE9q0GDBqFs2bJISkrCkSNHcPLkSQDAs2fPEBAQgCtXrnz0Nn8OTExMMGbMmBzTo6Ojpffffvst+vbt+9HaYm5uju+++w6pqam4c+cONmzYgOTkZADAnDlzMHr06A9yAfhT6t+/f5HWX7NmTdSrVw+6uro4ePAgLly4AABISkpCYGAg7t+/Dw2NjAfAu3XrBldX12zzEEJg0qRJePv2LQCgefPmsvTU1FS0b99eCmLo6enB19cXTk5OUCgUePz4MS5fvgwdHZ0827to0SKsW7dO+vzgwQPs3bu3UMs+ePBgtG7dWjZt7Nix0ntPT0907dpVlu7l5ZXj/F6/fg1jY+NCtcXW1jbX46wwinrfKqgv8fjOpFAo0L17d8yePRvp6elYunQp/ve//xV1s4iIiIg+PUFERET0lWvbtq0AIACIefPmZUtfs2aNlA5AHD9+XJZep04dWfrdu3eFEEJMnjxZmmZvby8rc/z4cVmZqKgoKS0hIUFMnTpVeHh4CCMjI6GlpSVKlCghqlSpIvr16ycOHDgg5Y2KisrWtq1btwovLy+hp6cnihUrJgICAsTz589VLlf9+vVFsWLFhJaWljAzMxNOTk6iS5cuYsmSJbK89vb2Uh2TJ08WV65cEa1atRImJibC0NBQNG7cWISHh8vKqGqbEELUr19fNj3rK+v6VvXKug1UUa4n6/ofP368bH7nzp3LVv7Fixdi+vTpwtPTU5iYmAgdHR1hb28v+vXrJyIjI1XWef/+fdGtWzdhbm4uDAwMRN26dcXhw4ezLVNWV69eFa1atRLGxsbC2NhYNGvWTFy6dCnXfSjrNhFCiICAgDzX3fsaM2aMuH79umxaenq6aNy4sayeq1ev5jmvPXv2yMocOXJElq683mxsbMS9e/fynGfW/U5DQ0MAEDo6OuLx48dSvnHjxkl5NDU1pfcBAQH5WxFZKNepah5Z9/HNmzcLLy8vYWBgIG3bJ0+eiDFjxggfHx9hZ2cnjIyMhLa2trC0tBRNmjQR69atE+np6bL55vZdorw/1K9fX/z777+iT58+wtLSUujq6go3Nzexffv2bG1VtW+pquuff/4RCxYsEC4uLkJHR0eULFlSfPvttyIpKSnbPJ89eyYGDRokrKyshJ6enqhatarYuHFjru3Pzfse38+fPxeTJ08WHh4ewtjYWOjo6IjSpUuLrl27itOnT8vy7tq1S5qXgYGBSElJkdLat28vpa1YsUKafuTIEdn+9erVKyGEECkpKWL+/PnC29tbmJqaCk1NTWFhYSGcnZ1Fr169xKZNm7K19eLFi9K8LCwsRGpqar7WEREREdGXhIEMIiIi+qqlpqYKExMT6SLR2bNns+XJK5AxZswYWfqZM2eEEIUPZDRo0CDXC9Fdu3aV8ma9aNu0aVOVZWrXri2rX7ltql5WVlay/MoXNuvVqyd0dXWzlbGwsJBdKFbnQMbChQtl87tz544s/datW8LOzi7H+g0NDcWhQ4dkZaKiooS1tXW2vAqFQrRo0SLHYEJoaKgwMjLKVk5XV1c0atQox2UoqkBGThYtWiSr5+LFi3mWUd5GHh4e2dLr1asnpfft21f4+/sLe3t7oaurK8qWLSvGjBkj4uLiZGWy7nft2rWT3k+bNk0IIcSbN29EsWLFBADh7u4uW5efIpBRu3Zt2efMbRsaGprn9uvdu7dsvvkNZJQpUybH/TPrvpzfQEbW5ch8+fn5yeb34sULUbFiRZV527Rpk2P7c/M+x/eNGzdE6dKlc1zHCoVCzJgxQ9b+zIAYAPH3339LaZaWltL0Xr16SdOVv2OrV6+ucpuoetWoUSPbsqakpAgDAwMpT2hoaL7WEREREdGXhF1LERER0Vft2rVriI+Plz57eHgUeB5Z++7Pra/+vERERCAkJAQAoKGhAX9/fzg5OeHZs2eIioqS0nLy119/oWbNmmjUqBH27duHsLAwABkDNJ87dw41a9YEACxdulQq06hRI/j4+CAxMREPHz7E6dOnkZSUlGMdJ0+ehL29Pbp3744bN25I3fPExcVh9erVmDhxYq5tzOyWR7krnq5du8LT0xMA4OjoiKCgIGzZskUagL1MmTIYPHiwlD+v7r9ykpaWhjt37mD16tXSNA8PD5QrV06Wx9fXV+r6ysrKCj169ICpqSn27duH0NBQJCYmokuXLoiMjESJEiUAAMOGDZMNOt2mTRt4eHjgwIEDOHDgQI5t6tOnDxISEgBkdCPj5+cHBwcH7NixA0ePHi3Q8mV24TRz5ky8ePECANCkSRM0bdq0QPMpDOVxM4yMjFCxYsVc81+6dAknTpyQPmftHiktLU3qrgoAVq1aJUu/e/cu5s6diz/++ANnzpyBpaWlynoaN26M27dv49atW1i2bBkmTpyIjRs34vnz5wCA4cOHY9q0aflbyA/kzJkzsLKyQteuXWFhYYGoqCgAGce8i4sLvLy8YGVlBTMzM7x9+xZXrlzB3r17IYTAmjVrMGjQoGzjfeTl3r17MDAwwPDhw5Geno5ly5YhLS0NQgjMmzevUPvImTNn0KxZM3h5eWHjxo24d+8eAGDTpk2YM2cOSpUqBQD44YcfcOvWLalcnTp14OPjg1OnThW6ey9V8nN8p6amwtfXF48ePQIAaGlpISAgAFZWVti2bRsiIyMhhMD3338PDw8PtGjRAmZmZnB3d8fly5cBAKdOnUL16tVx+/ZtPH36VJr3qVOnpPeZXQ4CgI+PD4CMMZXWr18vTe/YsSOqVq2KV69e4cGDB7LjQZmWlhZcXV2l4+HMmTPS9yURERHRV6OIAylERERERWrfvn3SXa7GxsYq82R9QmDQoEEiKChITJ8+PdvTBVWqVJHKFeaJjMuXL0vTKlWqlK0bmdTUVHH//n3pc9a7z729vaVuT54/fy7rMmfhwoVSOeWnUGJiYrItc2b3WJmU79A2MjKSlfHw8JDSOnTokGPbsj5FoZy2Zs2abG3I2i1OQeX15AcA4eXlJVufQgixe/duKV1HR0eW/u7dO9mTGpl3bf/3339CoVBI03v27CmVSU5OFi4uLrJ6M507d042/YcffpDSXr16JYoXL57jPpTTXfN5pX0Mp0+fFjo6OlKdkyZNyrNMt27dpPx2dnay7nqEECI2Njbb9qpYsaL48ccfRceOHWXTu3fvLpXLut8tWrRILF68WPq8ZcsW4e7uLgCIYsWKiaSkpE/+RIaZmZn4999/c5zXgwcPxPbt28XixYvF3LlzRVBQkChVqpRUPvPJEiHy/0QGALFv3z4pbcSIEdJ0CwsLWf35fSKjU6dOUlpYWJgsbc+ePUKIjP1f+YmjWrVqSV0jpaWlCR8fnxzbn5vCHt/K3UQBEMuXL5fSXrx4ISwsLKS0xo0bS2mjR4+Wprdr104IIcTKlSul/Sgz7eHDhyI5OVn2BEXmEy9xcXHSNBMTE/Hu3TtZ29LT03PsPq1169ZS2bFjx+ZrHRERERF9SfhEBhEREX3VXr58Kb03MTHJV5lly5apnG5hYYHg4OD3ak+lSpVQrFgxPH/+HBEREShXrhw8PDzg5OQENzc3NG7cGPb29jmW79u3L7S0tKT2FC9eHE+ePAEA6Q59AKhbty7+/PNPAICrqytq1KiB8uXLw8XFBT4+PrI7mLNq166d7KkTJycnaYBz5TrUnaWlJX766ads6/PMmTPS++TkZDg4OOQ4j7NnzwLIeLpACCFN79Gjh/ReW1sbXbp0weTJk7OVz3ziRFU5ExMTtGnTBmvWrMnfAhWRAwcOoEuXLtLgyp06dVK5rMqio6Oxfft26fO3334r7beZMueXSU9PDydOnJCevOjYsSN27twJANi5cyeSkpKgr6+vsr6AgAB89913iI+Px6hRo/Dvv/8CyBjUWk9PrwBL+2EEBATAxsYm2/Tnz58jICBAOjZzkvk0QUGUKlUKrVq1kj5XqFBBel/Y43bgwIEq56c8z9u3b0tPHAEZ+7impiaAjCdQAgICcPz48ULVn5ucju/MYzZTz549pfdmZmZo166ddMwp5/Xx8cG8efMAZHxHCCFw+vRpAICvry8OHjyIR48e4dSpU3B0dMSbN28AZBz/tWvXBpAxKLmLiwtu3LiB+Ph4ODo6wsvLC+XLl0flypXRqFEjODo6qlwe5d8n5d8tIiIioq+FRlE3gIiIiKgomZmZSe+Vu5jKL0NDQ1SuXBnjxo3DjRs34O7urjKf8kVuAHj37p3KfHp6eti6dSvs7OwAZHQHs2PHDsyaNQvdu3dHqVKlMH/+/Bzbk/Wina6urvQ+PT1der906VJ4e3sDyLh4un//fixYsAADBgxA+fLl0bVrV1n+wtShTszNzREUFISxY8fCysoKAPD06VO0bNkyW3cucXFx+Z5vbGwsgOwXFrN2c5RZZ1aFLacufvvtN7Rt21a6UO3n54dNmzZBQyP3vxm//PILUlNTAQCmpqbo379/tjzKxyYAODs7y9ZP/fr1pffv3r2TghOqGBkZISAgAACkfJqamrLuyj4lJycnldP79u2bZxADyPn7Ize5HbdZv58KM0/l+QH/912QdR/P2vXe+3TFl6kgx7dy0MbIyAgGBgaydOVj7s2bN1JArW7dulIA5tmzZ7h165YUyKhTpw7q1KkDADh9+rSsW6kaNWrA0NBQ+rxx40Y4OzsDAP777z/s3r0bc+fORUBAAOzs7DBq1CiVy6j8+5T12CAiIiL6GvCJDCIiIvqqKd8V/fr1a7x9+zbPO7SPHz+OBg0a5Dlv5Yu5WceciIyMzLFcw4YNERUVhcuXLyMsLAz//PMPzp49i1OnTiE5ORljxoxB27ZtVY4Toa2tLfusUChU1mFra4tz587hn3/+wYULFxAZGYmrV69iz549SE1NxdatW9GiRQsEBgYWug51YmJiIo3BMGDAALi7uyMxMRFpaWkYNGgQrl27Jj0RYG5uLpUzMjLK9emCzIuwWS8sKvebD0B6KiYrVeUsLCzyLFfUxP8fQ2DWrFnStHHjxmH27Nl57g/x8fFYuXKl9HnAgAEwNjbOls/AwACOjo7S+BFZZa0nr+N22LBhWLx4sXTRvl27dlLA8FPLevEcABITE7Fv3z7pc7du3RAUFAQbGxtoaGigevXqCA0NLXSdH+O4VZ5nTvPL69hQHlemsAp7fCckJODNmzey7aF8zBkYGEBHR0eqo1q1atI4Fdu3b8c///wDICOQkZiYiM2bN+PUqVPS+DrA/42PkcnNzQ03btzAtWvXcPnyZURGRuLy5cs4cOAA0tPTMX/+fLRt2zbbb4zyessce4SIiIjoa8InMoiIiOirVrlyZRgZGUmfMwfH/hCUL+DFxsZKA+G+fv1aNti2srdv3yIiIgIaGhrw9PREv379MHv2bJw4cQKmpqYAMu50ft92hoeHIz09HeXKlYOfnx8mT56MHTt2oGXLllKeS5cuvVcd70v5ImlmNy0fQrly5WQDS9+6dQsbNmyQPteqVUt6n5CQgKpVq2LMmDGy1+jRo+Hh4SF1GVO1alXZhVzl+aWkpGDr1q0q25J1wF7lcvHx8YUeCDk/627KlClQKBRQKBS5dp+VVXJyMnr06CEFMbS0tLB8+XL8/PPP+bo4vmLFCrx+/Vpq57fffptj3tatW0vvIyIipCdgAMjutLe2ts7z4q6Tk5NsQOvhw4fn2dZP6dWrV0hLS5M+d+7cGaVLl4aGhgYiIiIQHh5ehK0rvIoVK8oCVVu2bJGCSUII/P777x+0voIc3wBkg2+/fPkSu3fvzjGvclBi4cKFAICSJUuibNmyqFu3LgDg+vXrsn2zYcOGsnlkfndXrlwZAQEB+Omnn7B//364ublJebJ+96ampuLatWvS58zvHSIiIqKvCZ/IICIioq+alpYW6tWrh/379wMAzp8/L3W59L6yXqSuU6cOGjRogPPnz+d4l/nLly/h7OwMFxcXVK9eHTY2NtDX18fp06fx6tUrKd/7di3StWtXvHr1Cj4+PihVqhQsLCxw9+5daT18iDrel/KF6UuXLuHbb7+Fra0tdHR08M0337zXvL/99lvMmzdP6hJp1qxZ6NWrFzQ0NNC6dWtUqFABt2/fBgC0atUKHTt2RMWKFZGamoo7d+4gJCQEMTExOH78OBwdHWFjY4MWLVpI62/9+vWIj4+Hu7s7Dhw4gBs3bqhsR40aNaQ+8wFgxowZuH//PhwcHLB9+3Y8e/asUMtXqlQp6W7x4OBg6OnpwcTEBGXLloWvr2+h5pmpQ4cOsu6PGjVqhPj4eMydO1eWr0WLFnBxcZFNS01NlS4AAxlPHeQWgBg5ciRWr16NxMREJCUloUGDBujUqRMiIiKwY8cOKd/w4cPzFURZsmQJrl27Bk1NzXw9VfUpWVpawszMTOqK6dtvv8WVK1eQkJCA4ODgbGOGfC60tLQQGBiIRYsWAQBCQkLQqFEj1K1bFydPnkRISMgHrzOv47t8+fLSU3FDhw7FhQsXYG1tja1bt8q6lhs5cqRsvj4+Pvj5558BQDo2M7uUcnV1hbm5OV68eCEF6vT09FCzZk3ZPLy9vWFjY4O6devCxsYGJiYmCA8Px9WrV6U8Wb97w8LCpKf6LCws4OHh8V7rh4iIiOhzxEAGERERffX69u0rXYDesWMHRowY8UHmW6tWLdSqVUsaMDYmJgabNm0CADRt2hR//fVXjmVv3LiR48Xv6tWry8YHKKzHjx9L7cnKwsICffv2fe863kf79u0xffp0pKenIz09XboAbmho+N6BDHNzcwwaNEi6+H779m1s374dXbp0gZaWFv744w80a9YM0dHRePv2reyO7pwsXrwY3t7eUhcwe/bswZ49ewBkjOeQta9+IKM7ntWrV6Nhw4ZITEyEEEK6Q1xbW1u2/xREhw4dpPpiY2Mxffp0ABlBmfcNZFy/fl32+dChQzh06FC2fMWLF88WyNiyZQsePnwofVa+c14VR0dHrF27Ft27d0dycjJu3ryJadOmyfL4+vpi3Lhx+Wp72bJlVXbJpg60tLQwYcIETJgwAUDGgN4//fQTgIyL5GXLli3yp6QKa9q0aTh8+DBu3boFIKN7vswBvlu0aIEDBw5IefMaXyU/8jq+d+7ciWbNmuG///5DamoqVq1alW0eU6dOlT2hBmQELbS1tZGSkiKbBmQcy7Vr15Z1D1arVq1sY4cAQFRUVI7BbEdHR3Tq1Ek2bfv27dL7gIAAaawOIiIioq8Ju5YiIiKir55yX/lnzpzJ8QJTYezduxeBgYEoVqwY9PT04Onpia1bt2LixIkq85ubm2Px4sXo3r07nJ2dYWFhAU1NTZiYmMDT0xPTp0/H0aNHpf7eC2vWrFkYNGgQqlWrBmtra2hra8PAwAAVK1bEkCFDcOnSpQJ1N/QxuLu7Y9OmTahatWqe4x8UxujRo2UXGWfOnCl1eVOxYkVcvXoVM2fORI0aNWBqagptbW2UKlUKNWrUwOjRo3Hq1CnUq1dPKu/o6Ijz58+jS5cuMDMzg76+PmrWrCntAzmpXr06zpw5gxYtWsDIyAhGRkZo1KgRQkJC0KRJk0It29ChQzFlyhSUKVMmx31Fuc/9GjVqFKqegpo3b570vkmTJrLudHLSoUMHXL58Gf7+/ihdujS0tbVhamqKevXqITg4GDt27Hjv40FdjB8/HkuWLIGTkxO0tbVhbW2N/v3748SJE7Iu8D43ZmZmOHXqFAYOHAhLS0vo6uqiSpUqWLt2Lfz9/bPl/RByO75dXV1x9epV/Pjjj3B3d4ehoaF0fHfu3BknT57EpEmTss3T0NAQXl5esmmZgQwAUvdSmbKOjwEAS5cuRe/eveHm5oYSJUpAS0sLRkZGcHNzw7hx4/D3339L3QgCGV0JZgacNTQ0imyAeiIiIqKiphCZZ3NEREREX7G1a9ciICAAQMagwJndoBB9qZydnREREQFDQ0PcunULpUuXLuom0RcsKSkJ+vr62aZ36tRJ6iasfPnyuHPnzqdumlrbtm0bunTpAiDj6cGVK1cWcYuIiIiIigYDGURERETIGHS2evXquHjxIvT09HDv3j2ULFmyqJtF9FHExsbC0tISADB79myMHz++iFtEXzo7Ozs0a9ZMGvvn6dOn2LZtm6xbqUWLFmHYsGFF2Er1IoSAh4cHwsPDYWRkhMjISFhbWxd1s4iIiIiKBAMZRERERERfme3bt6Nz585SF1ra2tpF3ST6wpmZmeHVq1c5pvfv3x/Lly/P16DtRERERPT1YSCDiIiIiIiIPqqff/4ZBw8exK1btxAXFwcNDQ2ULFkS3t7e6Nu3Lxo1alTUTSQiIiIiNcZABhERERERERERERERqS2Nom4AERERERERERERERFRThjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiI1t3//ftSqVQvm5uZQKBRQKBT45ZdfEBISIn12cHAo6mYW2MqVK6X2Hz58uKibQ/nQoEEDaZsFBwd/snqV95Vjx459snqJiIhItS/1/LRnz55QKBQwNjZGXFxcUTfnixMcHCztHw0aNPhk9b548QImJiZQKBTw9/f/ZPUS0YfFQAYREdH/l56ejt27d6NLly5wcHCAgYEBTE1N4eLigoCAAOzbtw9CiE/apitXrqBt27Y4d+4cXr58+UnrVqVZs2bSnw+FQoE2bdoUaj6JiYmYNGkSAMDLywtNmjTJlkcdt8eXbsqUKdJLHfa3TP7+/ihdujQAYMyYMdzuRET01VDH8yF1OD91cHCQnZMqFApoaWmhWLFi8Pb2xsyZM5GYmFigeV66dAkbN24EAAwePBgWFhYq882aNUtWb/HixZGcnPzey0Qfj7m5OQYNGgQAWL9+Pa5cuVLELSKiwlAI/hMkIiLCkydP0KVLF5w8eTLXfC9evICZmdmnaRSAyZMnY9q0aQAyLvjPmjULurq6KFOmDAwNDXHt2jUAgJ6eHjw9PT9qW/7991/Y2dkhPT1dmqalpYVHjx7BysqqQPOaP38+Ro0aBQD4/fffs90Zpa7b40unUCik91FRUdnupLx27RpevXoFAHBycoKlpeUna9v06dOl4Ncff/yBdu3afbK6iYiIioK6ng+pw/mpg4MDHjx4kGuemjVr4tSpU9DU1MzXPNu1a4c9e/ZAoVAgKioK9vb2KvNVrFgRt2/flk3bvn07OnbsmL/Gf8WePn2KO3fuAABMTU1RuXLlT1Z3dHQ0HBwcIIRA+/btsWvXrk9WNxF9GFpF3QAiIqKilpSUhGbNmiE8PBwAoKGhgcDAQLRu3RqmpqZ4+PAhDhw4gJ07d37ytj18+FB636JFCzRq1EiWXqdOnU/WlrVr18qCGACQmpqK9evXY/To0fmejxACy5YtAwDo6+vD19dXlq7O26MopKSkQAgBHR2dom7KJ/2zmVX37t2lQMayZcsYyCAioi+aOp8PqdP5KQD07t0bffr0QXJyMjZs2IDVq1cDAM6dO4czZ86gXr16ec7j4cOH+PPPPwEAtWrVyjGIce7cuWxBDCCjyyR1DGSkp6fj3bt30NfXL+qmAAAsLS0/6Y0wyuzs7FCrVi2cOXMG+/btw7///otSpUoVSVuIqJAEERHRV27WrFkCgPTatGmTyny3b98W7969kz6np6eLdevWiYYNGwoLCwuhra0tSpQoIVq2bCn27t2brby9vb1Ux+HDh8WcOXNE+fLlhY6OjnBwcBBBQUFS3uPHj8valPUVFRUly2Nvby+rKykpSUycOFGULl1a6OrqCjc3N/H777+LNWvWSGXq169foPVUoUIFqWzv3r2l966urgWaz8WLF6WyzZo1y5aujtsj08aNG0X9+vWFhYWF0NTUFObm5qJSpUrCz89P7N+/X5Y3NTVVLFu2TNSpU0eYmZkJbW1tYWdnJ/r16yfu3bsnyxsVFSVb5piYGBEQECBKlCghFAqFmD17tpRWtmzZbO0aPHiwlD5q1CghhBChoaGiZ8+eonLlyqJEiRJCW1tbGBoaChcXFzF69GgRGxsrlQ8ICMh1f1uzZo0QQoj69etnm9atWzdp2vTp02XtevfunTAzM5PSw8PDpbSbN2+Kvn37CkdHR6GrqyuMjY1FrVq1xJo1a0R6erqqTS6cnJwEAKGhoSGeP3+uMg8REdGXQB3Ph9Tp/FS53ZMnT5amv379Ol/rLau5c+dKZWbNmpVjvgEDBkj5evXqJTQ1NQUAoaWlJR4/fqyyzN69e4Wnp6fQ1dUV1tbWYtiwYeLly5fZ1p2y1atXCxcXF6GjoyPs7OzEDz/8IG7duiUro0x5enh4uPjmm2+EjY2N0NDQELt27ZLyHTp0SLRt21ZYWVkJbW1tUbx4cdGmTRtx8uTJbO2+cOGC8PX1FSVLlhTa2trCyMhIODg4iDZt2oiFCxfK8ub3HFnVtj548GCBz3OFECIxMVH8/PPPwsvLSxgbGwsdHR1Rrlw5MXLkSPH06VOV22LmzJnSvH755ReVeYhIfTGQQUREXz3lC/SNGjXKV5m0tDTRqVOnXP/MjRw5UlZG+Q9X+fLlVZbZsGGDEOL9/iimp6eL5s2bqyxXrVq1QgUyzp49K5UrXry4eP36tewC9cWLF/M9L+U/ipMmTcqWro7bQwghgoODc53/wIEDpbxv3rwRPj4+OeY1MzMTf//9t5Q/ayAja3suXbok7OzspM/nz5+XyqakpIjixYtLadevXxdCCLF06dJc2+vo6ChevHghhHi/QMaRI0ekaRUrVpSt4127dklpXl5esul6eno51tejRw+VwYxevXpJeZT/lBMREX1p1PF8SJ3OT1UFMpKTk8Vvv/0mm/eNGzfyNb/WrVtLZY4dO6YyT1JSkuz8NywsTLZMc+fOzVZmw4YNQqFQ5LrMmesuk/LF9tzKKMvtPDLznGn8+PE5bjsNDQ2xdOlSaX63bt0Surq6OeavUKGClLcg58iqAhlpaWkFPs+NjY0Vrq6uOdZZqlSpbDcOCSHE0aNHpTzt2rVTvTMQkdriYN9ERPRVS0xMlD0ermrQaVV+/fVXbN++HUDGOBGTJ0/GgQMH8O2330p55s+fj3379qksf+/ePUyePBn79u2TPe6+cOFCAICHhwdOnTqFFi1aSGm9e/fGqVOncOrUKZQsWTLHtm3cuBEHDx6UPn/77bfYv38/xowZg8uXL+dr+bIKDg6W3nft2hVGRkbo1KmTyvS8ZPabDGSMs6BMXbcHAGzbtk16P3nyZBw9ehR//PEHFi5ciHbt2sHY2FhKnzJlCo4fPw4AcHR0xJo1a3Do0CEMHDgQAPDy5Ut0794dKSkpKtsTHR2NadOm4dChQ1ixYgUsLS3Ru3dvKX3Dhg3S+0OHDuHZs2cAAG9vb7i4uAAA3NzcMHfuXOzcuROHDx9GSEgIdu3ahWbNmgHIGANj5cqVAIDvv/8ep06dkrVh27Zt0v7WsmVLle0EgIYNG8LR0REAcOvWLdk+ptzOvn37AgBiY2PRq1cvvH37FgAwaNAgHDx4EGvXroWdnZ1Ubs2aNdnqqlChgvT+6tWrObaJiIjoc6au50Pqdn6aaerUqVAoFNDR0UH//v0BANra2pg9ezacnZ3zNY/czk8z7dq1Sxrc3MXFBVWqVEHPnj2l9KznwwkJCRg6dKg0GLunpyd27tyJ4OBg/PfffyrrePDggdSVJgA0a9YMe/bsweLFixEZGZmvZbl79y5Gjx6NAwcOYN26dShbtiwOHDiAn3/+GUBG165z5szB4cOHMXfuXOjq6iI9PR3Dhw+Xxq/Yu3cv3r17BwDo1KkTDh48iAMHDmDlypXo06ePrEumgpwjq6KhoVHg89yhQ4fi+vXrAAB3d3ds3rwZBw4cQIcOHQBkjO0XEBCQrS6eSxJ95oo6kkJERFSUHj16JLt757fffstXuapVq0plBg8eLEtr2bKllNaxY0dpuvKdY0OHDpWmnzt3TppuYWEhm5fynfLKj80LIXK8461NmzbS9ObNm8vK+Pr6FviOt6x3n507d04IIURISIg0rVixYrJuDXKjvH4OHDggS1Pn7eHn5ydN37JlS46PrKenp4sSJUpIef/3v/+JU6dOSa+SJUtKaQcPHhRCZH8iI+vj+kIIcf/+faGhoSEACEtLS5GSkiKEEKJ79+4q11dKSopYtGiRqFOnjvSYv3IdAESHDh1kdSinZe3iQAjVT2QIIcS0adOk6ZmP/L969Up66sLAwEC8evVKCCHEokWLpLyurq6ydfP9999Lad7e3tnq//XXX6X0IUOGqFz/REREnzt1Ph8SQj3OT5XbreplZGQkvv/+e5GWlpav+RkYGEhlk5KSVOZp2rSplCez+6nExERhZGQkTVd+SnnHjh3SdC0tLfHw4UMpbffu3SrPu+bNmyc7v05MTJTKLFiwQFZGmfJ05e6XMnXs2FFK79Wrl+z8S3nfmDBhghBCiBUrVkjTxo4dK+7fv5/juszvObIQqp/IEKJg57kvXryQnddu3LhRWpbjx48LbW1tKe3WrVuy+t+8eSOlGRgY5NhOIlJPfCKDiIi+amZmZrLPz58/z1e5iIgI6X3WAQ2V72BTzqesYcOG0vvixYtL7+Pi4vJVf26U79aqW7euLK1+/foFnp/y3WdlypSBt7c3gIzlzBwI8fnz59i7d2++5if+/11pWd8D6r09Bg4cCE1NTQAZT6VYWlrC3NwcdevWxU8//YQXL14AyHjiIDY2Vio3atQo1K1bV3rFxMRIaTdu3FDZHlWDRdrb20uDaT59+hRHjhxBQkICdu/eDQAwNDRE165dpfx9+vTB8OHDcfr0acTFxSEtLS3bPDPb/L569+4NDY2M08rNmzcjPT0dO3bskJ666NSpE0xMTAAAN2/elMpdv35dtm5mzJghpalaN8r7i0Kh+CBtJyIiUjfqfD5UWB/6/FRZ5lMhISEhWLJkCczNzZGQkIAZM2Zg+vTpBZ5f1vNTIOMO/yNHjgDIOAfp3r07AMDAwAC+vr5SPuWnMpSX2dHREaVLl5Y+57TMymWqVq0KAwODPMtkpeo8Uvn8a926dbLzr/3790tpmedf7du3h42NDQAgKCgIDg4OMDQ0hLu7O7799lvZE0P5PUfOTUHOc+/cuSM7r/Xz85OWxcfHR/bEc9bzSZ5LEn3eGMggIqKvmqGhoewR48w/KO9D1Z+frCwsLKT3Wlpa711nTrKeoOenbVkp/yG7d+8eFAoFFAoFNDQ08ODBA5X5cmNpaSm9z/rHWJ23R7169XDlyhUpMGFtbY2XL1/i9OnT+PHHH9GsWTOVwYLcvH79WuX0nLpmyOyeCch47P6PP/7AmzdvAGT8ccx8dP/ff//FunXrpLzffPMNDh06hFOnTmHcuHHS9PT09AK1NyelS5dG06ZNAQD//fcfjh8/LusWoF+/fgWep6p1o7y/lChRohAtJSIiUn/qfD70IXyI81NldnZ2qFOnDurXr48hQ4Zg7NixUtqqVavyNQ/l8wpVgZu1a9dK501CCDg4OEjnxMrnXJs2bUJycnK28oW5aF7Y9ZRbF195yTz/KlGiBC5fvowZM2agefPmcHR0RHJyMsLDw7Fw4UJ4e3vj4cOHAD7cOXJ+z3MLszyZeC5J9HljIIOIiL56gYGB0vsjR47I+nlVdufOHemPSaVKlaTpZ86ckeU7ffq09L5ixYofsKX5o9yv79mzZ2VpJ0+eLNC8lO8+y8vBgwfx5MmTPPNVrlxZeq98N1cmdd0eQghUrlwZ8+bNw8mTJxETE4P//vsPDg4OAIDQ0FBERkaiRIkSsrsYDx06BCFEtld8fDwmT56ssq6c/uz6+vqiWLFiAIA//vgDv/32m5Sm/Ocv848lkHFRYsGCBWjatCnq1KmT6zZSrregQQ7lYMXcuXOlMULKly8vu/NSeVvVqlVL5brJXD9ZKe8vyvsRERHRl0Zdz4cK60Oen+ZF+YK/8lOyucnr/PT333/P13yUn1JWXuaoqCg8fvxY+nzixAmV5ZXLXL58WXq6Fcj/elJ1Hqm8b0ycOFHluVdKSor0dIYQAlZWVvjuu+9w4MAB3Lt3D/Hx8dLTJy9fvsSff/4p5c3POXJe8nue6+TkJD0BAmRsr5zOJbOOk8FzSaLP28cLsRMREX0mvv32W2zevBnh4eEAgO7du+Ovv/5C69atYWJigocPH+LAgQPYsWMHnj59Ch0dHfTu3VsamPC3336DtbU1vLy88Ndff0kn9QBkA9d9Kl27dsWePXsAAH/++SfGjh2LRo0a4dixY/jjjz8KNC/lu8/Kly+Pb775Jlue+fPn4969e0hNTcX69esxevToXOfZoEED6f2FCxeypavr9hgxYgT++ecfNG3aFLa2tjA3N0dkZKTsD/Lbt2+hUCjQu3dvBAUFAQD8/f0xYcIEuLq6IjExEdHR0Th27BgOHjyIpKSkArVBR0cHPXv2xIIFC5CQkCD9oa1YsSJq1aol5StTpoz0Pi4uDtOmTYO3tzcOHTqEtWvX5jj/YsWKSQMqLlu2DK1bt4aGhgaqV68OHR2dXNvWtm1blChRArGxsbLBPJX/eAIZ++d3332HhIQEnD17Fp06dYKfnx9MTU3x77//IiIiAjt37kT37t0xZcoUWdnM/UWhUMi6yCAiIvrSqOv5UGF9yPPTrKKjo3H69GmkpaUhIiIC8+bNk9KUL+DnpkGDBtIg6BcuXJB1s3Xu3DnpArimpibmzZsnu5AOAPv27cOhQ4cAZDyl3LFjRzRt2hTm5uZ48eIFUlJS0KFDB4wfPx4vX77ExIkTVbajY8eOGDduHFJTU/Hs2TN07twZgwYNwv379/Hjjz/mf6Vk0bdvX+zcuRNARldRaWlpqF+/PjQ0NPDw4UNcvHgRO3fuxLZt29CgQQNs3boV8+bNQ9u2bVGuXDlYWVnh+fPnsm7JMoMs+T1Hzkt+z3PNzMzQoUMHKbjXsmVLjB07FuXKlcPLly/x4MEDHDp0CPfu3csWQFH+7/G+XZoRURH4qCNwEBERfSZiYmJEvXr1ch00EIB48eKFEEKI1NRU2aB5ql4jRoyQ1aE8KOHx48el6VkHelZWmMEU09PTRfPmzVW2ycPDo0CDKVaoUEHKP23aNJV5lAdodnV1zXOe6enpwsnJSQAQ+vr6Ij4+PlseddweAwcOzHX+VatWlQZBfPPmjWjQoEGe7c+rTlWuXr2abT5BQUHZ8ikPvKj88vHxyXEfUB5QUfmVOThlToN9Zxo1apSsnJaWloiJicmWb+fOndJA4Dm9su7vkZGRUlqTJk1yXUdERERfAnU8HxKi6M9Ps7Y7p5e2trY4cOBAvuYXHR0tDSBdu3ZtWdqAAQOkeTZs2FBl+cOHD8vOfx4/fiyEEGL9+vVCoVDkuszA/w32LYQQM2fOzHM9Zd0mOc1L2bhx4/JcZ5n7wKZNm3LNZ2JiIh48eCCEKNg5ck6DfWfK73nu06dPhaura671Ku9/mWrXri0ACE1NTREdHa1yPRGR+mLXUkRERACsra1x/Phx7Nq1C506dYKdnR309PRgZGSEChUqwM/PD7t374apqSmAjLuxtm3bhrVr18LHxwfm5ubQ0tJC8eLF0aJFC+zZswfz588vkmVRKBTYtWsXJkyYgFKlSkFHRwcuLi5YvXo1/P39pXyGhoa5zuf8+fOyx687deqkMp/ygILXr1/HpUuX8mzfwIEDAQBJSUnYtWtXtjzquD38/PzQv39/uLm5oXjx4tDS0oKBgQFcXV0xfvx4HD16VBrwWl9fH0eOHMGKFSvQoEEDWFhYQEtLC1ZWVqhWrRpGjhwpdb1UUJUrV4aXl5f0WVtbW7ZdM/32228YM2YM7O3toaenB3d3d2zZskVl3kwLFixA165dYWFhUai+nLM+fdGyZUtYW1tny+fr64srV65gwIABKFeuHPT09GBoaIhy5cqhdevWWLZsGYYMGSIrs2nTJun94MGDC9w2IiKiz406ng8V1oc6P82Lrq4uypQpg169euH8+fNo3rx5vsrZ2tqiZcuWADK6vsocB+7t27fYunWrlC+n8+EGDRpI3SJlPqUMAD169MDu3bvh6ekJXV1dWFpaYtCgQdixY4esvPJyT5w4EatWrYKzszN0dHRQunRpTJw4Eb/++quUR3kQ8Pz6+eef8ddff8HX1xclS5aEtrY2zM3N4ezsDH9/f2zfvh3e3t4AgBo1amDMmDGoVasWSpYsCR0dHejo6MDBwQEBAQH4+++/YWdnB6Bg58h5ye95bokSJXDhwgXMnTsX3t7eMDU1hba2NmxsbODt7Y3vv/8+2zqOjo6WujVr1aoVbG1tC7wOiahoKYR4z1GViIiISO0IIVReiPb19ZUe3x81apTs0ftPKTExEeXLl0dMTAy8vLxUdjFFlCk5ORlly5bFo0eP4O7ujkuXLuX7DzERERGpB3U/P7106RK8vLwghMDYsWMxZ86c955nTsu8e/dutG/fHkBG156xsbFSvpzKLFiwACNGjAAAVK1aNc+bh0hu3LhxCAoKgkKhQGhoKKpVq1bUTSKiAuIYGURERF+gYcOGwdLSEo0bN4a9vT1iY2Oxbt066U+iQqFAr169iqx9hoaGmD59Ovr164fQ0FD89ddfaNq0aZG1h9TbunXr8OjRIwAZA4kziEFERPT5Uffz02rVqqFHjx5Yv349li5digkTJsDCwuK95nn48GGsXLkSvXr1QqVKlSCEwPnz5zF+/Hgpj7+/vyxwsXr1apw/fx6dOnWCk5MT3r59i2PHjmHSpElSnqyDWFPuXr58iWXLlgHIeEqGQQyizxOfyCAiIvoCdevWDVu2bFGZpqGhgXnz5kl3dBERERERfWxf4/npwYMH0aJFixzT69atiwMHDsi6llq2bFmu3Wh27twZmzZtyjbgOBHRl45PZBAREX2BOnTogJcvX+L69et49uwZFAoFSpUqhTp16mDo0KGyvmeJiIiIiD62r/H81MnJCf7+/vj7778RExODN2/ewNzcHFWqVEG3bt0QGBiYLSBRvXp1dOnSBRcvXsSTJ0+QnJyM4sWLo1q1avD390fnzp2LaGmIiIoWn8ggIiIiIiIiIiIiIiK1xQ6GiYiIiIiIiIiIiIhIbTGQQfQFEUIgPj4efNCKiIiIiD4mnncSERER0afEQAbRF+T169cwNTXF69evi7opRERERPQF43knEREREX1KDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS2tom4AEX14Q1ecgo6+YVE3g4iIiIhUWDW0QVE34cNZVxXQ1yzqVhARERGRKn1uF3ULPhg+kUFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZRERERERERERERESkthjIICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMtSYg4MDfvnll09Wn0KhwB9//JFj+v3796FQKBAWFgYACAkJgUKhwMuXLz9J+4iIiIiIvnQvX76Eu7u79HJycoKWlhbi4uJw8eJF1KxZEx4eHqhUqRLmzJkjlYuMjESTJk1QpUoVuLi4YMuWLUW4FERERESk7r755hs4ODhAoVDg+vXr0vQ+ffqgQoUKcHd3R7169aRrwZl+/fVXVKpUCa6urnBzc8Pbt28BAAsXLpSmubu7y85Hg4ODYWZmJp3j+vj4FLi9DGRQodWqVQsxMTEwNTUF8H87pDpRxzblB4NERERERF8nMzMzhIWFSa8BAwagRYsWsLCwQP/+/TFx4kRcuXIFZ86cwdy5c3Hz5k0AQGBgIHr06IHw8HAcO3YMY8eOxb///lvES0NERERE6qpTp044ffo07O3tZdPbt2+PGzduICwsDOPGjUOXLl2ktN27d2PDhg04f/48rl+/jiNHjkBbWxsA4OLigjNnzuDq1avYu3cvhg0bhgcPHkhlGzduLJ3jHj9+vMDtZSDjC5OSkvLJ6tLR0YG1tTUUCsUnq5OIiIiI6GuyZs0a9O3bV/qceaNLYmIidHR0YGFhAQAIDw9Hy5YtAQBWVlaoUqUKn8ogIiIiohzVq1cPpUuXzja9bdu20NLSAgB4e3vjwYMHSE9PBwAEBQVh6tSp0o3tlpaW0NTUBAA0atRImm5rawsrKys8fPjwg7WXgYyPbPv27ahcuTL09fVRrFgxNG7cGImJiWjQoAFGjBghy9u+fXsEBgbKpr1+/Rp+fn4wMjKCjY0NFi1aJEtXKBRYtmwZ2rVrB0NDQ/z0008AgL1796JatWrQ09NDmTJlMHXqVKSmpkrlIiMjUa9ePejp6cHZ2RmHDx/O1vYLFy7Aw8MDenp68PT0xJUrV2Tpyk8NhISEoHfv3nj16hUUCgUUCgWmTJmS5/pxcHDA9OnTc13G6OhotGvXDkZGRjAxMUGXLl3w5MkTKT08PBw+Pj4wNjaGiYkJqlWrhosXLxa6Te/evcO4ceNga2sLXV1dlC9fHqtWrZLST5w4gerVq0NXVxclS5bEhAkTZOtWVZdg7u7usroVCgVWrlwJX19fGBgYoHz58tizZw+AjC68Mh+vMjc3h0KhyLZfKLc1Pj5e9iIiIiKiL8O5c+fw/PlztG7dGkBGUOPHH3+EnZ0dnJycMGvWLFhbWwMAvLy8sH79egDA3bt3cfbsWdy/f/+DtYXnnURERERfnwULFqBly5bQ0MgII9y8eRMXL15E7dq14enpiYULF6osd+TIEbx48QLVqlWTpp04cQLu7u6oXbs2tm/fXuC2MJDxEcXExKB79+7o06cPIiIiEBISgg4dOkAIke95BAUFwc3NDZcvX8bEiRMxcuTIbEGHyZMno127drh27Rr69OmDQ4cOoWfPnvjmm29w8+ZNLF++HMHBwZgxYwYAID09HR06dICmpibOnz+PZcuWYfz48bJ5JiYmonXr1qhQoQIuXbqEKVOmYMyYMTm2s1atWvjll19gYmKCmJgYxMTE5Jo/v8sohED79u0RFxeHEydO4PDhw7h79y66du0qle/RowdKly6N0NBQXLp0CRMmTIC2tnah2+Tv74/Nmzdj4cKFiIiIwLJly2BkZAQA+Pfff9GyZUt4eXkhPDwcS5cuxapVq6QAUkFMnToVXbp0wdWrV9GyZUv06NEDcXFxsLW1xY4dOwAAt2/fRkxMDBYsWKByHrNmzYKpqan0srW1LXA7iIiIiEg9rV69Gv7+/tIdcUFBQQgKCkJ0dDRu3LiB77//Hrdv3waQ0aXquXPn4O7ujrFjx6Jx48bSY/4fAs87iYiIiL4u69evx9atW7F8+XJpWmpqKu7evYuTJ0/ir7/+wm+//Yb9+/fLyl27dg29e/fGli1boK+vDwBo3bo1Hjx4gLCwMKxcuRIjR47E+fPnC9QerfdfJMpJTEwMUlNT0aFDB6mvscqVKxdoHrVr18aECRMAAE5OTjhz5gzmz5+PJk2aSHn8/PzQp08f6XOvXr0wYcIEBAQEAADKlCmD6dOnY9y4cZg8eTKOHDmCiIgI3L9/X3p8aObMmWjRooU0jw0bNiAtLQ2rV6+GgYEBXFxc8OjRIwwePFhlO3V0dGBqagqFQiHdFfYhlvHIkSO4evUqoqKipD9L69atg4uLC0JDQ+Hl5YXo6GiMHTsWFStWBACUL19emndB23Tnzh1s3boVhw8fRuPGjaX1l+nXX3+Fra0tFi9eDIVCgYoVK+K///7D+PHjMWnSJCk6mR+BgYHo3r07gIz1v2jRIly4cAHNmzeXugiwtLTMdYyPiRMnYtSoUdLn+Ph4/qkkIiIi+gIkJiZiy5YtuHDhAgDg2bNn2LVrFzZs2AAg4xy1Ro0aOHv2LCpUqAB7e3ts27ZNKt+8eXM0bdr0g7WH551EREREX48tW7Zg6tSpOHr0KCwtLaXpdnZ26N69OzQ1NWFhYYEWLVrgwoULUhenN2/eROvWrbF69WrUqVNHKle8eHHpfaVKldCyZUucOXMG3t7e+W4Tn8j4iKpUqYJGjRqhcuXK6Ny5M3777Te8ePGiQPOoWbNmts8RERGyaZ6enrLPly5dwrRp02BkZCS9+vfvj5iYGLx58wYRERGws7OT9YGWtZ6IiAhUqVIFBgYGOeb5UHJbxoiICNja2sr+JDk7O8PMzEzKM2rUKPTr1w+NGzfG7Nmzcffu3UK3JSwsDJqamqhfv77K9IiICNSsWVM2Lkjt2rWRkJCAR48eFaguNzc36b2hoSGMjY3x9OnTAs1DV1cXJiYmshcRERERff62bdsGNzc36WYdc3Nz6Onp4cSJEwAyAhvnz5+Hq6srAODJkyfSk9+HDh3CzZs34efn98Haw/NOIiIioq/D1q1b8cMPP+DIkSOws7OTpfn5+eHgwYMAgLdv3+LEiROoUqUKgIzrpi1btsSKFStkN+EDGb3cZHry5AmOHTsGDw+PArWLgYyPSFNTE4cPH8aBAwfg7OyMRYsWoUKFCoiKioKGhka2LqbyO1B31sG1DQ0NZZ/T09MxdepUaRT4sLAwXLt2DZGRkdDT01PZtVXWeRak+6uPIbM9QgiVg4krT58yZQpu3LiBVq1a4dixY3B2dsauXbsKVW/m4045UdWezHWVOT2/2zbro/4KhUIaOIeIiIiIvm6rVq2SDfKtqamJrVu3YtSoUahSpQrq1auHMWPGwMvLC0DGGHnly5dHxYoVMXv2bOzfvz/Pc1siIiIi+noNHToUpUuXxqNHj9C4cWOUK1cOQEY3/m/fvkW7du3g7u4Od3d3PH/+HAAwcuRIPH78GM7OzqhWrRpatGgBX19fAMA333yDV69eYfz48VK5Q4cOAQCWLFkCFxcXuLu7o0mTJhg5ciQaNmxYoPaya6mPTKFQoHbt2qhduzYmTZoEe3t77Nq1CyVKlEBMTIyULy0tDdevX5cGec6Uta+w8+fPS3dl5aRq1aq4ffu2tPNl5ezsjOjoaPz333+wsbEBkDGQYNY869atQ1JSkvQHKK9+y3R0dJCWlpZrHlVyW8bMtj58+FB6KuPmzZt49eoVKlWqJJVxcnKCk5MTRo4cie7du2PNmjXw9fUtcJsqV66M9PR0nDhxQupaSpmzszN27NghC2icPXsWxsbGKFWqFABk27bx8fGIiorKdxuAjHUJoFDrk4iIiIg+f6dOnco2rXHjxrh06ZLK/P369UO/fv0+drOIiIiI6AuxZMkSLFmyJNv03G6219fXx9q1a1WmZR3XWdnMmTMxc+bMgjdSCZ/I+Ij+/vtvzJw5ExcvXkR0dDR27tyJ2NhYVKpUCQ0bNsSff/6JP//8E7du3cKQIUPw8uXLbPM4c+YM5syZgzt37mDJkiXYtm0bvv3221zrnTRpEtauXSs9qRAREYEtW7bghx9+AJDxB6hChQrw9/dHeHg4Tp06he+//142Dz8/P2hoaKBv3764efMm9u/fj7lz5+Zar4ODAxISEnD06FE8e/YMb968ydd6ym0ZGzduDDc3N/To0QOXL1/GhQsX4O/vj/r168PT0xNJSUkYNmwYQkJC8ODBA5w5cwahoaFSkKOgbXJwcEBAQAD69OmDP/74A1FRUQgJCcHWrVsBAEOGDMHDhw8xfPhw3Lp1C7t378bkyZMxatQoaXyMhg0bYt26dTh16hSuX7+OgIAAaGpq5mtdZLK3t4dCocC+ffsQGxuLhISEApUnIiIiIiIiIiIi+lIwkPERmZiY4OTJk2jZsiWcnJzwww8/YN68eWjRogX69OmDgIAA6aK8o6NjtqcxAGD06NG4dOkSPDw8MH36dMybNw/NmjXLtd5mzZph3759OHz4MLy8vODt7Y3//e9/0oDjGhoa2LVrF969e4fq1aujX79+mDFjhmweRkZG2Lt3L27evAkPDw98//33+Pnnn3Ott1atWhg0aBC6du2KEiVKYM6cOflaT7kto0KhwB9//AFzc3PUq1cPjRs3RpkyZbBlyxYAGY/YP3/+HP7+/nByckKXLl3QokULTJ06tdBtWrp0KTp16oQhQ4agYsWK6N+/PxITEwEApUqVwv79+3HhwgVUqVIFgwYNQt++faUgEZAxEGK9evXQunVrtGzZEu3bt0fZsmXztS4ylSpVClOnTsWECRNgZWWFYcOGFag8ERERERERERER0ZdCIYp6MAT6qjk4OGDEiBEYMWJEUTflixAfHw9TU1P0DNoHHX3DvAsQERER0Se3amiDom7Ce8s873y1uCxM9Av29DERERERfSJ9bhd1Cz4YPpFBRERERERERERERERqi4EM+mhOnToFIyOjHF9sExERERERERERERHlRauoG0BfLk9PT4SFheWa5/79+5+kLZny0yYiIiIiIiIiIiIiUh8MZNBHo6+vj3LlyhV1M2TUsU1ERERERERERERElDN2LUVERERERERERERERGpLIYQQRd0IIvow4uPjYWpqilevXsHExKSom0NEREREXyiedxIRERHRp8QnMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUllZRN4CIPryhK05BR9+wqJtBRESkllYNbVDUTSD6cqyrCuhrFnUriIiISJU+t4u6BUQfDJ/IICIiIiIiIiIiIiIitcVABhERERERERERERERqS0GMoiIiIiIiIiIiIiISG0xkEFERERERERERERERGqLgQwiIiIiIiIiIiIiIlJbDGQQEREREREREREREZHaYiCDiIiIiIiIiIiIiIjUFgMZXxEHBwf88ssvRd0MIiIiIiIiIiIiIqJ8YyDjCxQcHAwzM7OibgYRERHRZ8nBwQEVK1aEu7s73N3dsWXLFgDAxYsXUbNmTXh4eKBSpUqYM2dOtrIhISHQ1NTE4sWLP3WziYiIiIgK5ODBg/D09ISbmxu8vb0RHh4OAAgNDUXt2rXh5uYGd3d3HDt2TCoTGRmJJk2aoEqVKnBxcZHOlQHgzz//hKenJ3R1dTFmzJhPvjz0ZdMq6gbQ5y05ORk6OjpF3YzPnhACaWlp0NLiIUlERKQOtm/fDldXV9m0/v37Y+rUqWjbti3i4uJQsWJFtG7dGs7OzgCA169fY/z48WjRokVRNJmIiIiIKN9evHiBnj174tSpU6hUqRJOnDiBHj164Nq1a/D19cW6devg4+ODW7duoUmTJrhz5w709fURGBiI/v37IzAwEE+ePIGXlxfq1KmDUqVKoXz58li1ahW2bduGt2/fFvUi0heGT2SooYMHD6JOnTowMzNDsWLF0Lp1a9y9exdAxl1+CoUCL1++lPKHhYVBoVDg/v37CAkJQe/evfHq1SsoFAooFApMmTJFyvvmzRv06dMHxsbGsLOzw4oVK2R1X7t2DQ0bNoS+vj6KFSuGAQMGICEhQUoPDAxE+/btMWvWLNjY2MDJySnP5XFwcMBPP/0Ef39/GBkZwd7eHrt370ZsbCzatWsHIyMjVK5cGRcvXpSVO3v2LOrVqwd9fX3Y2trim2++QWJiopS+fv16eHp6wtjYGNbW1vDz88PTp0+l9Mx1dfToUXh6esLAwAC1atXC7du387UdwsPD4ePjA2NjY5iYmKBatWqyNp45cwb169eHgYEBzM3N0axZM7x48QIA8O7dO3zzzTewtLSEnp4e6tSpg9DQ0GxtO3TokBSpPnXqFIQQmDNnDsqUKQN9fX1UqVIF27dvz1d7iYiI6OPLPAdLTEyEjo4OLCwspLRRo0Zh7NixKF68eBG1joiIiIgof+7evQtLS0tUqlQJAFC/fn08ePAAoaGhiIuLg4+PDwCgYsWKMDMzw4EDBwBkXC9r2bIlAMDKygpVqlSRnspwcnJClSpVeKMufRQMZKihxMREjBo1CqGhoTh69Cg0NDTg6+uL9PT0PMvWqlULv/zyC0xMTBATE4OYmBjZo1zz5s2Dp6cnrly5giFDhmDw4MG4desWgIwgR/PmzWFubo7Q0FBs27YNR44cwbBhw2R1HD16FBERETh8+DD27duXr2WaP38+ateujStXrqBVq1bo1asX/P390bNnT1y+fBnlypWDv78/hBAAMgIqzZo1Q4cOHXD16lVs2bIFp0+flrUlOTkZ06dPR3h4OP744w9ERUUhMDAwW93ff/895s2bh4sXL0JLSwt9+vTJV5t79OiB0qVLIzQ0FJcuXcKECROgra0NICN41KhRI7i4uODcuXM4ffo02rRpg7S0NADAuHHjsGPHDvz+++/S8jVr1gxxcXGyOsaNG4dZs2YhIiICbm5u+OGHH7BmzRosXboUN27cwMiRI9GzZ0+cOHFCZRvfvXuH+Ph42YuIiIjeX48ePVC5cmX069cPsbGxAIA1a9bgxx9/hJ2dHZycnDBr1ixYW1sDAA4cOICXL1+iU6dORdlsoo+G551ERERflvLlyyM2Nhbnz58HAOzatQsJCQl49OgRrKyssGPHDgDA33//jTt37uD+/fsAAC8vL6xfvx5ARjDk7NmzUhrRx8TwmBrq2LGj7POqVatgaWmJmzdv5llWR0cHpqamUCgU0h9rZS1btsSQIUMAAOPHj8f8+fMREhKCihUrYsOGDUhKSsLatWthaGgIAFi8eDHatGmDn3/+GVZWVgAAQ0NDrFy5skBdSrVs2RIDBw4EAEyaNAlLly6Fl5cXOnfuLLWlZs2aePLkCaytrREUFAQ/Pz+MGDECQMaX68KFC1G/fn0sXboUenp6soBEmTJlsHDhQlSvXh0JCQkwMjKS0mbMmIH69esDACZMmIBWrVrh7du30NPTy7XN0dHRGDt2LCpWrCi1IdOcOXPg6emJX3/9VZrm4uICICMQtXTpUgQHB0tdS/z22284fPgwVq1ahbFjx0plpk2bhiZNmkjl/ve//+HYsWOoWbOmtFynT5/G8uXLpWVQNmvWLEydOjXX5SAiIqKCOXnyJOzs7JCSkoIffvgBAQEB2L9/P4KCghAUFIQuXbrg3r17aNCgAapXrw4rKytMmDABhw8fLuqmE300PO8kIiL6spiammLHjh2YMGECXr9+jTp16sDZ2Rna2trYvXs3xo8fjxkzZqBy5cqoU6eOdHNvcHAwxowZA3d3d5QpUwaNGzeW0og+JgYy1NDdu3fx448/4vz583j27Jn0JEZ0dDQMDAzea95ubm7S+8xgR2Z3TBEREahSpYoUxACA2rVrIz09Hbdv35YCGZUrVy7wuBjK9SrPJ+u0p0+fwtraGpcuXcI///yDDRs2SHmEEEhPT0dUVBQqVaqEK1euYMqUKQgLC0NcXJxsPWX2VZ217pIlS0r12NnZ5drmUaNGoV+/fli3bh0aN26Mzp07o2zZsgAynsjIDMJkdffuXaSkpKB27drSNG1tbVSvXh0RERGyvJ6entL7mzdv4u3bt1JgI1NycjI8PDxU1jVx4kSMGjVK+hwfHw9bW9tcl4uIiIhyl3mOoK2tjREjRsDJyQnPnj3Drl27pHOTMmXKoEaNGjh79izKly+PmJgYVK9eHQDw7Nkz7N27F7GxsbzwS18MnncSERF9eerVq4eQkBAAGU9fWltbo1KlSihXrpzUlRQAVKpUSbrWZm9vj23btklpzZs3R9OmTT9pu+nrxECGGmrTpg1sbW3x22+/wcbGBunp6XB1dUVycrL0pEFmF0wAkJKSku95Z42QKhQKKQAghIBCoVBZTnm6cqCjMPVmzkvVtMy2pKenY+DAgfjmm2+yzcvOzg6JiYlo2rQpmjZtivXr16NEiRKIjo5Gs2bNkJycnGfd+emma8qUKfDz88Off/6JAwcOYPLkydi8eTN8fX2hr6+fY7nMbZN1Xapav8rrMrNNf/75J0qVKiXLp6urq7IuXV3dHNOIiIio4BITE5GSkgIzMzMAwKZNm+Dh4QFzc3Po6enhxIkTqF+/Pp49e4bz589j3Lhx8PLyko3TFRgYCE9Pz2zdcxJ9znjeSURE9OWJiYmRbvqdPn06GjZsiHLlyuHx48dSTy+//fYbDA0N0bBhQwDAkydPYGlpKY39evPmTfj5+RXZMtDXg4EMNfP8+XNERERg+fLlqFu3LgDg9OnTUnqJEiUAZHzRmJubA8h4OkCZjo6ONFZDQTg7O+P3339HYmKidIH9zJkz0NDQyNeg3h9S1apVcePGDZQrV05l+rVr1/Ds2TPMnj1buhMs62DhH4KTkxOcnJwwcuRIdO/eHWvWrIGvry/c3Nxw9OhRlXdZlitXDjo6Ojh9+rT0RZ6SkoKLFy9KXWWp4uzsDF1dXURHR6vsRoqIiIg+vidPnqBjx45IS0uDEAJlypTB2rVroampia1bt2LUqFFITU1FSkoKxowZAy8vr6JuMhERERFRofz44484ffo0UlNTUbNmTaxatQoAsHz5cmzYsAFCCFSqVAm7du2Sbs7du3cvZs+eDS0tLZQsWRL79++XbvgNCQlBz549ER8fDyEENm/ejF9//RVt27YtsmWkLwcDGWrG3NwcxYoVw4oVK1CyZElER0djwoQJUnq5cuVga2uLKVOm4KeffkJkZCTmzZsnm4eDgwMSEhJw9OhRVKlSBQYGBvnqkqpHjx6YPHkyAgICMGXKFMTGxmL48OHo1auX1PXTpzJ+/Hh4e3tj6NCh6N+/PwwNDaUBxhctWgQ7Ozvo6Ohg0aJFGDRoEK5fv47p06d/sPqTkpIwduxYdOrUCY6Ojnj06BFCQ0Ol8UsmTpyIypUrY8iQIRg0aBB0dHRw/PhxdO7cGcWLF8fgwYMxduxYWFhYwM7ODnPmzMGbN2/Qt2/fHOs0NjbGmDFjMHLkSKSnp6NOnTqIj4/H2bNnYWRkhICAgA+2fERERKRamTJlcOXKFZVpjRs3xqVLl/KcR3Bw8AduFRERERHRh7dy5UqV0ydPnozJkyerTOvXrx/69eunMq1BgwZ49OjRB2sfkTKNom4AyWloaGDz5s24dOkSXF1dMXLkSAQFBUnp2tra2LRpE27duoUqVarg559/xk8//SSbR61atTBo0CB07doVJUqUwJw5c/JVt4GBAQ4dOoS4uDh4eXmhU6dOaNSoERYvXvxBlzE/3NzccOLECURGRqJu3brw8PDAjz/+KD3uVqJECQQHB2Pbtm1wdnbG7NmzMXfu3A9Wv6amJp4/fw5/f384OTmhS5cuaNGihfQEhpOTE/766y+Eh4ejevXqqFmzJnbv3g0trYzY4OzZs9GxY0f06tULVatWxT///INDhw5JT9HkZPr06Zg0aRJmzZqFSpUqoVmzZti7dy8cHR0/2LIRERERERERERERfU4UQnmwBSL6rMXHx8PU1BQ9g/ZBR7/gY5kQERF9DVYNbVDUTSD67GWed75aXBYm+ppF3RwiIiJSpc/tom4B0QfDJzKIiIiIiIiIiIiIiEhtMZBB7+XUqVMwMjLK8aXOXFxccmz3hg0birp5RERERERERERERAQO9k3vydPTE2FhYUXdjELZv38/UlJSVKZ96sHNiYiIiIiIiIiIiEg1BjLovejr66NcuXJF3YxCsbe3L+omEBEREREREREREVEe2LUUERERERERERERERGpLYUQQhR1I4jow4iPj4epqSlevXoFExOTom4OEREREX2heN5JRERERJ8Sn8ggIiIiIiIiIiIiIiK1xUAGERERERERERERERGpLQYyiIiIiIiIiIiIiIhIbTGQQUREREREREREREREaouBDCIiIiIiIiIiIiIiUltaRd0AIvrwhq44BR19w6JuBhFRvq0a2qCom0BERIWxriqgr1nUrSAiIip6fW4XdQuIvmh8IoOIiIiIiIiIiIiIiNQWAxlERERERERERERERKS2GMggIiIiIiIiIiIiIiK1xUAGERERERERERERERGpLQYyiIiIiIiIiIiIiIhIbTGQQUREREREREREREREaouBDCIiIiIiIiIiIiIiUlsMZBARERERERERERERkdpiIIMAAA4ODvjll1+KuhlEREQqNW3aFG5ubnB3d0fdunURFhYGALh48SJq1qwJDw8PVKpUCXPmzJHKBAYGonTp0nB3d4e7uzvGjh1bRK0nIiIiIqKv3cGDB+Hp6Qk3Nzd4e3sjPDwcANCnTx9UqFAB7u7uqFevnvRfR1lISAg0NTWxePHibGm3b9+GgYEBxowZ87EXgahIMZDxlQkODoaZmVlRN+OT+VyXNyQkBAqFAi9fvizqphARqYWtW7fi6tWrCAsLw+jRo9GnTx8AQP/+/TFx4kRcuXIFZ86cwdy5c3Hz5k2p3IQJExAWFoawsDAEBQUVVfOJiIiIiOgr9uLFC/Ts2RPr1q3D1atX8fPPP6NHjx4AgPbt2+PGjRsICwvDuHHj0KVLF1nZ169fY/z48WjRokW2+aalpWHgwIFo3779p1gMoiLFQAZ9NMnJyUXdBCIi+kIoB6VfvXoFDY3/O4XJDPomJiZCR0cHFhYWn7h1REREREREObt79y4sLS1RqVIlAED9+vXx4MEDXL58GW3btoWWlhYAwNvbGw8ePEB6erpUdtSoURg7diyKFy+ebb6zZ89G69at4eTk9GkWhKgIMZDxmTl48CDq1KkDMzMzFCtWDK1bt8bdu3cBqL6LPywsDAqFAvfv30dISAh69+6NV69eQaFQQKFQYMqUKVLeN2/eoE+fPjA2NoadnR1WrFghq/vatWto2LAh9PX1UaxYMQwYMAAJCQlSemBgINq3b49Zs2bBxsYmX1+iDg4OmD59Ovz8/GBkZAQbGxssWrRIlic6Ohrt2rWDkZERTExM0KVLFzx58kRKDw8Ph4+PD4yNjWFiYoJq1arh4sWLeS5vTt69e4dx48bB1tYWurq6KF++PFatWiWlnzhxAtWrV4euri5KliyJCRMmIDU1VbZMWbvpcnd3l9WtUCiwcuVK+Pr6wsDAAOXLl8eePXsAAPfv34ePjw8AwNzcHAqFAoGBgTm2NT4+XvYiIvpS+fv7w9bWFj/88AN+//13AMCaNWvw448/ws7ODk5OTpg1axasra2lMv/73//g5uaG1q1bq3xEm4iI8ofnnURERIVXvnx5xMbG4vz58wCAXbt2ISEhAffv35flW7BgAVq2bCnduHXgwAG8fPkSnTp1yjbPq1ev4tChQxg5cuRHbz+ROmAg4zOTmJiIUaNGITQ0FEePHoWGhgZ8fX1lkdqc1KpVC7/88gtMTEwQExODmJgYWf958+bNg6enJ65cuYIhQ4Zg8ODBuHXrFoCMIEfz5s1hbm6O0NBQbNu2DUeOHMGwYcNkdRw9ehQRERE4fPgw9u3bl69lCgoKgpubGy5fvoyJEydi5MiROHz4MABACIH27dsjLi4OJ06cwOHDh3H37l107dpVKt+jRw+ULl0aoaGhuHTpEiZMmABtbe08lzcn/v7+2Lx5MxYuXIiIiAgsW7YMRkZGAIB///0XLVu2hJeXF8LDw7F06VKsWrUKP/30U76WVdnUqVPRpUsXXL16FS1btkSPHj0QFxcHW1tb7NixA0BGP4cxMTFYsGCBynnMmjULpqam0svW1rbA7SAi+lysXbsWDx8+xE8//SSNdxEUFISgoCBER0fjxo0b+P7773H79m0AwIwZM/DPP//g6tWr6Nu3L1q0aCELwBMRUf7xvJOIiKjwTE1NsWPHDkyYMAHVqlVDSEgInJ2doa2tLeVZv349tm7diuXLlwPIePJ8woQJWLJkSbb5paSkoH///li2bBk0NTU/2XIQFSWtom4AFUzHjh1ln1etWgVLS0tZf+A50dHRgampKRQKhexu1UwtW7bEkCFDAADjx4/H/PnzERISgooVK2LDhg1ISkrC2rVrYWhoCABYvHgx2rRpg59//hlWVlYAAENDQ6xcuRI6Ojr5XqbatWtjwoQJAAAnJyecOXMG8+fPR5MmTXDkyBFcvXoVUVFR0p+ldevWwcXFBaGhofDy8kJ0dDTGjh2LihUrAsiIcmfKbXlVuXPnDrZu3YrDhw+jcePGAIAyZcpI6b/++itsbW2xePFiKBQKVKxYEf/99x/Gjx+PSZMmybo6yUtgYCC6d+8OAJg5cyYWLVqECxcuoHnz5lK3KJaWlrmO8TFx4kSMGjVK+hwfH88/lUT0xQsICMCgQYPw5MkT7Nq1Cxs2bACQ8X1do0YNnD17FhUqVECpUqWkMr6+vpgwYQJu376NatWqFVXTiYg+WzzvJCIiej/16tVDSMj/Y+/Ow2u6+v//v04SGYgEERIViZCQOZSaCdIaW6mqeYxyu0vVWNyoUEUNLYoaSqLqYyzaqqGEpEpRaU2V2xxp70ZNlRCqSH5/+Nlfp4kpIid4Pq7rXM3Za6+132vntF05773WipN0a6ajm5ubsdTUsmXLNHr0aMXGxqpEiRKSpIMHDyolJUUvvPCCJOncuXP6+uuvdfbsWXXv3l3Hjx9X06ZNJd1KemRmZurPP/80W1UEeJowI+MJc/z4cbVv317e3t5ycnJS2bJlJd1afulRBQcHGz/f/vL/zJkzkqTExESFhIQYSQzpVgIiIyPDePJVkoKCgh4qiSFJNWrUyPI+MTHRuK6Hh4fZH0n+/v4qUqSIcc6AAQP0xhtvKDw8XBMmTDCW2sqJvXv3ytraWvXq1cu2PDExUTVq1JDJZDKO1apVS5cvX9Zvv/32UNe6834XKlRIhQsXNu73g7Kzs5OTk5PZCwCeNmlpafr999+N96tXr5aLi4uKFy8ue3t7xcfHS7o1sN+5c6cCAwMlyey/yzt37tT58+dVvnz5vA0eAJ4SjDsBAHg0KSkpxs/vvfeeGjRooPLly2v58uUaMWKENm/erDJlyhjn1K5dW2fOnFFSUpKSkpLUqlUrjR49WqNHj1aZMmV07tw5o6xfv37q0aMHSQw81ZiR8YR5+eWX5eHhoXnz5qlUqVLKyMhQYGCg/v77b2P5o8zMTOP869evP3Dbd05nk24lM24vWZWZmWn25f0/z7vtzkTHo7jd5t2ue+fxqKgotW/fXt98843Wr1+vUaNGaenSpXr11Vcf+roODg73LM8untv3+/ZxKysrs9+BlP3v4V73GwDw/6Smpuq1117T1atXZWVlJVdXV61du1bW1tZavny5BgwYoBs3buj69esaNGiQqlatKunWzLc//vhD1tbWcnBw0IoVK+Ts7Gzh3gAAAAB4Fo0cOVLff/+9bty4oRo1ahhJhw4dOsjNzU0tWrQwzo2NjZWLi4ulQgXyJRIZT5Dz588rMTFRc+bMUZ06dSRJ33//vVHu6uoq6VaGt2jRopKUZWNTW1tb3bx586Gv7e/vr4ULFyo9Pd1IVmzfvl1WVlYPtKn3vdze6OjO97eXifL391dycrJ+/fVXY1bGoUOHlJqaaky/k24tSeXr66v+/furXbt2io6O1quvvvrQ/Q0KClJGRobi4+ONpaXu5O/vry+++MIsobFjxw4VLlzYWMLE1dXVLMuelpamkydPPnAMkoxZLTn5XQHA08bDw0O7d+/Otiw8PFwJCQnZlm3evPlxhgUAAAAAD+zTTz/N9viDPoQcExNz17KoqKgcRAQ8WVha6glStGhRubi4aO7cuTp27Ji2bNlitk5t+fLl5eHhoaioKB05ckTffPONpkyZYtaGl5eXLl++rNjYWJ07d05Xrlx5oGt36NBB9vb26tKliw4ePKitW7fqrbfeUqdOnYz9MXJq+/btmjhxoo4cOaKZM2dqxYoVevvttyXd+oIqODhYHTp00E8//aTdu3erc+fOqlevnqpUqaKrV6+qT58+iouL06lTp7R9+3b9+OOPRpLjYfvr5eWlLl26KDIyUmvWrNHJkycVFxen5cuXS5LefPNN/frrr3rrrbf03//+V19++aVGjRqlAQMGGPtjNGjQQIsWLdK2bdt08OBBdenS5aE3XvL09JTJZNLatWt19uxZNqcFAAAAAAAA8MwikfEEsbKy0tKlS5WQkKDAwED1799fkyZNMsoLFCigJUuW6L///a9CQkL0wQcfaOzYsWZt1KxZU7169VKbNm3k6uqqiRMnPtC1CxYsqI0bN+rChQuqWrWqWrVqpYYNG2rGjBmP3K+BAwcqISFBlSpV0nvvvacpU6aoUaNGkm4tt7RmzRoVLVpUdevWVXh4uLy9vbVs2TJJkrW1tc6fP6/OnTvL19dXrVu3VpMmTTR69Ogc9/eTTz5Rq1at9Oabb6pixYrq0aOH0tPTJUnPPfec1q1bp927dyskJES9evVS9+7dNWLECKP+sGHDVLduXTVv3lxNmzZVRESEypUr91D35LnnntPo0aM1dOhQlSxZUn369Hmo+gAAAAAAAADwtDBl/nMxfyAPeXl5qV+/furXr5+lQ3kqpKWlydnZWR0nrZWtQ+7sVwIAeWF+7zBLhwAAeAi3x52pM8rJyeHhZh8DAPBUijxs6QiApxozMgAAAAAAAAAAQL5FIgOPzbZt2+To6HjXFzEBAAAAAAAAAO7HxtIB4OlVpUoV7d27957nJCUl5Ukstz1ITAAAAAAAAACA/INEBh4bBwcHlS9f3tJhmMmPMQEAAAAAAAAA7o7NvoGniLHpYmqqnJycLB0OAAAAnlKMOwEAAJCX2CMDAAAAAAAAAADkWyQyAAAAAAAAAABAvkUiAwAAAAAAAAAA5FskMgAAAAAAAAAAQL5FIgMAAAAAAAAAAORbJDIAAAAAAAAAAEC+ZWPpAADkvt5zt8nWoZClw8ATYn7vMEuHAAAAnlSLKksO1paOAgDyXuRhS0cAAM8UZmQAAAAAAAAAAIB8i0QGAAAAAAAAAADIt0hkAAAAAAAAAACAfItEBgAAAAAAAAAAyLdIZAAAAAAAAAAAgHyLRAYAAAAAAAAAAMi3SGQAAAAAAAAAAIB8i0QGnhhJSUkymUzau3evcWz79u0KCgpSgQIFFBERYbHYsmMymbRmzRpLhwE8kr59+8rLy0smk0kHDx40jtesWVOhoaEKDQ1VYGCgTCaT9u/fL0k6evSoXnzxRYWEhCggIEDLli2zVPgAAAAAYBHXrl1Tnz595OPjo4CAAHXs2FGSFBYWJm9vb+PvqY8++ihL3bi4OFlbW2vGjBnGsW+++UZVqlSRnZ2dBg0alGf9AID8wsbSAQCPYsCAAQoNDdX69evl6OioqKgorVmzxizZkRseV7tAfteqVSu98847ql27ttnxHTt2GD+vXLlSo0ePVnBwsCSpa9eu6tGjh7p27ao//vhDVatWVe3atfXcc8/laewAAAAAYClDhw6VlZWVjhw5IpPJpJSUFKNs+vTpat68ebb1Ll26pCFDhqhJkyZmx318fDR//nytWLFCf/3112ONHQDyI2Zk4Il2/PhxNWjQQKVLl1aRIkUsHQ7w1Klbt65Kly59z3MWLFig7t27G+/37dunpk2bSpJKliypkJAQZmUAAAAAeGakp6crOjpa48aNk8lkkiS5u7s/UN0BAwZo8ODBKl68uNlxX19fhYSEyMaGZ5IBPJtIZCDPrVy5UkFBQXJwcJCLi4vCw8OVnp4uSYqOjpafn5/s7e1VsWJFzZo1K9s2bi8zdf78eUVGRspkMikmJkajR4/Wvn37ZDKZjGOSlJqaqp49e6pEiRJycnJSgwYNtG/fPknS2bNn5ebmpnHjxhnt79q1S7a2tvr222/v2e7D+N///qc2bdqoaNGicnFxUYsWLZSUlGSUd+3aVREREZo8ebLc3d3l4uKi3r176/r163dt89q1a0pLSzN7AXnpf//7n+Li4oxp0pJUtWpVff7555JuJRt37Nhh9lkHAABPHsadAPDgjh8/LhcXF40dO1ZVqlRRnTp1FBsba5QPHjxYQUFBatOmjU6cOGEcX79+vS5evKhWrVpZImwAyNdI4yJPpaSkqF27dpo4caJeffVVXbp0Sdu2bVNmZqbmzZunUaNGacaMGapUqZJ+/vln9ejRQ4UKFVKXLl3M2vHw8FBKSooqVKigMWPGqE2bNnJ2dtbBgwe1YcMGbd68WZLk7OyszMxMNWvWTMWKFdO6devk7OysOXPmqGHDhjpy5IhcXV21YMECRURE6KWXXlLFihXVsWNHvfnmm3rppZd09erVbNt9GFeuXFH9+vVVp04dfffdd7KxsdHYsWPVuHFj7d+/X7a2tpKkrVu3yt3dXVu3btWxY8fUpk0bhYaGqkePHtm2O378eI0ePfphfw1AromJiVHz5s3NnhaKiYnRoEGDFBoaKm9vb4WHh6tAgQIWjBIAADwqxp0A8OCuX7+uEydOyN/fXxMmTNC+ffsUHh6uQ4cOadGiRfLw8FBmZqZmzpyp5s2b69ChQ7p48aKGDh2qTZs2WTp8AMiXSGQgT6WkpOjGjRtq2bKlPD09JUlBQUGSpPfee09TpkxRy5YtJUlly5bVoUOHNGfOnCyJDGtra7m5uclkMsnZ2Vlubm6SJEdHR9nY2BjvJWnLli06cOCAzpw5Izs7O0nS5MmTtWbNGq1cuVI9e/ZU06ZN1aNHD3Xo0EFVq1aVvb29JkyYIElycHDItt2HsXTpUllZWenTTz81ppVGR0erSJEiiouL00svvSRJKlq0qGbMmCFra2tVrFhRzZo1U2xs7F0TGcOGDdOAAQOM92lpafLw8MhRjMDDyszMVHR0tGbOnGl23NPTUytWrDDeN27c2PiMAwCAJxPjTgB4cJ6enrKyslKHDh0kSSEhISpbtqx++eUXhYWFSZJMJpP69OmjQYMG6fz580pMTFRKSopeeOEFSdK5c+f09ddf6+zZsySSAUAkMpDHQkJC1LBhQwUFBalRo0Z66aWX1KpVK924cUO//vqrunfvbval/Y0bNx569sM/JSQk6PLly3JxcTE7fvXqVR0/ftx4P3nyZAUGBmr58uXas2eP7O3tH+m6/4zh2LFjKly4sNnxv/76yyyGgIAAWVtbG+/d3d114MCBu7ZrZ2dnJGeAvBYfH6+///5bL774otnxP/74QyVKlJDJZNLGjRt16NAhtW/f3kJRAgCA3MC4EwAeXPHixdWwYUNt3LhRTZs21alTp3Ty5EmVK1dOf/zxh0qWLClJ+uKLL1SyZEm5uLiodu3aOnPmjNFG165dVaVKFfXp08dS3QCAfIVEBvKUtbW1Nm3apB07dujbb7/Vxx9/rOHDh+vrr7+WJM2bN0/VqlXLUudRZGRkyN3dXXFxcVnK7twg/MSJE/r999+VkZGhU6dOKTg4+JGu+88Ynn/+eS1evDhLmaurq/HzP5ffMZlMysjIyLU4gIfVu3dvffnllzp9+rTCw8Pl6OioY8eOSZLmz5+vbt26ycrKfLulr7/+WhMmTJCNjY3c3d21bt06OTg4WCJ8AAAAALCI2bNnKzIyUkOGDJG1tbXmzp2rYsWKqV69erp27ZqsrKxUvHhxffXVVw/U3u29CdPS0pSZmamlS5dq1qxZeuWVVx5zTwAgfyCRgTxnMplUq1Yt1apVS++++648PT21fft2Pffcczpx4oQx9TInbG1tdfPmTbNjlStX1unTp2VjYyMvL69s6/3999/q0KGD2rRpo4oVK6p79+46cOCA8ZREdu0+jMqVK2vZsmXGZuPAk2LmzJlZlo66bdGiRdkef+ONN/TGG288zrAAAAAAIF/z9vbO9oHKPXv2PFD9mJgYs/dhYWH67bffciEyAHgyWd3/FCD37Nq1S+PGjdOePXuUnJysVatW6ezZs/Lz81NUVJTGjx+vadOm6ciRIzpw4ICio6P14YcfPnD7Xl5eOnnypPbu3atz587p2rVrCg8PV40aNRQREaGNGzcqKSlJO3bs0IgRI4wBxPDhw5Wamqrp06frnXfekZ+fn7p3737Pdh9Ghw4dVLx4cbVo0ULbtm3TyZMnFR8fr7fffpuBCAAAAAAAAADcA4kM5CknJyd99913atq0qXx9fTVixAhNmTJFTZo00RtvvKFPP/1UMTExCgoKUr169RQTE6OyZcs+cPuvvfaaGjdurPr168vV1VVLliyRyWTSunXrVLduXUVGRsrX11dt27ZVUlKSSpYsqbi4OE2dOlWLFi2Sk5OTrKystGjRIn3//ff65JNP7truwyhYsKC+++47lSlTRi1btpSfn58iIyN19epVZmgAAAAAAAAAwD2YMjMzMy0dBIDckZaWJmdnZ3WctFa2DoUsHQ6eEPN7h1k6BAAA8IS5Pe5MnVFOTg6PtqcdADyRIg9bOgIAeKYwIwMAAAAAAAAAAORbJDKAHFi8eLEcHR2zfQUEBFg6PAAAAAAAAAB4athYOgDgSfTKK6+oWrVq2ZYVKFAgj6MBAAAAAAAAgKcXiQwgBwoXLqzChQtbOgwAAAAAAAAAeOqxtBQAAAAAAAAAAMi3TJmZmZmWDgJA7khLS5Ozs7NSU1Pl5ORk6XAAAADwlGLcCQAAgLzEjAwAAAAAAAAAAJBvkcgAAAAAAAAAAAD5FokMAAAAAAAAAACQb5HIAAAAAAAAAAAA+RaJDAAAAAAAAAAAkG/ZWDoAALmv99xtsnUoZOkwgCfO/N5hlg4BAIAny6LKkoO1paMAgLwVedjSEQDAM4cZGQAAAAAAAAAAIN8ikQEAAAAAAAAAAPItEhkAAAAAAAAAACDfIpEBAAAAAAAAAADyLRIZAAAAAAAAAAAg3yKRAQAAAAAAAAAA8i0SGQAAAAAAAAAAIN96ohMZXl5emjp1ap5dz2Qyac2aNXctT0pKkslk0t69eyVJcXFxMplMunjxYp7E96j+eT/v118AAAAAAAAAAB63JzqRkd/VrFlTKSkpcnZ2liTFxMSoSJEilg3qIaSkpKhJkyaWDuOp9aR9HoBn3V9//aWIiAj5+voqNDRUjRs3VlJSkiQpMzNTUVFR8vX1VWBgoMLCwrLUj4uLk7W1tWbMmJG3gQMAAADIU9euXVOfPn3k4+OjgIAAdezYUZIUFhYmb29vhYaGKjQ0VB999JFR58qVK2rXrp3Kly8vX19frVq1yig7f/68IiIiFBwcLD8/P3Xp0kVXr17N834BgCXZWDqAvHb9+nUVKFAgT65la2srNze3PLnW4/Akxw4Aj0PPnj3VpEkTmUwmzZgxQz179tS3336r6dOn68CBAzp48KBsbW2VkpJiVu/SpUsaMmQIyWEAAADgGTB06FBZWVnpyJEjMplMZn8fTJ8+Xc2bN89SZ/LkybKzs9OxY8d08uRJ1ahRQ/Xr11fRokU1duxYeXt7a82aNbp586aaNWum6Ohovfnmm3nZLQCwKIvPyFi5cqWCgoLk4OAgFxcXhYeHKz09XWFhYerXr5/ZuREREeratavZsUuXLql9+/ZydHRUqVKl9PHHH5uVm0wmzZ49Wy1atFChQoU0duxYSdLXX3+t559/Xvb29vL29tbo0aN148YNo97Ro0dVt25d2dvby9/fX5s2bcoS++7du1WpUiXZ29urSpUq+vnnn83K71xaKi4uTt26dVNqaqpMJpNMJpOioqLue3+8vLw0duxYde7cWY6OjvL09NSXX36ps2fPqkWLFnJ0dFRQUJD27NljVm/Hjh2qW7euHBwc5OHhob59+yo9Pd0oP3PmjF5++WU5ODiobNmyWrx4cZZr/3NpqSFDhsjX11cFCxaUt7e3Ro4cqevXrxvlUVFRCg0N1aJFi+Tl5SVnZ2e1bdtWly5dum8/JSkjI0MffPCBypcvLzs7O5UpU0bvv/++UX7gwAE1aNDA+Kz07NlTly9fNsq7du2qiIgIjRs3TiVLllSRIkWM3+vgwYNVrFgxlS5dWgsWLDDq3F4ObPny5apTp44cHBxUtWpVHTlyRD/++KOqVKkiR0dHNW7cWGfPnjWLNzo6Wn5+frK3t1fFihU1a9asLO2uWrVK9evXV8GCBRUSEqIffvhBku75eZg1a5Z8fHxkb2+vkiVLqlWrVg90/wA8Xvb29mratKlMJpMkqXr16jpx4oQkadKkSfrggw9ka2srSXJ3dzerO2DAAA0ePFjFixfP26ABAAAA5Kn09HRFR0dr3Lhxxt8O//z7IDvLli1T7969JUlly5ZV3bp19eWXXxrlly5dUkZGhv7++29duXJFpUuXfjwdAIB8yqKJjJSUFLVr106RkZFKTExUXFycWrZsqczMzAduY9KkSQoODtZPP/2kYcOGqX///lmSDqNGjVKLFi104MABRUZGauPGjerYsaP69u2rQ4cOac6cOYqJiTG+NM/IyFDLli1lbW2tnTt3avbs2RoyZIhZm+np6WrevLkqVKighIQERUVFadCgQXeNs2bNmpo6daqcnJyUkpKilJSUe55/p48++ki1atXSzz//rGbNmqlTp07q3LmzOnbsqJ9++knly5dX586djft24MABNWrUSC1bttT+/fu1bNkyff/99+rTp4/RZteuXZWUlKQtW7Zo5cqVmjVrls6cOXPPOAoXLqyYmBgdOnRI06ZN07x588ymQUrS8ePHtWbNGq1du1Zr165VfHy8JkyY8ED9HDZsmD744AONHDlShw4d0v/93/+pZMmSkm5NsWzcuLGKFi2qH3/8UStWrNDmzZvN+iRJW7Zs0e+//67vvvtOH374oaKiotS8eXMVLVpUu3btUq9evdSrVy/9+uuvZvVGjRqlESNG6KeffpKNjY3atWund955R9OmTdO2bdt0/Phxvfvuu8b58+bN0/Dhw/X+++8rMTFR48aN08iRI7Vw4UKzdocPH65BgwZp79698vX1Vbt27XTjxo27fh727Nmjvn37asyYMTp8+LA2bNigunXr3vWeXbt2TWlpaWYvAHlj+vTpevnll5WWlqazZ89q9erVql69uqpXr65ly5YZ561fv14XL14kKQkAeKIx7gSAB3P8+HG5uLho7NixqlKliurUqaPY2FijfPDgwQoKClKbNm2MB6MkKTk5WZ6ensZ7Ly8vJScnS5JGjhypY8eOyc3NTSVKlJCfn59eeeWVvOsUAOQDFl1aKiUlRTdu3FDLli2N/1gHBQU9VBu1atXS0KFDJUm+vr7avn27PvroI7344ovGOe3bt1dkZKTxvlOnTho6dKi6dOkiSfL29tZ7772nd955R6NGjdLmzZuVmJiopKQkI8M9btw4syVBFi9erJs3b2rBggUqWLCgAgIC9Ntvv+nf//53tnHa2trK2dlZJpPpoZdsatq0qf71r39Jkt5991198sknqlq1ql5//XVJt2ZK1KhRQ3/88Yfc3Nw0adIktW/f3pjR4uPjo+nTp6tevXr65JNPlJycrPXr12vnzp2qVq2aJGn+/Pny8/O7ZxwjRowwfvby8tLAgQO1bNkyvfPOO8bxjIwMxcTEqHDhwpJu3evY2FizmRXZuXTpkqZNm6YZM2YYv5dy5cqpdu3akm7d76tXr+qzzz5ToUKFJEkzZszQyy+/rA8++MBIeBQrVkzTp0+XlZWVKlSooIkTJ+rKlSv6z3/+I+lWsmTChAnavn272rZta1x/0KBBatSokSTp7bffVrt27RQbG6tatWpJkrp3766YmBjj/Pfee09TpkxRy5YtJd16WuJ2Uux2/LfbbdasmSRp9OjRCggI0LFjx1SxYsVsPw/JyckqVKiQmjdvrsKFC8vT01OVKlW6630bP368Ro8efc97CyD3jRs3TkePHtXs2bN19epV/f3337p69ap27typ5ORk1ahRQwEBASpdurSGDh2a7aw+AACeJIw7AeDBXL9+XSdOnJC/v78mTJigffv2KTw8XIcOHdKiRYvk4eGhzMxMzZw5U82bN9ehQ4eMurdncEgye8h3xYoVCg4O1ubNm3XlyhW98soriomJybJqCQA8zSw6IyMkJEQNGzZUUFCQXn/9dc2bN09//vnnQ7VRo0aNLO8TExPNjlWpUsXsfUJCgsaMGSNHR0fj1aNHD6WkpOjKlStKTExUmTJlzKbp/fM6iYmJCgkJUcGCBe96Tm4JDg42fr79hf2dCZ/bx27PqEhISFBMTIxZ/xo1aqSMjAydPHlSiYmJsrGxMbsvFStWvO/G0ytXrlTt2rXl5uYmR0dHjRw50ng64DYvLy8jiSHdmj55v5ke0q37ee3aNTVs2PCu5SEhIUYSQ7qVxMrIyNDhw4eNYwEBAbKy+n8f65IlS5rdK2tra7m4uGSJ6UHu8e06Z8+e1a+//qru3bub3eOxY8fq+PHjd2339lTSe92PF198UZ6envL29lanTp20ePFiXbly5a7nDxs2TKmpqcbrnzNNAOS+yZMna9WqVVq/fr0KFiwoFxcXOTo6Ghv4lSlTRrVq1dKePXt08OBBpaSk6IUXXpCXl5dWrlypUaNGadSoURbuBQAAD4dxJwA8GE9PT1lZWalDhw6Sbn33VbZsWf3yyy/y8PCQdCth0adPH504cULnz5+XdOvviKSkJKOdU6dOqUyZMpKkjz/+WB06dJC1tbUKFy6sVq1aaevWrXnbMQCwMIsmMqytrbVp0yatX79e/v7++vjjj1WhQgWdPHlSVlZWWZaYunM/hnu5M4MtyezLb+nWrIHRo0dr7969xuvAgQM6evSo7O3ts13a6p9tPszyV4/qzs3Jb8eR3bGMjAzjn//617/M+rdv3z4dPXpU5cqVM2L/Z5/uZefOnWrbtq2aNGmitWvX6ueff9bw4cP1999/3zXW29e4Hde9ODg43LM8MzPzrvHeeTy76z9ITA9yj++8v9Kt5aXuvMcHDx7Uzp0779vuve5H4cKF9dNPP2nJkiVyd3fXu+++q5CQEF28eDHb8+3s7OTk5GT2AvD4fPjhh1qyZIk2bdpklvxt166dNmzYIEn6888/tXv3bgUHB6t27do6c+aMkpKSlJSUpFatWmn06NE80QoAeOIw7gSAB1O8eHE1bNhQGzdulHQrIXHy5EmVK1dOf/zxh3HeF198oZIlS8rFxUWS9Prrr2vmzJmSpJMnTyo+Pt5YPsrb21vr16+XdOu7sQ0bNigwMDAvuwUAFmfRpaWkW1/u1qpVS7Vq1dK7774rT09PrV69Wq6urkpJSTHOu3nzpg4ePKj69eub1f/nF8c7d+5UxYoV73nNypUr6/Dhwypfvny25f7+/kpOTtbvv/+uUqVKSZKxSfOd5yxatEhXr141voT/Zyz/ZGtrq5s3b97znNxQuXJl/fLLL3ftn5+fn27cuKE9e/bohRdekCQdPnz4rl+WS9L27dvl6emp4cOHG8dOnTqVazH7+PjIwcFBsbGxeuONN7KU+/v7a+HChUpPTzcSU9u3b5eVlZV8fX1zLY4HUbJkST333HM6ceKE8YRFTtzt82BjY6Pw8HCFh4dr1KhRKlKkiLZs2WIsYwXAMn777TcNHDhQ3t7exv+L7OzstGvXLo0bN07dunXTrFmzJN16arVy5cqWDBcAAACAhcyePVuRkZEaMmSIrK2tNXfuXBUrVkz16tXTtWvXZGVlpeLFi+urr74y6gwePFiRkZEqX768rKysNHPmTBUrVkySNG3aNPXq1UuBgYHKyMhQrVq11LdvX0t1DwAswqKJjF27dik2NlYvvfSSSpQooV27duns2bPy8/NToUKFNGDAAH3zzTcqV66cPvroo2y/aN++fbsmTpyoiIgIbdq0SStWrNA333xzz+u+++67at68uTw8PPT666/LyspK+/fv14EDBzR27FiFh4erQoUK6ty5s6ZMmaK0tDSzL/ClW/tuDB8+XN27d9eIESOUlJSkyZMn3/O6Xl5eunz5smJjY41lqe5cmiq3DBkyRNWrV1fv3r3Vo0cPFSpUSImJidq0aZMx66Vx48bq0aOH5s6dKxsbG/Xr1++esyLKly+v5ORkLV26VFWrVtU333yj1atX51rM9vb2GjJkiN555x3Z2tqqVq1aOnv2rH755Rd1795dHTp00KhRo9SlSxdFRUXp7Nmzeuutt9SpUydjKai8FBUVpb59+8rJyUlNmjTRtWvXtGfPHv35558aMGDAA7WR3edhy5YtOnHihOrWrauiRYtq3bp1ysjIUIUKFR5zjwDcT+nSpe86G6948eL6+uuv79vGnXvtAAAAAHg6eXt7Ky4uLsvxPXv23LVOoUKFtGzZsmzLypYta8zwAIBnlUWXlnJyctJ3332npk2bytfXVyNGjNCUKVPUpEkTRUZGqkuXLurcubPq1aunsmXLZpmNIUkDBw5UQkKCKlWqZGzAfHvT5rtp1KiR1q5dq02bNqlq1aqqXr26PvzwQ2PDcSsrK61evVrXrl3TCy+8oDfeeCPLZtWOjo76+uuvdejQIVWqVEnDhw/XBx98cM/r1qxZU7169VKbNm3k6uqqiRMnPuQdezDBwcGKj4/X0aNHVadOHVWqVEkjR4409miQpOjoaHl4eKhevXpq2bKlevbsqRIlSty1zRYtWqh///7q06ePQkNDtWPHDo0cOTJX4x45cqQGDhyod999V35+fmrTpo2xn0TBggW1ceNGXbhwQVWrVlWrVq3UsGFDzZgxI1djeFBvvPGGPv30U8XExCgoKEj16tVTTEyMypYt+8BtZPd5KFKkiFatWqUGDRrIz89Ps2fP1pIlSxQQEPAYewMAAAAAAAAA+ZcpMy83ewDwWKWlpcnZ2VkdJ62VrUOh+1cAYGZ+7zBLhwAAwBPh9rgzdUY5OTlYWzocAMhbkYctHQEAPHMsOiMDAAAAAAAAAADgXkhkWNC2bdvk6Oh419fTJDk5+Z59TU5OtnSIAAAAAAAAAIB8yKKbfT/rqlSpor1791o6jDxRqlSpe/a1VKlSeRcMAAAAAAAAAOCJQSLDghwcHFS+fHlLh5EnbGxsnpm+AgAAAAAAAAByD0tLAQAAAAAAAACAfMuUmZmZaekgAOSOtLQ0OTs7KzU1VU5OTpYOBwAAAE8pxp0AAADIS8zIAAAAAAAAAAAA+RaJDAAAAAAAAAAAkG+RyAAAAAAAAAAAAPkWiQwAAAAAAAAAAJBvkcgAAAAAAAAAAAD5lo2lAwCQ+3rP3SZbh0KWDgPAP8zvHWbpEAAAyF2LKksO1paOAgByT+RhS0cAAMgGMzIAAAAAAAAAAEC+RSIDAAAAAAAAAADkWyQyAAAAAAAAAABAvkUiAwAAAAAAAAAA5FskMgAAAAAAAAAAQL5FIgMAAAAAAAAAAORbJDIAAAAAAAAAAEC+RSIjF3l5eWnq1Kl5dj2TyaQ1a9bctTwpKUkmk0l79+6VJMXFxclkMunixYt5Et+j+uf9vF9/AQAAAAAAAABPHxIZz5CaNWsqJSVFzs7OkqSYmBgVKVLEskE9hJSUFDVp0sTSYQDAY/HXX38pIiJCvr6+Cg0NVePGjZWUlCRJ+vHHH1WrVi0FBwcrNDRUW7ZsMep17dpVpUuXVmhoqEJDQzV48GAL9QAAAAB4+l27dk19+vSRj4+PAgIC1LFjR0lSt27djPF61apVFRsba9T5z3/+Iz8/P4WEhOiFF14wG8+fP39eERERCg4Olp+fn7p06aKrV6/meb8AIL+zsXQAz7rr16+rQIECeXItW1tbubm55cm1HocnOfb7ycvPAYD8q2fPnmrSpIlMJpNmzJihnj17auPGjXr11Ve1aNEi1a9fX//973/14osv6siRI3JwcJAkDR06VH369LFw9AAAAMDTb+jQobKystKRI0dkMpmUkpIiSfroo4+Mh0X37t2r8PBwnT17ViaTSXXq1NHIkSPl4OCgffv2KSwsTCkpKbK3t9fYsWPl7e2tNWvW6ObNm2rWrJmio6P15ptvWrCXAJD/MCPjH1auXKmgoCA5ODjIxcVF4eHhSk9PV1hYmPr162d2bkREhLp27Wp27NKlS2rfvr0cHR1VqlQpffzxx2blJpNJs2fPVosWLVSoUCGNHTtWkvT111/r+eefl729vby9vTV69GjduHHDqHf06FHVrVtX9vb28vf316ZNm7LEvnv3blWqVEn29vaqUqWKfv75Z7PyO5eWiouLU7du3ZSamiqTySSTyaSoqKj73h8vLy+NHTtWnTt3lqOjozw9PfXll1/q7NmzatGihRwdHRUUFKQ9e/aY1duxY4fq1q0rBwcHeXh4qG/fvkpPTzfKz5w5o5dfflkODg4qW7asFi9enOXa/1xaasiQIfL19VXBggXl7e2tkSNH6vr160Z5VFSUQkNDtWjRInl5ecnZ2Vlt27bVpUuX7ttP6e6fhdsWLFiggIAA2dnZyd3d3exLxOTkZON+ODk5qXXr1vrjjz+yxLZgwQJ5e3vLzs5OmZmZSk1NVc+ePVWiRAk5OTmpQYMG2rdv3wPFC+DJZm9vr6ZNm8pkMkmSqlevrhMnTuj8+fO6cOGC6tevL0mqWLGiihQpovXr11syXAAAAOCZk56erujoaI0bN84Yt7u7u0uS2YoXFy9eNMolqUmTJsZDSEFBQbp586bOnTtnlF+6dEkZGRn6+++/deXKFZUuXToPegMATxYSGXdISUlRu3btFBkZqcTERMXFxally5bKzMx84DYmTZqk4OBg/fTTTxo2bJj69++fJekwatQotWjRQgcOHFBkZKQ2btyojh07qm/fvjp06JDmzJmjmJgYvf/++5KkjIwMtWzZUtbW1tq5c6dmz56tIUOGmLWZnp6u5s2bq0KFCkpISFBUVJQGDRp01zhr1qypqVOnysnJSSkpKUpJSbnn+Xf66KOPVKtWLf38889q1qyZOnXqpM6dO6tjx4766aefVL58eXXu3Nm4bwcOHFCjRo3UsmVL7d+/X8uWLdP3339v9sV/165dlZSUpC1btmjlypWaNWuWzpw5c884ChcurJiYGB06dEjTpk3TvHnz9NFHH5mdc/z4ca1Zs0Zr167V2rVrFR8frwkTJty3j/f7LHzyySfq3bu3evbsqQMHDuirr75S+fLlJUmZmZmKiIjQhQsXFB8fr02bNun48eNq06aN2TWOHTum5cuX64svvjD2MWnWrJlOnz6tdevWKSEhQZUrV1bDhg114cKFbOO8du2a0tLSzF4Ang7Tp0/Xyy+/rOLFi6tkyZL64osvJEm7du3SkSNHjGWnJOnDDz9UcHCwmjdvbvz3BACA3MS4EwBufcfg4uKisWPHqkqVKqpTp47ZElJDhw5VuXLl1LJlS61YscIsmXFbdHS0ypUrZyQrRo4cqWPHjsnNzU0lSpSQn5+fXnnllTzrEwA8KVha6g4pKSm6ceOGWrZsKU9PT0m3MuUPo1atWho6dKgkydfXV9u3b9dHH32kF1980Tinffv2ioyMNN536tRJQ4cOVZcuXSRJ3t7eeu+99/TOO+9o1KhR2rx5sxITE5WUlGT8j27cuHFm+0UsXrxYN2/e1IIFC1SwYEEFBATot99+07///e9s47S1tZWzs7NMJtNDL9nUtGlT/etf/5Ikvfvuu/rkk09UtWpVvf7665JuzZSoUaOG/vjjD7m5uWnSpElq3769MaPFx8dH06dPV7169fTJJ58oOTlZ69ev186dO1WtWjVJ0vz58+Xn53fPOEaMGGH87OXlpYEDB2rZsmV65513jOMZGRmKiYlR4cKFJd2617GxsUaS6G7u91kYO3asBg4cqLfffts4VrVqVUnS5s2btX//fp08eVIeHh6SpEWLFikgIEA//vijcd7ff/+tRYsWydXVVZK0ZcsWHThwQGfOnJGdnZ0kafLkyVqzZo1Wrlypnj17Zolz/PjxGj169D37AuDJM27cOB09elSzZ8+WJH355ZcaMmSI3n//fQUFBal27drGcnTvv/++3N3dZWVlpdWrV6tJkyY6evSoHB0dLdkFAMBThnEnANxaFvrEiRPy9/fXhAkTtG/fPoWHh+vQoUNydXXVhAkTNGHCBG3evFmDBw/W9u3bZWtra9SPjY3V6NGjzR54XbFihYKDg7V582ZduXJFr7zyimJiYrKsAAIAzzpmZNwhJCREDRs2VFBQkF5//XXNmzdPf/7550O1UaNGjSzvExMTzY5VqVLF7H1CQoLGjBkjR0dH49WjRw+lpKToypUrSkxMVJkyZcymFv7zOomJiQoJCVHBggXvek5uCQ4ONn4uWbKkJPMv+W8fuz2jIiEhQTExMWb9a9SokTIyMnTy5EklJibKxsbG7L7cXjrlXlauXKnatWvLzc1Njo6OGjlypJKTk83O8fLyMpIY0q0pn/eb6SHd+7Nw5swZ/f7772rYsGG2dRMTE+Xh4WEkMSTJ399fRYoUMfsseHp6GkmM2/fp8uXLcnFxMbtXJ0+e1PHjx7O91rBhw5Sammq8fv311/v2DUD+NnnyZK1atUrr1683/pseHBys9evX66efftLChQv1+++/y9/fX5L03HPPycrq1v/OX331VTk5Oenw4cMWix8A8HRi3AkAt/6Ot7KyUocOHSTd+u6gbNmy+uWXX8zOCw8P16VLl3TgwAHjWHx8vLp166avv/5aFSpUMI5//PHH6tChg6ytrVW4cGG1atVKW7duzZsOAcAThBkZd7C2ttamTZu0Y8cOffvtt/r44481fPhw7dq1S1ZWVlmWmLpzP4Z7+edUwkKFCpm9z8jI0OjRo9WyZcssde3t7bNd2uqfbT7M8leP6s5NqW/Hkd2xjIwM45//+te/1Ldv3yxtlSlTxvjCLbspl3ezc+dOtW3bVqNHj1ajRo3k7OyspUuXasqUKXeN9fY1bsd1L/f6LBQvXvyedTMzM7Ptyz+PZ/c5cHd3V1xcXJa6d0vq2NnZGbM3ADz5PvzwQy1ZskSbN282+/f+9OnTxuy5efPmqVChQmrQoIEk6bfffjMS3Tt37tT58+eNpe4AAMgtjDsBQCpevLgaNmyojRs3qmnTpjp16pROnjypcuXK6ejRo/Lx8ZF0aw/TM2fOyNvbW5L03XffqVOnTvryyy8VEhJi1qa3t7fWr1+vF154QdevX9eGDRtUt27dPO8bAOR3JDL+wWQyqVatWqpVq5beffddeXp6avXq1XJ1dVVKSopx3s2bN3Xw4EFj89Xbdu7cmeV9xYoV73nNypUr6/Dhw3f94snf31/Jycn6/fffVapUKUnSDz/8kOWcRYsW6erVq8YGUv+M5Z9sbW118+bNe56TGypXrqxffvnlrv3z8/PTjRs3tGfPHr3wwguSpMOHD+vixYt3bXP79u3y9PTU8OHDjWOnTp3K1bjv9lkYMGCAvLy8FBsbm+X3L/2/39evv/5qzMo4dOiQUlNT77lcVuXKlXX69GnZ2NjIy8srV/sCIP/77bffNHDgQHl7exv/bbGzs9OuXbs0Z84cLV68WJmZmfLz89Pq1auNxGjXrl31xx9/yNraWg4ODlqxYoWcnZ0t2RUAAADgqTV79mxFRkZqyJAhsra21ty5c1WiRAk1aNBAqampsra2VqFChbRy5UoVLVpUktS9e3ddu3ZN3bp1M9pZtGiRgoKCNG3aNPXq1UuBgYHKyMhQrVq1sn0QFACedSQy7rBr1y7FxsbqpZdeUokSJbRr1y6dPXtWfn5+KlSokAYMGKBvvvlG5cqV00cffZTtF+3bt2/XxIkTFRERoU2bNmnFihX65ptv7nndd999V82bN5eHh4def/11WVlZaf/+/Tpw4IDGjh2r8PBwVahQQZ07d9aUKVOUlpZm9gW+dGvfjeHDh6t79+4aMWKEkpKSNHny5Hte18vLS5cvX1ZsbKyxLNWdS1PlliFDhqh69erq3bu3evTooUKFCikxMVGbNm3Sxx9/rAoVKqhx48bq0aOH5s6dKxsbG/Xr189IyGSnfPnySk5O1tKlS1W1alV98803Wr16da7FfK/PgiRFRUWpV69eKlGihJo0aaJLly5p+/bteuuttxQeHq7g4GB16NBBU6dO1Y0bN/Tmm2+qXr16WZYVu1N4eLhq1KihiIgIffDBB6pQoYJ+//13rVu3ThEREfesC+DJV7p06bvOrhs1apRGjRqVbdnmzZsfZ1gAAAAA7uDt7Z3tSgrbt2+/a52jR4/etaxs2bLauHFjboQGAE819si4g5OTk7777js1bdpUvr6+GjFihKZMmaImTZooMjJSXbp0UefOnVWvXj2VLVs226fxBw4cqISEBFWqVEnvvfeepkyZokaNGt3zuo0aNdLatWu1adMmVa1aVdWrV9eHH35obDJ9ewPXa9eu6YUXXtAbb7yRZbNqR0dHff311zp06JAqVaqk4cOH64MPPrjndWvWrKlevXqpTZs2cnV11cSJEx/yjj2Y4OBgxcfH6+jRo6pTp44qVaqkkSNHyt3d3TgnOjpaHh4eqlevnlq2bKmePXuqRIkSd22zRYsW6t+/v/r06aPQ0FDt2LFDI0eOzLWY7/VZkKQuXbpo6tSpmjVrlgICAtS8eXNjYGIymbRmzRoVLVpUdevWVXh4uLy9vbVs2bJ7XtNkMmndunWqW7euIiMj5evrq7Zt2yopKcnYdwQAAAAAAAAAnjWmzLzcXAHAY5WWliZnZ2d1nLRWtg6F7l8BQJ6a3zvM0iEAAJArbo87U2eUk5ODtaXDAYDcE3nY0hEAALLBjAwAAAAAAAAAAJBvkciAYdu2bXJ0dLzr62mSnJx8z74mJydbOkQAAAAAAAAAgNjsG3eoUqWK9u7da+kw8kSpUqXu2ddSpUrlXTAAAAAAAAAAgLsikQGDg4ODypcvb+kw8oSNjc0z01cAAAAAAAAAeJKxtBQAAAAAAAAAAMi3TJmZmZmWDgJA7khLS5Ozs7NSU1Pl5ORk6XAAAADwlGLcCQAAgLzEjAwAAAAAAAAAAJBvkcgAAAAAAAAAAAD5FokMAAAAAAAAAACQb5HIAAAAAAAAAAAA+RaJDAAAAAAAAAAAkG+RyAAAAAAAAAAAAPmWjaUDAJD7es/dJluHQpYO47Ga3zvM0iEAAABgUWXJwdrSUQDAvUUetnQEAIBHxIwMAAAAAAAAAACQb5HIAAAAAAAAAAAA+RaJDAAAAAAAAAAAkG+RyAAAAAAAAAAAAPkWiQwAAAAAAAAAAJBvkcgAAAAAAAAAAAD5FokMAAAAAAAAAACQb5HIwDMhLi5OJpNJFy9evOd5Xl5emjp1aq5cMyoqSqGhobnSFh7OxYsXFRoaarx8fX1lY2OjCxcuGOcsXLhQJpNJa9eutWCkAAAAAABLu3btmvr06SMfHx8FBASoY8eOkqRx48apQoUKsrKyyvK345UrV9SuXTuVL19evr6+WrVqlVHWt29fs79J7e3tNX369DztEwA8bWwsHQDwOISFhSk0NNRIStSsWVMpKSlydnaWJMXExKhfv373TWzgyVSkSBHt3bvXeD958mTFx8erWLFikqTffvtNc+bMUfXq1S0UIQAAAAAgvxg6dKisrKx05MgRmUwmpaSkSJIaNmyoNm3aqHv37lnqTJ48WXZ2djp27JhOnjypGjVqqH79+ipatKhZ0uL06dMqW7asWrdunWf9AYCnETMy8EywtbWVm5ubTCaTpUOBBURHR5sNPHv27KmPPvpIdnZ2FowKAAAAAGBp6enpio6O1rhx44zvDNzd3SVJ1apVU7ly5bKtt2zZMvXu3VuSVLZsWdWtW1dffvlllvM+++wzNWrUSG5ubo+pBwDwbCCRgadO165dFR8fr2nTpslkMslkMikmJsZYWiouLk7dunVTamqqUR4VFZVtW6mpqerZs6dKlCghJycnNWjQQPv27ctxbNHR0fLz85O9vb0qVqyoWbNmGWVJSUkymUxatWqV6tevr4IFCyokJEQ//PDDXdu7du2a0tLSzF4w98MPP+j8+fNq3ry5JOmTTz5RQECAqlWrZuHIAAAAnhyMOwE8rY4fPy4XFxeNHTtWVapUUZ06dRQbG3vfesnJyfL09DTee3l5KTk5Oct5CxYsyHZGBwDg4ZDIwFNn2rRpqlGjhnr06KGUlBSlpKTIw8PDKK9Zs6amTp0qJycno3zQoEFZ2snMzFSzZs10+vRprVu3TgkJCapcubIaNmxottfCg5o3b56GDx+u999/X4mJiRo3bpxGjhyphQsXmp03fPhwDRo0SHv37pWvr6/atWunGzduZNvm+PHj5ezsbLzu7CduWbBggTp37iwbGxudPHlS8+bN05gxYywdFgAAwBOFcSeAp9X169d14sQJ+fv7a8+ePZoxY4batm2rs2fP3rfunas+ZGZmZinfvn270tLS1LRp01yNGQCeRSQy8NRxdnaWra2tChYsKDc3N7m5ucna2toot7W1lbOzs0wmk1Hu6OiYpZ2tW7fqwIEDWrFihapUqSIfHx9NnjxZRYoU0cqVKx86rvfee09TpkxRy5YtVbZsWbVs2VL9+/fXnDlzzM4bNGiQmjVrJl9fX40ePVqnTp3SsWPHsm1z2LBhSk1NNV6//vrrQ8f1NEtPT9eyZcsUGRkp6dbsjN9//11+fn7y8vLSzp071b17d82bN8/CkQIAAORvjDsBPK08PT1lZWWlDh06SJJCQkJUtmxZ/fLLL/esV6ZMGSUlJRnvT506pTJlypidM3/+fHXp0sXsOwkAQM6w2TdwFwkJCbp8+bJcXFzMjl+9elXHjx9/qLbOnj2rX3/9Vd27d1ePHj2M4zdu3DA2IL8tODjY+Pn2upxnzpxRxYoVs7RrZ2fHPg/3sGLFCgUHBxv3rn379mrfvr1RHhYWpkGDBhnLTgEAACB7jDsBPK2KFy+uhg0bauPGjWratKlOnTqlkydPqkKFCves9/rrr2vmzJmKiYnRyZMnFR8fr9mzZxvlly9f1sqVK5WQkPC4uwAAzwQSGcBdZGRkyN3dXXFxcVnKihQp8tBtSbeWl/rn3gz/fDKjQIECxs+3p6nero+HM3/+fNYiBQAAAADc0+zZsxUZGakhQ4bI2tpac+fOlbu7u8aPH6+ZM2fq7Nmz6tq1q+zt7fXzzz/L1dVVgwcPVmRkpMqXLy8rKyvNnDlTxYoVM9pctmyZKlWqJB8fHwv2DACeHiQy8FSytbXVzZs3c1wuSZUrV9bp06dlY2MjLy+vR4qnZMmSeu6553TixAljuioev23btt2zPLskFQAAAADg2eLt7Z3t34fDhg3TsGHDsq1TqFAhLVu27K5tdu/enQfrACAXkcjAU8nLy0u7du1SUlKSHB0ds8xo8PLy0uXLlxUbG6uQkBAVLFhQBQsWNDsnPDxcNWrUUEREhD744ANVqFBBv//+u9atW6eIiAhVqVLloWKKiopS37595eTkpCZNmujatWvas2eP/vzzTw0YMOCR+wwAAAAAAAAATyM2+8ZTadCgQbK2tpa/v79cXV2VnJxsVl6zZk316tVLbdq0kaurqyZOnJilDZPJpHXr1qlu3bqKjIyUr6+v2rZtq6SkJJUsWfKhY3rjjTf06aefKiYmRkFBQapXr55iYmJUtmzZHPcTAAAAAAAAAJ52pszMzExLBwEgd6SlpcnZ2VkdJ62VrUMhS4fzWM3vHWbpEAAAAJ5Zt8edqTPKycnB+v4VAMCSIg9bOgIAwCNiRgYAAAAAAAAAAMi3SGQAORQQECBHR8dsX4sXL7Z0eAAAAAAAAADwVGCzbyCH1q1bp+vXr2dblpM9NAAAAAAAAAAAWZHIAHLI09PT0iEAAAAAAAAAwFOPpaUAAAAAAAAAAEC+ZcrMzMy0dBAAckdaWpqcnZ2VmpoqJycnS4cDAACApxTjTgAAAOQlZmQAAAAAAAAAAIB8i0QGAAAAAAAAAADIt0hkAAAAAAAAAACAfItEBgAAAAAAAAAAyLdIZAAAAAAAAAAAgHzLxtIBAMh9veduk61DIbNj83uHWSYYAAAAPL0WVZYcrC0dBfD4RR62dAQAADzTmJEBAAAAAAAAAADyLRIZAAAAAAAAAAAg3yKRAQAAAAAAAAAA8i0SGQAAAAAAAAAAIN8ikQEAAAAAAAAAAPItEhkAAAAAAAAAACDfIpEBAAAAAAAAAADyLRIZuK+4uDiZTCZdvHjxnud5eXlp6tSpeRLT49K1a1dFRERYOow8d/HiRYWGhhovX19f2djY6MKFC5YODQAAAADyvZdeeknBwcEKDQ1VnTp1tHfvXknSnj17VKNGDVWqVEl+fn6aOHGiUWfBggUKCgqSjY2NZsyYYdbeH3/8oZYtWyo4OFgVK1Z84v/WBgDgUZHIQBZhYWHq16+f8b5mzZpKSUmRs7OzJCkmJkZFihSxTHC5JCkpSSaTyRhc3jZt2jTFxMRYJKZ/MplMWrNmTZ5cq0iRItq7d6/x6tmzp5o0aaJixYrlyfUBAAAA4Em2fPly7d+/X3v37tXAgQMVGRkpSerRo4eGDRumn3/+Wdu3b9fkyZN16NAhSdLzzz+v5cuXq3379lnaGzBggIKCgrR//37t2bNHCxYs0I8//pinfQIAID8hkYH7srW1lZubm0wmk6VDeeycnZ2f+CRNboiOjlb37t0tHQYAAAAAPBHu/DsyNTVVVlb/7+uW26sbpKeny9bW1nhgLCQkRH5+fmbn3rZv3z41a9ZMkuTo6Kh69epp0aJFj68DAADkcyQyYKZr166Kj4/XtGnTZDKZZDKZFBMTYywtFRcXp27duik1NdUoj4qKyrat1NRU9ezZUyVKlJCTk5MaNGigffv2PVAc+/btU/369VW4cGE5OTnp+eef1549e4zyHTt2qG7dunJwcJCHh4f69u2r9PR0o9zLy0vjxo1TZGSkChcurDJlymju3LlGedmyZSVJlSpVkslkUlhYmNH/O5eWCgsL01tvvaV+/fqpaNGiKlmypObOnav09HR169ZNhQsXVrly5bR+/Xqz+A8dOqSmTZvK0dFRJUuWVKdOnXTu3Dmzdvv27at33nlHxYoVk5ubm9l99PLykiS9+uqrMplMxvt/unbtmtLS0sxej+qHH37Q+fPn1bx580duCwAAAE+HxzHuBJ42nTt3loeHh0aMGKGFCxdKuvWQ2MiRI1WmTBn5+vpq/PjxcnNzu29bVatW1f/93/8pIyNDZ86c0caNG5WUlPSYewAAQP5FIgNmpk2bpho1aqhHjx5KSUlRSkqKPDw8jPKaNWtq6tSpcnJyMsoHDRqUpZ3MzEw1a9ZMp0+f1rp165SQkKDKlSurYcOGD7TvQocOHVS6dGn9+OOPSkhI0NChQ1WgQAFJ0oEDB9SoUSO1bNlS+/fv17Jly/T999+rT58+Zm1MmTJFVapU0c8//6w333xT//73v/Xf//5XkrR7925J0ubNm5WSkqJVq1bdNZaFCxeqePHi2r17t9566y39+9//1uuvv66aNWvqp59+UqNGjdSpUydduXJFkpSSkqJ69eopNDRUe/bs0YYNG/THH3+odevWWdotVKiQdu3apYkTJ2rMmDHatGmTJBlThqOjo5WSknLXKcTjx4+Xs7Oz8brzd5VTCxYsUOfOnWVjY/PIbQEAAODp8DjGncDT5rPPPtOvv/6qsWPHavDgwZKkSZMmadKkSUpOTtYvv/yi4cOH6/Dhw/dta8qUKUpLS1PlypXVuXNnNWjQwPibGACAZxGJDJhxdnaWra2tChYsKDc3N7m5ucna2toot7W1lbOzs0wmk1Hu6OiYpZ2tW7fqwIEDWrFihapUqSIfHx9NnjxZRYoU0cqVK+8bR3JyssLDw1WxYkX5+Pjo9ddfV0hIiKRbA8H27durX79+8vHxUc2aNTV9+nR99tln+uuvv4w2mjZtqjfffFPly5fXkCFDVLx4ccXFxUmSXF1dJUkuLi5yc3O7514QISEhGjFihHx8fDRs2DA5ODioePHi6tGjh3x8fPTuu+/q/Pnz2r9/vyTpk08+UeXKlTVu3DhVrFhRlSpV0oIFC7R161YdOXLEaDc4OFijRo2Sj4+POnfurCpVqig2NtYsviJFisjNzc14/0/Dhg1Tamqq8fr111/ve2/vJT09XcuWLTPWcwUAAACk3B93Ak+zLl26aOvWrfrjjz+0evVq46E2b29vVatWTTt27LhvG8WKFdOCBQu0d+9ebdiwQZLk7+//WOMGACA/45FrPBYJCQm6fPmyXFxczI5fvXpVx48fv2/9AQMG6I033tCiRYsUHh6u119/XeXKlTPaPnbsmBYvXmycn5mZqYyMDJ08eVJ+fn6SbiUKbrudeDlz5sxD9+XOdqytreXi4qKgoCDjWMmSJSXJaDshIUFbt27NNsFz/Phx+fr6ZmlXktzd3R86Pjs7O9nZ2T1UnXtZsWKFgoODVbFixVxrEwAAAE++3B53Ak+TtLQ0Xb58WaVKlZIkrV69Wi4uLipevLjs7e0VHx+vevXq6dy5c9q5c6feeeed+7Z5/vx5OTk5qUCBAvrpp5+0Zs0a/fzzz4+7KwAA5FskMvBYZGRkyN3d3ZgBcacH2Uw7KipK7du31zfffKP169dr1KhRWrp0qV599VVlZGToX//6l/r27ZulXpkyZYyf/znt1mQyKSMj46H7kl07dx67vQn67bYzMjL08ssv64MPPsjSlru7e67Hl5vmz5/PJt8AAAAA8BBSU1P12muv6erVq7KyspKrq6vWrl0ra2trLV++XAMGDNCNGzd0/fp1DRo0SFWrVpUkff755xo6dKj+/PNPffnll5owYYK+/vprVapUyVjauECBAipcuLCWL19u9vckAADPGhIZyMLW1lY3b97McbkkVa5cWadPn5aNjc1dN6q+H19fX/n6+qp///5q166doqOj9eqrr6py5cr65ZdfVL58+Ry1K93qg6T79iMnKleurC+++EJeXl6PtM9EgQIFHkt897Jt27Y8vR4AAAAAPOk8PDyMfRj/KTw8XAkJCdmWdezYUR07dsy2rEmTJjp27FiuxQgAwJOOPTKQhZeXl3bt2qWkpCSdO3cuyywBLy8vXb58WbGxsTp37pyxyfWdwsPDVaNGDUVERGjjxo1KSkrSjh07NGLECO3Zs+ee17969ar69OmjuLg4nTp1Stu3b9ePP/5oLBk1ZMgQ/fDDD+rdu7f27t2ro0eP6quvvtJbb731wH0sUaKEHBwcjI24U1NTH7ju/fTu3VsXLlxQu3bttHv3bp04cULffvutIiMjHyox4eXlpdjYWJ0+fVp//vlnrsUHAAAAAAAAAE8SEhnIYtCgQbK2tpa/v79cXV2VnJxsVl6zZk316tVLbdq0kaurqyZOnJilDZPJpHXr1qlu3bqKjIyUr6+v2rZtq6SkJGNPibuxtrbW+fPn1blzZ/n6+qp169Zq0qSJRo8eLenW3hLx8fE6evSo6tSpo0qVKmnkyJEPNc3WxsZG06dP15w5c1SqVCm1aNHigeveT6lSpbR9+3bdvHlTjRo1UmBgoN5++205OzvLyurB/5WbMmWKNm3aJA8PD1WqVCnX4gMAAAAAAACAJ4kpMzMz09JBAMgdaWlpcnZ2VsdJa2XrUMisbH7vMMsEBQAAgKfO7XFn6oxycnKwtnQ4wOMXedjSEQAA8ExjRgYAAAAAAAAAAMi3SGTAIgICAuTo6Jjta/HixZYODwAAAAAAAACQT9hYOgA8m9atW6fr169nW3a/PTQAAAAAAAAAAM8OEhmwCE9PT0uHAAAAAAAAAAB4ArC0FAAAAAAAAAAAyLdMmZmZmZYOAkDuSEtLk7Ozs1JTU+Xk5GTpcAAAAPCUYtwJAACAvMSMDAAAAAAAAAAAkG+RyAAAAAAAAAAAAPkWiQwAAAAAAAAAAJBvkcgAAAAAAAAAAAD5FokMAAAAAAAAAACQb9lYOgAAua/33G2ydShk6TBy1fzeYZYOAQAAAP+0qLLkYG3pKPC0iDxs6QgAAEA+xYwMAAAAAAAAAACQb5HIAAAAAAAAAAAA+RaJDAAAAAAAAAAAkG+RyAAAAAAAAAAAAPkWiQwAAAAAAAAAAJBvkcgAAAAAAAAAAAD5FokMAAAAAAAAAACQb5HIQI6FhYWpX79+Fm8jP4mLi5PJZNLFixctHQoAAAAAAAAAPBVIZCDHVq1apffee8/SYTyVvLy8NHXqVEuH8US5du2a+vTpIx8fHwUEBKhjx46SpD179qhGjRqqVKmS/Pz8NHHiRAtHCgAAACAnXnrpJQUHBys0NFR16tTR3r17JUlnzpxR48aN5ePjo8DAQH3//fdGnf/85z/y8/NTSEiIXnjhBW3ZssUoy8jI0FtvvaVy5cqpfPnymjVrVl53CQAAPCAbSweAJ1exYsUsHQJgGDp0qKysrHTkyBGZTCalpKRIknr06KHRo0frlVde0YULF1SxYkU1b95c/v7+Fo4YAAAAwMNYvny5ihQpIklas2aNIiMj9dNPP2no0KGqXr26NmzYoB9//FGtWrXS8ePHZWNjozp16mjkyJFycHDQvn37FBYWppSUFNnb2+vzzz/XoUOHdOTIEaWmpqpy5cpq0KCBKlasaNmOAgCALJiRgRy7c1moWbNmycfHR/b29ipZsqRatWqVozY3bNggZ2dnffbZZ5Kkrl27KiIiQpMnT5a7u7tcXFzUu3dvXb9+3ajz559/qnPnzipatKgKFiyoJk2a6OjRo5KkzMxMubq66osvvjDODw0NVYkSJYz3P/zwgwoUKKDLly9Lkkwmkz799FO9+uqrKliwoHx8fPTVV189VD+2b9+ukJAQ2dvbq1q1ajpw4IBZ+RdffKGAgADZ2dnJy8tLU6ZMMcrCwsJ06tQp9e/fXyaTSSaT6aGu/SxKT09XdHS0xo0bZ9wvd3d3o/z2Ul/p6emytbUlCQcAAAA8gW4nMSQpNTVVVla3vtJYvny5evfuLUmqWrWqSpYsaczKaNKkiRwcHCRJQUFBunnzps6dOydJWrZsmXr16iVra2sVK1ZMrVu31tKlS/OwRwAA4EGRyMAj27Nnj/r27asxY8bo8OHD2rBhg+rWrfvQ7SxdulStW7fWZ599ps6dOxvHt27dquPHj2vr1q1auHChYmJiFBMTY5R37dpVe/bs0VdffaUffvhBmZmZatq0qa5fvy6TyaS6desqLi5O0q2kx6FDh3T9+nUdOnRI0q19LZ5//nk5OjoabY4ePVqtW7fW/v371bRpU3Xo0EEXLlx44L4MHjxYkydP1o8//qgSJUrolVdeMZIvCQkJat26tdq2basDBw4oKipKI0eONPq0atUqlS5dWmPGjFFKSooxsyA7165dU1pamtnrWXT8+HG5uLho7NixqlKliurUqaPY2FhJUnR0tEaOHKkyZcrI19dX48ePl5ubm4UjBgAAeLIw7kR+0blzZ3l4eGjEiBFauHChzp8/r4yMDLm6uhrneHl5KTk5OUvd6OholStXTqVLl5YkJScny9PT8771AACA5ZHIwCNLTk5WoUKF1Lx5c3l6eqpSpUrq27fvQ7Uxa9Ys9erVS19++aVatGhhVla0aFHNmDHDWBKoWbNmxpfUR48e1VdffaVPP/1UderUUUhIiBYvXqz//e9/WrNmjaRbMxxuJzK+++47hYSEqEGDBsaxuLg4hYWFmV2za9euateuncqXL69x48YpPT1du3fvfuD+jBo1Si+++KKCgoK0cOFC/fHHH1q9erUk6cMPP1TDhg01cuRI+fr6qmvXrurTp48mTZok6daSXdbW1ipcuLDc3Nzu+aX7+PHj5ezsbLw8PDweOManyfXr13XixAn5+/trz549mjFjhtq2bauzZ89q0qRJmjRpkpKTk/XLL79o+PDhOnz4sKVDBgAAeKIw7kR+8dlnn+nXX3/V2LFjNXjwYEnKMos9MzMzS73Y2FiNHj06y4yLO+tmVw8AAOQPJDLwyF588UV5enrK29tbnTp10uLFi3XlypUHrv/FF1+oX79++vbbb1W/fv0s5QEBAbK2tjbeu7u768yZM5KkxMRE2djYqFq1aka5i4uLKlSooMTEREm3Ehm//PKLzp07p/j4eIWFhSksLEzx8fG6ceOGduzYoXr16pldMzg42Pi5UKFCKly4sHHNB1GjRg3j52LFipnFk5iYqFq1apmdX6tWLR09elQ3b9584GtI0rBhw5Sammq8fv3114eq/7Tw9PSUlZWVOnToIEkKCQlR2bJlFR8fr9WrV6t169aSJG9vb1WrVk07duywZLgAAABPHMadyG+6dOmirVu3Gu/Pnj1r/Hzq1CmVKVPGeB8fH69u3brp66+/VoUKFYzjZcqUUVJS0l3rAQCA/INEBh5Z4cKF9dNPP2nJkiVyd3fXu+++q5CQEGNfgvsJDQ2Vq6uroqOjs30CpkCBAmbvTSaTMjIyJN39iZnMzEzjyZrAwEC5uLgoPj7eSGTUq1dP8fHx+vHHH3X16lXVrl37ga+ZU7fjuTO2O+PNCTs7Ozk5OZm9nkXFixdXw4YNtXHjRkm3/gA5efKkatSoIXt7e8XHx0uSzp07p507dyowMNCS4QIAADxxGHfC0tLS0vT7778b71evXi0XFxcVK1ZMr7/+umbOnClJ+vHHH3X69Gnjb7zvvvtOnTp10pdffqmQkBCzNl9//XXNmTNHN2/e1IULF7Rs2TK1adMm7zoFAAAemI2lA8DTwcbGRuHh4QoPD9eoUaNUpEgRbdmyRS1btrxv3XLlymnKlCkKCwuTtbW1ZsyY8cDX9ff3140bN7Rr1y7VrFlTknT+/HkdOXJEfn5+kmTsk/Hll1/q4MGDqlOnjgoXLqzr169r9uzZqly5sgoXLpyzjt/Fzp07jSd5/vzzTx05ckQVK1Y0Yr698dxtO3bskK+vrzHzxNbW9qFnZzzrZs+ercjISA0ZMkTW1taaO3eunnvuOS1fvlwDBgzQjRs3dP36dQ0aNEhVq1a1dLgAAAAAHkJqaqpee+01Xb16VVZWVnJ1ddXatWtlMpn0wQcfqFOnTvLx8ZGtra0WLVokG5tbX3d0795d165dU7du3Yy2Fi1apKCgIHXq1Ek//vijfH19Jd3a6/D235EAACB/IZGBR7Z27VqdOHFCdevWVdGiRbVu3TplZGSYTdm9H19fX23dulVhYWGysbHR1KlTH6iej4+PWrRooR49emjOnDkqXLiwhg4dqueee85sr42wsDD1799flSpVMp4eq1u3rhYvXqwBAwY8VH8fxJgxY+Ti4qKSJUtq+PDhKl68uCIiIiRJAwcOVNWqVfXee++pTZs2+uGHHzRjxgzNmjXLqO/l5aXvvvtObdu2lZ2dnYoXL57rMT5tvL29jX1P7hQeHq6EhIS8DwgAAABArvHw8LjrvoUlS5bUt99+m23Z0aNH79qmtbW1MZMDAADkbywthUdWpEgRrVq1Sg0aNJCfn59mz56tJUuWKCAg4KHaqVChgrZs2aIlS5Zo4MCBD1wvOjpazz//vJo3b64aNWooMzNT69atM1seqn79+rp586bZpt716tXTzZs3s+yPkRsmTJigt99+W88//7xSUlL01VdfydbWVpJUuXJlLV++XEuXLlVgYKDeffddjRkzRl27djXqjxkzRklJSSpXrpxcXV1zPT4AAAAAAAAAeFKYMnO6OD+AfCctLU3Ozs7qOGmtbB0KWTqcXDW/d5ilQwAAAMD/7/a4M3VGOTk5WFs6HDwtIg9bOgIAAJBPPdKMjF9++UVt27ZVuXLlZGdnp59++kmSNHz4cK1fvz5XAgQAAAAAAAAAAM+uHCcyNm3apEqVKikpKUlt27bV9evXjbICBQqYrfePZ1NycrIcHR3v+kpOTrZ0iA+tV69ed+1Pr169LB0eAAAAAAAAADx1crzZ97Bhw9S2bVt99tlnunHjhsaPH2+UVapUSZ9++mmuBIgnV6lSpbR37957lj9pxowZo0GDBmVbdnsTcQAAAAAAAABA7slxIuPgwYNG8sJkMpmVFSlSROfOnXu0yPDEs7GxUfny5S0dRq4qUaKESpQoYekwAAAAAAAAAOCZkeOlpYoVK6bff/8927IjR47I3d09x0EBAAAAAAAAAABIjzAjIyIiQqNGjVL16tWNp+5NJpNOnz6tyZMn67XXXsu1IAE8nJk967DUFQAAAB6/Tj9JjDsBAADwmOV4Rsb48ePl6uqq4OBgVatWTZIUGRmpChUqyNnZWVFRUbkVIwAAAAAAAAAAeEbleEaGs7OzduzYoc8//1ybNm1SsWLFVKxYMfXu3VudO3eWra1tbsYJAAAAAAAAAACeQabMzMzMh630119/qXXr1ho4cKDq1av3OOICkANpaWlydnZWamoqS0sBAADgsWHcCQAAgLyUo6Wl7O3tFR8fr4yMjNyOBwAAAAAAAAAAwJDjPTJeeuklbdq0KTdjAQAAAAAAAAAAMJPjPTK6deumXr166fLly2rSpIlKlCghk8lkdk7lypUfOUAAAAAAAAAAAPDsytEeGZJkZWU+mePOJEZmZqZMJpNu3rz5aNEBeCi31yruOGmtbB0KWTqcRza/d5ilQwAAAEA2jD0yZpSTk4O1pcN5NkQetnQEAAAAFpPjGRlbt27NzTgAAAAAAAAAAACyyHEio169erkZBwAAAAAAAAAAQBY53uwbAAAAAAAAAADgccvxjAwrK6ssm3v/E3tkAAAAAAAAAACAR5HjRMbEiROzJDIuXLigTZs26Y8//tBbb731yMEBAAAAAAAAAIBnW44TGYMGDcr2+Pvvv6+OHTsqLS0tx0EBAAAAAAAAAABIj2mPjM6dO2vu3LmPo2kAAAAAAAAAAPAMeSyJjCNHjrA/Rj4SFxcnk8mkixcv3vM8Ly8vTZ06NVeuGRUVpdDQ0Fxp60ljMpm0Zs0aS4fx1Lt27Zr69OkjHx8fBQQEqGPHjmblCxculMlk0tq1ay0UIQAAAJB3+vbtKy8vL5lMJh08eNA4vmfPHtWoUUOVKlWSn5+fJk6caJS1atVKoaGhxsvKykpfffWVJGnmzJkKCgpSaGiogoKCNH369DzvEwAAwG05Xlrqww8/zHLs77//VmJiolasWKH27ds/UmDIubCwMIWGhhpJiZo1ayolJUXOzs6SpJiYGPXr1+++iQ0gPxs6dKisrKx05MgRmUwmpaSkGGW//fab5syZo+rVq1swQgAAACDvtGrVSu+8845q165tdrxHjx4aPXq0XnnlFV24cEEVK1ZU8+bN5e/vr5UrVxrn7dmzR40bN1ajRo0kSR07dlTv3r0lSWlpaQoMDFRYWJiCg4PzrlMAAAD/v1zdI8POzk6lS5fW22+/rZEjRz5SYMg9tra2cnNzs3QYeAR///23bG1tLR1GvpGenq7o6Gj99ttvMplMkiR3d3ejvGfPnvroo480ZMgQS4UIAAAA5Km6devetez2Q2zp6emytbVVsWLFspyzYMECdezYUXZ2dpJkPAgnSVeuXNGNGzeMsTcAAEBey/HSUhkZGVleV69e1dGjRzV+/HgVLFgwN+PEA+ratavi4+M1bdo0mUwmmUwmxcTEGEtLxcXFqVu3bkpNTTXKo6Kism0rNTVVPXv2VIkSJeTk5KQGDRpo3759DxXPokWL5OXlJWdnZ7Vt21aXLl0yyjZs2KDatWurSJEicnFxUfPmzXX8+HGj/O+//1afPn3k7u4ue3t7eXl5afz48Q90XZPJpE8//VSvvvqqChYsKB8fH2OKtHRrVkqRIkXM6qxZs8ZsYH57eawFCxaoTJkycnR01L///W/dvHlTEydOlJubm0qUKKH3338/y/VTUlLUpEkTOTg4qGzZslqxYoVZ+f/+9z+1adNGRYsWlYuLi1q0aKGkpCSjvGvXroqIiND48eNVqlQp+fr6ZtvPa9euKS0tzez1LDh+/LhcXFw0duxYValSRXXq1FFsbKwk6ZNPPlFAQICqVatm4SgBAACeHs/quPNpEB0drZEjR6pMmTLy9fXV+PHjszzo9tdff2nJkiXq3r272fGVK1cqICBAnp6eGjx4sIKCgvIydAAAAEOOExmfffaZzp8/n23ZhQsX9Nlnn+U4KOTctGnTVKNGDfXo0UMpKSlKSUmRh4eHUV6zZk1NnTpVTk5ORnl2s2syMzPVrFkznT59WuvWrVNCQoIqV66shg0b6sKFCw8Uy/Hjx7VmzRqtXbtWa9euVXx8vCZMmGCUp6ena8CAAfrxxx8VGxsrKysrvfrqq8rIyJAkTZ8+XV999ZWWL1+uw4cP6/PPP5eXl9cD34vRo0erdevW2r9/v5o2baoOHTo8cOx39mH9+vXasGGDlixZogULFqhZs2b67bffFB8frw8++EAjRozQzp07zeqNHDlSr732mvbt26eOHTuqXbt2SkxMlHTraab69evL0dFR3333nb7//ns5OjqqcePG+vvvv402YmNjlZiYqE2bNt11n4fx48fL2dnZeN35u36aXb9+XSdOnJC/v7/27NmjGTNmqG3btvrxxx81b948jRkzxtIhAgAAPFWe1XHn02DSpEmaNGmSkpOT9csvv2j48OE6fPiw2TlffPGFfHx8siQqWrVqpV9++UWHDx/WZ599lqUeAABAXslxIqNbt25mT8/f6eTJk+rWrVuOg0LOOTs7y9bWVgULFpSbm5vc3NxkbW1tlNva2srZ2Vkmk8kod3R0zNLO1q1bdeDAAa1YsUJVqlSRj4+PJk+erCJFipito3ovGRkZiomJUWBgoOrUqaNOnToZT81L0muvvaaWLVvKx8dHoaGhmj9/vg4cOKBDhw5JkpKTk+Xj46PatWvL09NTtWvXVrt27R74XnTt2lXt2rVT+fLlNW7cOKWnp2v37t0PXP92HxYsWCB/f3+9/PLLql+/vg4fPqypU6eqQoUK6tatmypUqKC4uDizeq+//rreeOMN+fr66r333lOVKlX08ccfS5KWLl0qKysrffrppwoKCpKfn5+io6OVnJxs1k6hQoX06aefKiAgQIGBgdnGN2zYMKWmphqvX3/99aH696Ty9PSUlZWVOnToIEkKCQlR2bJldfToUf3+++/y8/OTl5eXdu7cqe7du2vevHkWjhgAAODJ9qyOO590586d0+rVq9W6dWtJkre3t6pVq6YdO3aYnTd//vwsszHu5OXlpWrVqt31ASsAAIDHLceJjMzMzLuW/fnnnypcuHBOm0Y+kJCQoMuXL8vFxUWOjo7G6+TJk3dNYP2Tl5eX2efA3d1dZ86cMd4fP35c7du3l7e3t5ycnFS2bFlJtxIY0q1ExN69e1WhQgX17dtX33777UP14c5N6AoVKqTChQubXT8nfShZsqT8/f1lZWVlduyf7daoUSPL+9szMhISEnTs2DEVLlzYuK/FihXTX3/9ZXZvg4KC7rsvhp2dnZycnMxez4LixYurYcOG2rhxoyTp1KlTOnnypOrXr6/Tp08rKSlJSUlJql69uubPn68ePXpYOGIAAIAn27M67nzSFS1aVPb29oqPj5d0K7Gxc+dOswelTp48qd27d2d5aOz23y+SdPbsWcXGxrLRNwAAsJiH2ux7/fr1Wr9+vfF+ypQpKlmypNk5f/31l7Zs2aLQ0NBcCRCWkZGRIXd39ywzDSRl2VvibgoUKGD23mQyGctGSdLLL78sDw8PzZs3T6VKlVJGRoYCAwON5ZUqV66skydPav369dq8ebNat26t8PDwB54Rcq/rW1lZZUnGXb9+/YHauF+/7ub2/hsZGRl6/vnntXjx4iznuLq6Gj8XKlTovm0+y2bPnq3IyEgNGTJE1tbWmjt3rtmG3wAAAMCzpHfv3vryyy91+vRphYeHy9HRUceOHdPy5cs1YMAA3bhxQ9evX9egQYNUtWpVo96CBQv02muvZUlOffzxx4qPj1eBAgWUmZmp/v3768UXX8zrbgEAAEh6yETGkSNH9PXXX0u69aXstm3bZGdnZ3aOra2tAgMDNW7cuNyLEg/F1tZWN2/ezHG5dCuJcPr0adnY2DzUvhQP6vz580pMTNScOXNUp04dSdL333+f5TwnJye1adNGbdq0UatWrdS4cWNduHBBxYoVe6Tru7q66tKlS0pPTzcSBnv37n2kNu+0c+dOde7c2ex9pUqVJN26t8uWLTM2UUfOeHt7Z5tou9P9ygEAAICnxcyZMzVz5swsx8PDw5WQkHDXeu+99162x2fNmpVrsQEAADyqh0pkvP3223r77bclSWXLltWaNWsUEhLyWAJDznl5eWnXrl1KSkqSo6NjltkCXl5eunz5smJjYxUSEqKCBQuqYMGCZueEh4erRo0aioiI0AcffKAKFSro999/17p16xQREaEqVao8UoxFixaVi4uL8RR9cnKyhg4danbORx99JHd3d4WGhsrKykorVqyQm5vbA88IuZdq1aqpYMGC+s9//qO33npLu3fvVkxMzCO3e9vtvUVq166txYsXa/fu3Zo/f74kqUOHDpo0aZJatGihMWPGqHTp0kpOTtaqVas0ePBglS5dOtfiAAAAAAAAAIAnXY73yDh58iRJjHxq0KBBsra2lr+/v1xdXY09J26rWbOmevXqpTZt2sjV1VUTJ07M0obJZNK6detUt25dRUZGytfXV23btlVSUlKW5cRywsrKSkuXLlVCQoICAwPVv39/TZo0yewcR0dHffDBB6pSpYqqVq2qpKQkrVu3zmx/ipwqVqyYPv/8c61bt05BQUFasmSJoqKiHrnd20aPHq2lS5cqODhYCxcu1OLFi+Xv7y9JKliwoL777juVKVNGLVu2lJ+fnyIjI3X16lVmaAAAAAAAAADAP5gy77Vr9wM4duyYjhw5or/++itLWcuWLR+laQAPKS0tTc7Ozuo4aa1sHZ78PTbm9w6zdAgAAADIxu1xZ+qMcnJysLZ0OM+GyMOWjgAAAMBiHmppqTulpaWpZcuW2rp1qyQZGyff3tBY0n33YQAAAAAAAAAAALiXHK/RM2TIEKWkpGjbtm3KzMzU6tWrFRcXp+7du6ts2bLauXNnbsaJfCYgIECOjo7ZvhYvXvxYr7148eK7XjsgIOCxXhsAAAAAAAAAkLdyPCNjw4YNev/991WtWjVJUqlSpVS1alXVrVtXgwYN0pQpU7R06dJcCxT5y7p163T9+vVsy3JjD417eeWVV4zP3T8VKFDgsV4bAAAAAAAAAJC3cpzIOHPmjDw8PGRtba1ChQrp/PnzRlmTJk302muv5UqAyJ88PT0tdu3ChQurcOHCFrs+AAAAAAAAACDv5HhpKQ8PD507d06S5OPjo6+++soo27Fjh+zt7R89OgAAAAAAAAAA8EzL8YyMF198UZs3b9arr76q/v37q0uXLtq1a5dsbW21e/duDRw4MDfjBPAQZvasIycnJ0uHAQAAgKddp58kxp0AAAB4zEyZmZmZOal45coVXblyRcWLF5ckrV69WitXrtTVq1f14osv6l//+pesrHI84QNADqSlpcnZ2VmpqakkMgAAAPDYMO4EAABAXspxIgNA/sMflAAAAMgLjDsBAACQl3K8tNRtiYmJ2rNnj3799VdFRkbKzc1Nx44dU8mSJdmQGQAAAAAAAAAAPJIcJzKuXLmiN954Q8uXL5ckZWZmqnHjxnJzc9OwYcNUtmxZTZw4MdcCBQAAAAAAAAAAz54cb2IxaNAgbdmyRWvXrlVqaqruXKGqadOm2rBhQ64ECAAAAAAAAAAAnl05npGxcuVKTZo0SY0bN9bNmzfNyry8vJSUlPSosQHIod5zt8nWoZClw4CFze8dZukQAADA025RZcnB2tJRPBsiD1s6AgAAAIvJ8YyMy5cvy93dPduy9PT0HAcEAAAAAAAAAABwW44TGcHBwfriiy+yLfvmm29UpUqVHAcFAAAAAAAAAAAgPcLSUiNHjlSLFi105coVvf766zKZTNq9e7eWLFmiBQsWaN26dbkZJwAAAAAAAAAAeAbleEZGs2bNtHTpUn3//feKiIhQZmam3nzzTS1btkyLFy9Ww4YNczNOAAAAAAAAAADwDHqoGRn+/v5atmyZgoKCJEmtWrXSX3/9JV9fX924cUPFihVTxYoVH0ugAAAAAAAAAADg2fNQMzL++9//6urVq8b7mzdvqkuXLrKxsVHNmjVJYgAAAAAAAAAAgFyV46WlbsvMzMyNOAAAAAAAAAAAALJ45EQG8CDCwsLUr18/S4cB4P/Xt29feXl5yWQy6eDBg8bxzMxMRUVFydfXV4GBgQoLCzOrN2vWLPn5+SkwMFDBwcH666+/8jhyAAAA/NPdxnZ79uxRjRo1VKlSJfn5+WnixIlm9e43tjt8+LAKFiyoQYMG5Uk/AAAA7uah9siQJJPJ9EDHgDutWrVKBQoUeKQ2wsLCFBoaqqlTp+ZOUI+53UeRH2PC06VVq1Z65513VLt2bbPj06dP14EDB3Tw4EHZ2toqJSXFKPvyyy+1ePFi7dy5U87Ozjpz5swj/3sNAACAR3e3sV2PHj00evRovfLKK7pw4YIqVqyo5s2by9/f/75ju5s3b+pf//qXIiIi8rg3AAAAWT10IqN+/fqysjKfyFGnTp0sx0wmk1JTUx8tOjw1ihUrZukQANyhbt262R6fNGmS4uLiZGtrK0lyd3c3Kxs9erScnZ0lSSVKlHj8gQIAAOC+7ja2k6SLFy9KktLT02Vra2v8bXa/sd2ECRPUvHlzXb58WZcvX348gQMAADygh1paatSoURo8eLAGDhxovLI7NnDgQA0YMOBxxYwn0J1LS82aNUs+Pj6yt7dXyZIl1apVq/vW79q1q+Lj4zVt2jSZTCaZTCYlJSVJkg4dOqSmTZvK0dFRJUuWVKdOnXTu3DlJMr6Q3bZtm9HWlClTVLx4caWkpNyz3buJi4uTyWTSN998o5CQENnb26tatWo6cOCA2XlffPGFAgICZGdnJy8vL02ZMsWs/G734WFiunbtmtLS0sxeQE6lpaXp7NmzWr16tapXr67q1atr2bJlRvmhQ4e0Z88e1apVS1WqVNH06dMtGC0AAMhLjDufTNHR0Ro5cqTKlCkjX19fjR8/Xm5ubpLuPbbbv3+/Nm7cqP79+1sqdAAAADMPNSNj1KhRjysOPCP27Nmjvn37atGiRapZs6YuXLhglmS4m2nTpunIkSMKDAzUmDFjJEmurq5KSUlRvXr11KNHD3344Ye6evWqhgwZotatW2vLli1GAqVTp07at2+fkpKSNHz4cC1ZskTu7u53bfdBDB48WNOmTZObm5v+85//6JVXXtGRI0dUoEABJSQkqHXr1oqKilKbNm20Y8cOvfnmm3JxcVHXrl3veR8eJqbx48dr9OjRDxQvcD/Xr1/X33//ratXr2rnzp1KTk5WjRo1FBAQoMDAQN24cUPHjx/Xd999p9TUVNWrV0/ly5dX06ZNLR06AAB4zBh3PpkmTZqkSZMmqXXr1jpx4oTCwsL0wgsvqEKFCncd27344ovq0aOHoqOjZW1tbekuAAAASMrB0lLAo0hOTlahQoXUvHlzFS5cWJ6enqpUqdJ96zk7O8vW1lYFCxY0niCSpE8++USVK1fWuHHjjGMLFiyQh4eHjhw5Il9fX40dO1abN29Wz5499csvv6hTp0569dVX79nugxg1apRefPFFSdLChQtVunRprV69Wq1bt9aHH36ohg0bauTIkZIkX19fHTp0SJMmTVLXrl3veR8eJqZhw4aZzX5KS0uTh4fHQ/UDuM3FxUWOjo7q2LGjJKlMmTKqVauW9uzZo8DAQJUpU0bt2rWTtbW1ihUrpiZNmmj37t0kMgAAeAYw7nzynDt3TqtXr9bixYslSd7e3qpWrZp27NihChUq3HVsFxgYqOPHjxtjvIsXLyozM1N//vmn5s+fb8kuAQCAZ9hDLS0FPKoXX3xRnp6e8vb2VqdOnbR48WJduXIlx+0lJCRo69atcnR0NF4VK1aUJB0/flySZGtrq88//1xffPGFrl69mmsbaNeoUcP4uVixYqpQoYISExMlSYmJiapVq5bZ+bVq1dLRo0d18+bNXLsPdnZ2cnJyMnsBj6Jdu3basGGDJOnPP//U7t27FRwcLElq3769UfbXX38pPj5eISEhFosVAADkHcadT56iRYvK3t5e8fHxkm4lNnbu3KnAwEBJdx/blSlTRufOnVNSUpKSkpLUr18/9ejRgyQGAACwKBIZyFOFCxfWTz/9ZCzt9O677yokJMTYgO5hZWRk6OWXX9bevXvNXkePHjXb8G7Hjh2SpAsXLujChQu50ZVsmUwmSVJmZqbx822ZmZnGz7l9H4CH1bt3b5UuXVq//fabwsPDVb58eUnSuHHjtH79egUGBqpOnToaNmyYKleuLEnq37+/Tp8+LX9/fz3//PNq0qSJMbsJAAAAlpPd2M7a2lrLly/XgAEDFBISorp162rQoEGqWrWqJMZ2AADgycLSUshzNjY2Cg8PV3h4uEaNGqUiRYpoy5Ytatmy5T3r2dra6ubNm2bHKleurC+++EJeXl6yscn+43z8+HH1799f8+bN0/Lly9W5c2fFxsbKysrqru0+iJ07d6pMmTKSbj25fuTIEWM2iL+/v77//nuz83fs2CFfX19jndl73YecxgQ8qJkzZ2rmzJlZjhcvXlxff/11tnUcHBz02WefPe7QAAAA8JDuNrYLDw9XQkJCtnUedGwXFRX1qOEBAAA8MmZkIE+tXbtW06dP1969e3Xq1Cl99tlnysjIUIUKFe5b18vLS7t27VJSUpLOnTunjIwM9e7dWxcuXFC7du20e/dunThxQt9++60iIyN18+ZN3bx5U506ddJLL72kbt26KTo6WgcPHtSUKVPu2e6DGDNmjGJjY3Xw4EF17dpVxYsXV0REhCRp4MCBio2N1XvvvacjR45o4cKFmjFjhgYNGvRA9yGnMQEAAAAAAADA04ZEBvJUkSJFtGrVKjVo0EB+fn6aPXu2lixZooCAgPvWHTRokKytreXv7y9XV1clJyerVKlS2r59u27evKlGjRopMDBQb7/9tpydnWVlZaX3339fSUlJmjt3riTJzc1Nn376qUaMGKG9e/fetd0HMWHCBL399tt6/vnnlZKSoq+++kq2traSbs0UWb58uZYuXarAwEC9++67GjNmjLp27fpA9yGnMQEAAAAAAADA08aUeefC/QDuKy4uTvXr19eff/6pIkWKWDocM2lpaXJ2dlbHSWtl61DI0uHAwub3DrN0CAAA4Cl1e9yZOqOcnBysLR3OsyHysKUjAAAAsBhmZAAAAAAAAAAAgHyLRAbyheTkZDk6Ot71lZdLK/Xq1euucfTq1SvP4gAAAAAAAAAASDaWDgCQpFKlShl7VtytPK+MGTPG2JT7n5ycnFSiRAmxIhsAAAAAAAAA5A0SGcgXbGxsVL58eUuHIUkqUaKESpQoYekwAAAAAAAAAABiaSkAAAAAAAAAAJCPmTJZIwd4aqSlpcnZ2VmpqalycnKydDgAAAB4SjHuBAAAQF5iRgYAAAAAAAAAAMi3SGQAAAAAAAAAAIB8i0QGAAAAAAAAAADIt0hkAAAAAAAAAACAfItEBgAAAAAAAAAAyLdsLB0AgNzXe+422ToUynJ8fu+wvA8GAAAAT69FlSUHa0tH8XSLPGzpCAAAACyOGRkAAAAAAAAAACDfIpEBAAAAAAAAAADyLRIZAAAAAAAAAAAg3yKRAQAAAAAAAAAA8i0SGQAAAAAAAAAAIN8ikQEAAAAAAAAAAPItEhkAAAAAAAAAACDfIpHxDElKSpLJZNLevXuNY9u3b1dQUJAKFCigiIgIi8WWX2R3jwAAAAAAAAAAlkMi4xk3YMAAhYaG6uTJk4qJiVFUVJRCQ0Nz/TqPq91H0bVr1yzJGw8PD6WkpCgwMNAyQd3BEvdsw4YNqlKlioKDg1W9enXt27cvT68PAAAA4MH17dtXXl5eMplMOnjwoHF8z549qlGjhipVqiQ/Pz9NnDjRKFuwYIGCgoJkY2OjGTNmmLV3/vx5RUREKDg4WH5+furSpYuuXr2aZ/0BAAC4GxIZz7jjx4+rQYMGKl26tIoUKWLpcCzO2tpabm5usrGxsXQoee7PP/9Ux44dtWjRIu3fv18ffPCBOnToYOmwAAAAANxFq1at9P3338vT09PseI8ePTRs2DD9/PPP2r59uyZPnqxDhw5Jkp5//nktX75c7du3z9Le2LFj5e3trf379+vgwYP6448/FB0dnSd9AQAAuBcSGU+glStXKigoSA4ODnJxcVF4eLjS09MlSdHR0fLz85O9vb0qVqyoWbNmZdvG7SWUzp8/r8jISJlMJsXExGj06NHat2+fTCaTcUySUlNT1bNnT5UoUUJOTk5q0KCB8bT+2bNn5ebmpnHjxhnt79q1S7a2tvr222/v2e69REVFqUyZMrKzs1OpUqXUt29fo+zvv//WO++8o+eee06FChVStWrVFBcXZ5THxMSoSJEi2rhxo/z8/OTo6KjGjRsrJSXFaHvhwoX68ssvjZji4uKyLC0VFxcnk8mkjRs3qlKlSnJwcFCDBg105swZrV+/Xn5+fnJyclK7du105coV4/qZmZmaOHGivL295eDgoJCQEK1cudIov91ubGysqlSpooIFC6pmzZo6fPiwEX9O7tmjOH78uEqUKCE/Pz9JUr169XTq1Cn99NNPj/W6AAAAAHKmbt26Kl26dLZlFy9elCSlp6fL1tZWxYoVkySFhITIz89PVlbZfx1w6dIlZWRk6O+//9aVK1fu2j4AAEBeevYeO3/CpaSkqF27dpo4caJeffVVXbp0Sdu2bVNmZqbmzZunUaNGacaMGapUqZJ+/vln9ejRQ4UKFVKXLl3M2rm9hFKFChU0ZswYtWnTRs7Ozjp48KA2bNigzZs3S5KcnZ2VmZmpZs2aqVixYlq3bp2cnZ01Z84cNWzYUEeOHJGrq6sWLFigiIgIvfTSS6pYsaI6duyoN998Uy+99JKuXr2abbv3snLlSn300UdaunSpAgICdPr0abNljrp166akpCQtXbpUpUqV0urVq9W4cWMdOHBAPj4+kqQrV65o8uTJWrRokaysrNSxY0cNGjRIixcv1qBBg5SYmKi0tDTjCaNixYrp999/zzaeqKgozZgxQwULFlTr1q3VunVr2dnZ6f/+7/90+fJlvfrqq/r44481ZMgQSdKIESO0atUqffLJJ/Lx8dF3332njh07ytXVVfXq1TPaHT58uKZMmSJXV1f16tVLkZGR2r59u9q0afNA9+zatWu6du2a8T4tLe2e9/VefHx8dPbsWe3cuVPVq1fX6tWrdfnyZSUlJaly5co5bhcAAABPvtwcd+Lxi46OVosWLTRixAidPXtWc+fOlZub233rjRw5Uq+99prc3Nx09epVtW/fXq+88koeRAwAAHBvJDKeMCkpKbpx44ZatmxpTB8OCgqSJL333nuaMmWKWrZsKUkqW7asDh06pDlz5mRJZNxeQslkMsnZ2dkY1Do6OsrGxsZskLtlyxYdOHBAZ86ckZ2dnSRp8uTJWrNmjVauXKmePXuqadOm6tGjhzp06KCqVavK3t5eEyZMkCQ5ODhk2+69JCcny83NTeHh4SpQoIDKlCmjF154QdKtmQNLlizRb7/9plKlSkmSBg0apA0bNig6OtqYGXL9+nXNnj1b5cqVkyT16dNHY8aMMfrp4OCga9euPVBMY8eOVa1atSRJ3bt317Bhw3T8+HF5e3tLujWle+vWrRoyZIjS09P14YcfasuWLapRo4YkydvbW99//73mzJljlsh4//33jfdDhw5Vs2bN9Ndffz3wPRs/frxGjx79QPf0fpydnfXFF19o6NChunTpkmrXri1/f38VKFAgV9oHAADAkys3x514/CZNmqRJkyapdevWOnHihMLCwvTCCy+oQoUK96y3YsUKBQcHa/Pmzbpy5YpeeeUVxcTEqGvXrnkTOAAAwF2wtNQTJiQkRA0bNlRQ0P/X3r3H91z//x+/v2cHsxMWtjHm0GZ2MExIthEp5ySSY6iIpJL4IOdzhKJQIVT0cSpJ5jTn01gR0QczMjnEFjG2vX5/+Hl/vdvBaNv7bW7Xy+V1ae/X8/l6Ph+v52t5P997vJ+vV4ief/55zZkzR5cuXdL58+d16tQpde/eXa6uruZt9OjROnbs2L/qMzY2VleuXJGnp6dF2ydOnLBo+/3331dqaqqWLFmiRYsWqXDhwvfd5/PPP69r166pQoUKevnll7V8+XKlpqZKkvbt2yfDMOTv728RT0xMjEU8RYoUMScxJMnb21vnzp27r3hCQ0PNP5cqVUpFihQxJzFu77vd9qFDh3T9+nU1atTIIr4vvvgiw7W4s11vb29JuqcYBw0apKSkJPN26tSp+zq/2yIiIrRp0ybFxsZq4sSJOnPmjPlWUwAAAHh45fa8kvkX5wAAbDxJREFUE3nnwoULWr58udq2bSvp1peqatWqpe3bt9/12A8//FAdOnRQoUKF5ObmZv7CFgAAgLWxIuMBU6hQIUVHR2v79u1au3atPvzwQw0ePFjfffedJGnOnDmqVatWhmP+jfT0dHl7e1s8g+K2Ox8Qfvz4cZ05c0bp6ek6efKkxR/p75Wvr6+OHDmi6OhorVu3Tq+99pomTZqkmJgYpaenq1ChQoqNjc1wbq6uruaf/7mSwGQyyTCM+4rnzrZMJlOmbaenp0uS+b/ff/+9SpcubVHv9oqWrNq98/iccHJyytDmv5GYmGhOqIwaNUoNGjRQpUqVcq19AAAAPJhye96JvFOsWDEVLlxYMTExioyM1IULF7Rz504NGDDgrsdWqFBBP/zwgx577DHdvHlTa9asUURERD5EDQAAkD0SGQ8gk8mkunXrqm7dunrvvfdUrlw5bdu2TaVLl9bx48fVoUOH+27b0dFRaWlpFvuqV6+us2fPyt7eXn5+fpked+PGDXXo0EHt2rVT5cqV1b17dx04cEClSpXKst27cXZ2VosWLdSiRQv17t1blStX1oEDB1StWjWlpaXp3Llzqlev3n2d5/3GlBNVqlSRk5OTEhISLG4jda/yKr7sDB06VFu3blVqaqrq1Kmjzz77LF/7BwAAAJBzvXv31sqVK3X27Fk1bNhQrq6u+t///qclS5borbfeUmpqqm7evKn+/furZs2akqSFCxdq4MCBunTpklauXKnx48fru+++U7Vq1TRt2jT17NlTwcHBSk9PV926ddW3b18rnyUAAACJjAfOrl27tH79ej311FMqWbKkdu3apfPnzyswMFDDhw9X37595e7urmeeeUYpKSnau3evLl26pLfeeitH7fv5+enEiROKi4tTmTJl5ObmpoYNG6pOnTpq1aqVJkyYoICAAJ05c0arV69Wq1atFB4ersGDByspKUnTp0+Xq6urfvjhB3Xv3l2rVq3Kst3svtE1b948paWlqVatWipSpIgWLFggZ2dnlStXTp6enurQoYM6d+6syZMnq1q1arpw4YI2bNigkJAQNWnSJMfn+uOPP+rIkSPy9PS86wPIc8rNzU39+/fXm2++qfT0dD3xxBNKTk7W9u3b5erqmuF5JdnFdy9jlhs+/fTTPG0fAAAAQO6ZMWOGZsyYkWF/w4YNFRsbm+kxHTt2VMeOHTMtK1++vH788cdcjREAACA38IyMB4y7u7s2b96sJk2ayN/fX0OGDNHkyZP1zDPPqEePHvr00081b948hYSEKDIyUvPmzVP58uVz3P5zzz2np59+WvXr11eJEiX01VdfyWQyafXq1YqIiFC3bt3k7++vF154QfHx8SpVqpQ2bdqkqVOnasGCBXJ3d5ednZ0WLFigrVu36uOPP86y3ewULVpUc+bMUd26dRUaGqr169fru+++k6enpyRp7ty56ty5s95++20FBASoRYsW2rVrl3x9fXN8ri+//LICAgIUHh6uEiVKaNu2bTk+9m5GjRql9957T+PGjVNgYKAaN26s77777l9fCwAAAAAAAAB42JiM+31oAACbk5ycLA8PD3WctEqOzi4Zyj/rHZX/QQEAAKDAuT3vTPqootyd/90z+XAX3Y5YOwIAAACrY0UGAAAAAAAAAACwWSQyYBWLFi2Sq6trpltQUJC1wwMAAAAAAAAA2Age9g2raNGihWrVqpVpmYODQz5HAwAAAAAAAACwVSQyYBVubm5yc3OzdhgAAAAAAAAAABvHraUAAAAAAAAAAIDNMhmGYVg7CAC5Izk5WR4eHkpKSpK7u7u1wwEAAEABxbwTAAAA+YkVGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABslr21AwCQ+3rP3iJHZxdJ0me9o6wbDAAAAAquBdUl50LWjiJ/dDti7QgAAAAeWqzIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIyANRUVHq16+ftcOAFcTHx8tkMikuLs7aoeSYn5+fKleurLCwMIWFhWnx4sXWDgkAAAB44PTt21d+fn4ymUw6ePCgeX+3bt0UEBCgsLAwRUREWHxW+M9//qPAwEBVrVpVjz32mDZs2GAumz59uoKDgxUaGso8HQAAPPTsrR1AQbRs2TI5ODhYOwzksa5du+ry5ctasWKFtUP51/773/8qODjY2mEAAAAAD6w2bdpowIABeuKJJyz2t2rVSrNnz5a9vb1WrVqltm3b6ujRo5KkevXqaejQoXJ2dtZPP/2kqKgoJSYmqnDhwgoKCtK2bdvk4eGhU6dOqXr16qpdu7bKlStnjdMDAACwKhIZeaB48eLWDgEFzI0bN+To6GjtMAAAAABkISIiItP9LVq0MP9cu3ZtnTx5Uunp6bKzs9MzzzxjLgsJCVFaWpouXLigMmXK6MknnzSX+fr6qlSpUjp16hSJDAAA8FDi1lJ54M5bS82cOVOPPvqoChcurFKlSqlNmzY5amPNmjV64oknVLRoUXl6eqpZs2Y6duyYufz2LYyWLVum+vXrq0iRIqpatap27Nhh0c7SpUsVFBQkJycn+fn5afLkyRblfn5+Gjt2rLp16yY3NzeVLVtWs2fPNpc3aNBAffr0sTjm4sWLcnJyMi979vPz0+jRo9W5c2e5urqqXLlyWrlypc6fP6+WLVvK1dVVISEh2rt37z3FZjKZMqx2KFq0qObNmyfp1h/3+/TpI29vbxUuXFh+fn4aN25cjsZ3ypQpCgkJkYuLi3x9ffXaa6/pypUr5vLhw4crLCzM4pipU6fKz8/PXD5//nytXLlSJpNJJpNJmzZtMtc9fvz4v74uo0ePVteuXeXh4aGXX3450/NISUlRcnKyxXY/OnTooJCQEPXo0UPnz5+/rzYAAABQcOXWvPNhN23aNDVp0kR2dhk/is+dO1cVK1ZUmTJlMpStW7dOly5dUo0aNfIjTAAAAJtDIiMP7d27V3379tXIkSN15MgRrVmzJstv6fzT1atX9dZbb2nPnj1av3697Ozs9Oyzzyo9Pd2i3uDBg9W/f3/FxcXJ399f7du3V2pqqiQpNjZWbdu21QsvvKADBw5o+PDhGjp0qDkRcNvkyZMVHh6u/fv367XXXlOvXr3066+/SpJ69OihL7/8UikpKeb6ixYtko+Pj+rXr2/e98EHH6hu3brav3+/mjZtqk6dOqlz587q2LGj9u3bp0qVKqlz584yDOOeYsvO9OnT9e2332rJkiU6cuSIFi5caE403I2dnZ2mT5+ugwcPav78+dqwYYMGDBiQ47779++vtm3b6umnn1ZiYqISExP1+OOPm8tz47pMmjRJwcHBio2N1dChQzONY9y4cfLw8DBvvr6+OT6H2zZv3qyffvpJ+/btk6enp7p06XLPbQAAAKBgy41558Nu4cKFWrJkiWbNmpWhbP369RoxYoS+/vrrDGUHDhzQSy+9pMWLF8vZ2Tk/QgUAALA5JuP2X5aRa6KioswPcnvppZd0+vRpubm5/as2z58/r5IlS+rAgQMKDg5WfHy8ypcvr08//VTdu3eXJB06dEhBQUE6fPiwKleurA4dOuj8+fNau3atuZ0BAwbo+++/1y+//CLp1jf/69WrpwULFkiSDMOQl5eXRowYoZ49eyolJUU+Pj76+OOP1bZtW0lStWrV1KpVKw0bNizTNs6ePStvb28NHTpUI0eOlCTt3LlTderUUWJiory8vHIUm8lk0vLly9WqVStznaJFi2rq1Knq2rWr+vbtq19++UXr1q2TyWT6V+P7zTffqFevXrpw4YKkWysuVqxYYfEgvqlTp2rq1KmKj4+XlPkzMnLzulSrVk3Lly/PNu6UlBSLJFNycrJ8fX3VcdIqOTq7SJI+6x2V43FITEyUv7+//vrrrxwfAwAAgIIvq3ln0kcV5e5cyIqR5aNuR3JUzc/PT6tWrbJ4Bt3ixYs1ZMgQrV+/XmXLlrWoHxMTo06dOum7775T1apVLcoOHTqkZ555Rp9++qkaNWr0788BAADgAcWKjDzUqFEjlStXThUqVFCnTp20aNEi/f333zk69tixY3rxxRdVoUIFubu7q3z58pKkhIQEi3qhoaHmn729vSVJ586dkyQdPnxYdevWtahft25d/fbbb0pLS8u0DZPJJC8vL3MbTk5O6tixoz7//HNJUlxcnH766Sd17do1yzhKlSol6dY9Xv+5715jy07Xrl0VFxengIAA9e3b1yIxcDcbN25Uo0aNVLp0abm5ualz5866ePGirl69muM2spMb1yU8PPyu/Tg5Ocnd3d1iuxdXr17V5cuXza+/+uorVatW7Z7aAAAAQMH3b+edD7MlS5ZoyJAhWrduXYYkxubNm9WpUyetXLkyQxLj8OHDatKkiWbPnk0SAwAAPPRIZOQhNzc37du3T1999ZW8vb313nvvqWrVqhZ/OM5K8+bNdfHiRc2ZM0e7du3Srl27JN16LsSdHBwczD/fXpVw+/ZThmFkWKmQ2QKcO9u43c6dt7Dq0aOHoqOjdfr0aX3++ed68sknMzxgLrM4/m1sJpMpw76bN2+af65evbpOnDihUaNG6dq1a2rbtm2OnkFy8uRJNWnSRMHBwVq6dKliY2M1Y8YMi/bt7Oyy7ftucuO6uLi45Li/+/XHH3+ofv36Cg0NVUhIiGJiYvTFF1/keb8AAABAQdO7d2+VKVNGp0+fVsOGDVWpUiVJt55Hd/36dbVs2VJhYWEKCwvTxYsXJUndu3dXSkqKXnrpJXPZgQMHJEl9+/ZVUlKS3n33XXPZjz/+aLXzAwAAsCZ7awdQ0Nnb26thw4Zq2LChhg0bpqJFi2rDhg1q3bp1lsdcvHhRhw8f1qxZs1SvXj1J0tatW++57ypVqmQ4bvv27fL391ehQjlf/h0SEqLw8HDNmTNHX375pT788MN7juV+YitRooQSExPN5b/99luGFS3u7u5q166d2rVrpzZt2ujpp5/Wn3/+qeLFi2fZ9969e5WamqrJkyebH7K3ZMkSizolSpTQ2bNnLZIOd95mSpIcHR1zvHrkTrl1XXJDhQoVtH///nztEwAAACiIZsyYYf6C1J2y+0LUb7/9lmVZdHR0rsQFAABQEJDIyEOrVq3S8ePHFRERoWLFimn16tVKT09XQEBAtscVK1ZMnp6emj17try9vZWQkKCBAwfec/9vv/22atasqVGjRqldu3basWOHPvroI82cOfOe2+rRo4f69OmjIkWK6Nlnn73n4+8ntgYNGuijjz5S7dq1lZ6ernfffddipcMHH3wgb29vhYWFyc7OTt988428vLxUtGjRbPuuWLGiUlNT9eGHH6p58+batm2bPvnkE4s6UVFROn/+vCZOnKg2bdpozZo1+uGHHyyW0Pv5+enHH3/UkSNH5OnpKQ8Pj1w7dwAAAAAAAADALdxaKg8VLVpUy5YtU4MGDRQYGKhPPvlEX331lYKCgrI9zs7OTl9//bViY2MVHBysN998U5MmTbrn/qtXr64lS5bo66+/VnBwsN577z2NHDkyw/MtcqJ9+/ayt7fXiy++qMKFC9/z8fcT2+TJk+Xr66uIiAi9+OKL6t+/v4oUKWIud3V11YQJExQeHq6aNWsqPj5eq1evNq+yyEpYWJimTJmiCRMmKDg4WIsWLdK4ceMs6gQGBmrmzJmaMWOGqlatqt27d6t///4WdV5++WUFBAQoPDxcJUqU0LZt23Lt3AEAAAAAAAAAt5iMzG7OD/zDqVOn5Ofnpz179qh69erWDgdZSE5OloeHhzpOWiVH51vP2Pisd5R1gwIAAECBc3vemfRRRbk75+/tUa2m2xFrRwAAAPDQ4tZSyNbNmzeVmJiogQMHqnbt2iQxAAAAAAAAAAD5iltLWUFCQoJcXV2z3BISEqwdotm2bdtUrlw5xcbGZniOhK1atGhRlmN7t9t6AQAAAAAAAABsCysyrMDHx0dxcXHZltuKqKgoPWh3H2vRooVq1aqVadmdDwsHAAAAAAAAANg+EhlWYG9vr0qVKlk7jALLzc1Nbm5u1g4DAAAAAAAAAJALeNg3UICYH7qYlCR3d3drhwMAAIACinknAAAA8hPPyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm2Vv7QAA5L7es7fI0dnF2mHYtM96R1k7BAAAgAffguqScyFrR5G1bkesHQEAAAByASsyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QG8lxUVJT69etn7TDMZs+eLV9fX9nZ2Wnq1KnWDsdCfHy8TCaT4uLirB3KQ2/NmjUKDw9XaGioateurZ9++smifP78+TKZTFq1apWVIgQAAMC/9eOPP6pGjRqqVq2agoODNX/+fElSt27dFBAQoLCwMEVERGSYn8+cOVOBgYEKDg5WaGiorl+/boXoAQAAHh721g4AyE/Jycnq06ePpkyZoueee04eHh7WDgk26NKlS+rYsaO2bNmiwMBAxcTEqEOHDjp48KAk6fTp05o1a5Zq165t5UgBAABwvwzD0IsvvqiNGzcqNDRU8fHxqly5slq3bq1WrVpp9uzZsre316pVq9S2bVsdPXpUkrRy5UotWrRIO3fulIeHh86dOycHBwcrnw0AAEDBxooMPFQSEhJ08+ZNNW3aVN7e3ipSpIi1Q4INOnbsmEqWLKnAwEBJUmRkpE6ePKl9+/ZJkl555RV98MEHcnJysmaYAAAAyAWXL1+WdOtLT56ennJyclKLFi1kb3/re3+1a9fWyZMnlZ6eLkmaNGmSRowYYf5SVMmSJVWoUCGrxA4AAPCwIJGBXHX16lV17txZrq6u8vb21uTJky3KFy5cqPDwcLm5ucnLy0svvviizp07J+nWN6IqVaqk999/3+KYgwcPys7OTseOHbtr/wkJCWrZsqVcXV3l7u6utm3b6o8//pAkzZs3TyEhIZKkChUqyGQyKT4+Psu2kpKSVKhQIcXGxprjK168uGrWrGmu89VXX8nb29v8+vfff1e7du1UrFgxeXp6qmXLlhn6mDt3rgIDA1W4cGFVrlxZM2fOzDKG9PR0vfzyy/L399fJkyczlKekpCg5Odliw7/36KOP6vz589q5c6ckafny5bpy5Yri4+P18ccfKygoSLVq1bJylAAAAPmnIM47TSaTlixZotatW6tcuXJ64oknNH/+fDk6OlrUmzZtmpo0aSI7u1sfnw8dOqS9e/eqbt26Cg8P1/Tp060RPgAAwEOFRAZy1TvvvKONGzdq+fLlWrt2rTZt2mROBEjSjRs3NGrUKP30009asWKFTpw4oa5du0q69UGiW7dumjt3rkWbn3/+uerVq6eKFStm27dhGGrVqpX+/PNPxcTEKDo6WseOHVO7du0kSe3atdO6deskSbt371ZiYqJ8fX2zbM/Dw0NhYWHatGmTJOnnn382//f2B7dNmzYpMjJSkvT333+rfv36cnV11ebNm7V161a5urrq6aef1o0bNyRJc+bM0eDBgzVmzBgdPnxYY8eO1dChQ8334r3TjRs31LZtW+3du1dbt25VuXLlMtQZN26cPDw8zFt254Oc8/Dw0NKlSzVw4EDVqFFDmzZtUpUqVfT7779rzpw5GjlypLVDBAAAyFcFcd6ZmpqqcePGaeXKlTp58qTWr1+vLl266M8//zTXWbhwoZYsWaJZs2ZZHHfs2DFt3rxZa9eu1Zw5c7R69WprnAIAAMBDg0QGcs2VK1f02Wef6f3331ejRo0UEhKi+fPnKy0tzVynW7dueuaZZ1ShQgXVrl1b06dP1w8//KArV65Ikl566SUdOXJEu3fvliTdvHlTCxcuVLdu3e7a/7p16/Tzzz/ryy+/VI0aNVSrVi0tWLBAMTEx2rNnj5ydneXp6SlJKlGihLy8vO66BDwqKsqcyNi0aZOefPJJBQcHa+vWreZ9UVFRkqSvv/5adnZ2+vTTTxUSEqLAwEDNnTtXCQkJ5jZGjRqlyZMnq3Xr1ipfvrxat26tN9980+KD0e2xbNq0qc6ePatNmzapZMmSmcY3aNAgJSUlmbdTp07ddZyQMxEREeZE3MSJE3XmzBldunRJZ86cUWBgoPz8/LRz5051795dc+bMsXa4AAAAeaogzjvj4uJ05swZ1a1bV5JUs2ZN+fj46KeffpIkLV68WCNGjFB0dLTFfLxs2bJq3769ChUqpOLFi+uZZ54xf34BAABA3iCRgVxz7Ngx3bhxQ3Xq1DHvK168uAICAsyv9+/fr5YtW6pcuXJyc3MzJwESEhIkSd7e3mratKk+//xzSdKqVat0/fp1Pf/883ft//Dhw/L19bX4dliVKlVUtGhRHT58+L7OKSoqSlu2bFF6erpiYmIUFRWlqKgoxcTE6OzZszp69Kh5RUZsbKz+97//yc3NTa6urnJ1dVXx4sV1/fp1HTt2TOfPn9epU6fUvXt3c7mrq6tGjx6d4bZZ7du315UrV7R27dpsH0ju5OQkd3d3iw25IzEx0fzzqFGj1KBBA7333ns6e/as4uPjFR8fr9q1a+uzzz7Tyy+/bMVIAQAA8l5BnHf6+vrq9OnTOnLkiCTpf//7n44dOyZ/f38tWbJEQ4YM0bp161S2bFmL41588UWtWbNGknT9+nXFxMSoatWq+R4/AADAw8Te2gGg4DAMI9vyq1ev6qmnntJTTz2lhQsXqkSJEkpISFDjxo3Nt16SpB49eqhTp0764IMPNHfuXLVr1y5HD+U2DEMmkynH+3MiIiJCf/31l/bt26ctW7Zo1KhR8vX11dixYxUWFmbxQOj09HTVqFFDixYtytBOiRIldP36dUm3bi/1z+cr/HNlSJMmTbRw4ULt3LlTDRo0uK/Y8e8MHTpUW7duVWpqqurUqaPPPvvM2iEBAAAgF5UqVUqzZs1SmzZtZGdnJ8MwNHPmTJUuXVodOnSQl5eXWrZsaa6/fv16eXp66s0339Srr76qKlWqyGQy6fnnn9ezzz5rxTMBAAAo+EhkINdUqlRJDg4O2rlzp/lbS5cuXTKvWvj111914cIFjR8/3rxqYu/evRnaadKkiVxcXPTxxx/rhx9+0ObNm3PUf5UqVZSQkKBTp06Z2z906JCSkpLMyYZ7dfs5GR999JFMJpOqVKkiHx8f7d+/X6tWrTKvxpCk6tWra/HixSpZsmSm31Dz8PBQ6dKldfz4cXXo0CHbfnv16qXg4GC1aNFC33//vUU/yB+ffvrpXevcvmUYAAAAHkzt27dX+/btM+y/efNmlsc4Ozvriy++yMuwAAAA8A/cWgq5xtXVVd27d9c777yj9evX6+DBg+ratavs7G79mpUtW1aOjo768MMPdfz4cX377bcaNWpUhnYKFSqkrl27atCgQapUqZLFraqy07BhQ4WGhqpDhw7at2+fdu/erc6dOysyMlLh4eH3fV5RUVFauHChIiMjZTKZVKxYMVWpUkWLFy823xpLkjp06KBHHnlELVu21JYtW3TixAnFxMTojTfe0OnTpyVJw4cP17hx4zRt2jQdPXpUBw4c0Ny5czVlypQM/b7++usaPXq0mjVrZn4mBwAAAAAAAAA8bEhkIFdNmjRJERERatGihRo2bKgnnnhCNWrUkHTr9krz5s3TN998oypVqmj8+PF6//33M22ne/fuunHjRo4e8n2byWTSihUrVKxYMUVERKhhw4aqUKGCFi9e/K/OqX79+kpLS7NIWkRGRiotLc1ipUSRIkW0efNmlS1bVq1bt1ZgYKC6deuma9eumVdo9OjRQ59++qnmzZunkJAQRUZGat68eSpfvnymfffr108jRoxQkyZNtH379n91HgAAAAAAAADwIDIZd3uwAWAF27ZtU1RUlE6fPq1SpUpZO5wHRnJysjw8PNRx0io5OrtYOxyb9lnvKGuHAAAA8MC6Pe9M+qii3J0L3f0Aa+l2xNoRAAAAIBfwjAzYlJSUFJ06dUpDhw5V27ZtSWIAAAAAAAAAwEOOW0vBpnz11VcKCAhQUlKSJk6caFG2aNEiubq6ZroFBQXdV39BQUFZtrlo0aLcOCUAAAAAAAAAwL/AigzYlK5du6pr166ZlrVo0UK1atXKtMzBweG++lu9erVu3ryZaRmrQQAAAAAAAADA+khk4IHh5uYmNze3XG2zXLlyudoeAAAAAAAAACB3cWspAAAAAAAAAABgs0yGYRjWDgJA7khOTpaHh4eSkpLk7u5u7XAAAABQQDHvBAAAQH5iRQYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm2Vv7QAA5L7es7fI0dkl2zqf9Y7Kn2AAAABQcC2oLjkXyv12ux3J/TYBAADwwGJFBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIQJ6KiopSv379rB3GfZk9e7Z8fX1lZ2enqVOn3vPxw4cPV1hYWK7HBQAAAAAAAAAPExIZQCaSk5PVp08fvfvuu/r999/1yiuvWDukfNW3b1/5+fnJZDLp4MGD5v3dunVTQECAwsLCFBERobi4OOsFCQAAgIfeiBEjLOashmFo+PDh8vf3V3BwsKKiosx1Bw8erJCQEIWFhSksLEyLFy+2UtQAAAC4V/bWDgDIbTdu3JCjo+O/aiMhIUE3b95U06ZN5e3tnUuRPTjatGmjAQMG6IknnrDY36pVK82ePVv29vZatWqV2rZtq6NHj1opSgAAADzM9u3bp507d6ps2bLmfdOnT9eBAwd08OBBOTo6KjEx0Vz2zjvvaMyYMZKkM2fOqHLlynrqqadUrFixfI8dAAAA94YVGchz6enpGjBggIoXLy4vLy8NHz7cXJaQkKCWLVvK1dVV7u7uatu2rf744w9zedeuXdWqVSuL9vr162fxzaqoqCj16dNHb731lh555BE1atTorjFl1++8efMUEhIiSapQoYJMJpPi4+Pv2ub48eNVqlQpubm5qXv37rp+/bpF+Z49e9SoUSM98sgj8vDwUGRkpPbt22cu79atm5o1a2ZxTGpqqry8vPT555/ftf/cFBERoTJlymTY36JFC9nb38p/1q5dWydPnlR6enq+xgYAAACkpKSod+/emjlzpkwmk3n/pEmTNGHCBPMXm+78UlLRokXNP//1118ymUzMZQEAAB4QJDKQ5+bPny8XFxft2rVLEydO1MiRIxUdHS3DMNSqVSv9+eefiomJUXR0tI4dO6Z27drdVx/29vbatm2bZs2alW3du/Xbrl07rVu3TpK0e/duJSYmytfXN9s2lyxZomHDhmnMmDHau3evvL29NXPmTIs6f/31l7p06aItW7Zo586devTRR9WkSRP99ddfkqQePXpozZo1Ft8aW716ta5cuaK2bdtm2m9KSoqSk5Mttvwybdo0NWnSRHZ2/DMCAABQ0Flz3pmZ9957Tx07dlT58uXN+5KTk3X+/HktX75ctWvXVu3atTPcPmr69OkKCAhQ9erVNXv2bHl6euZ36AAAALgP3FoKeS40NFTDhg2TJD366KP66KOPtH79eknSzz//rBMnTpgTBQsWLFBQUJD27NmjmjVr5riPSpUqaeLEiTmqu27durv2e/sDTYkSJeTl5XXXNqdOnapu3bqpR48ekqTRo0dr3bp1FqsyGjRoYHHMrFmzVKxYMcXExKhZs2Z6/PHHFRAQoAULFmjAgAGSpLlz5+r555+Xq6trpv2OGzdOI0aMyNF556aFCxdqyZIl2rJlS773DQAAgPxnrXlnZnbs2KE9e/Zo/PjxFvtv3rypGzdu6Nq1a9q5c6cSEhJUp04dBQUFKTg4WNKtZ8H17dtXP/30kzp27KiGDRuSzAAAAHgA8FVq5LnQ0FCL197e3jp37pwOHz4sX19fi9UOVapUUdGiRXX48OF76iM8PDzHdXOz3zvbrFOnjsW+f74+d+6cevbsKX9/f3l4eMjDw0NXrlxRQkKCuU6PHj00d+5cc/3vv/9e3bp1y7LfQYMGKSkpybydOnXqvuK/F4sXL9aIESMUHR2tkiVL5nl/AAAAsD5rzDuzEhMTo19//VXly5eXn5+fTp8+rcaNG2v37t1ydXVVx44dJUlly5ZV3bp1tXfv3gxtVK1aVaVLl9amTZvyOXoAAADcDxIZyHMODg4Wr2/fi9YwDIv72d525347OzsZhmFRfvPmzQzHuLi45DienPSbF7p27arY2FhNnTpV27dvV1xcnDw9PXXjxg1znc6dO+v48ePasWOHFi5cKD8/P9WrVy/LNp2cnOTu7m6x5aUlS5ZoyJAhWrduncVDFQEAAFCw5fe8MzsDBw7UmTNnFB8fr/j4eJUpU0Y//vijnnnmGbVv315r1qyRJF26dEm7d+82f7Hqzi8tHTt2TPv371eVKlWscg4AAAC4NyQyYDVVqlRRQkKCxbe5Dh06pKSkJAUGBkq6dWunO58ZIUlxcXF53u+9CgwM1M6dOy32/fP1li1b1LdvXzVp0kRBQUFycnLShQsXLOp4enqqVatWmjt3rubOnauXXnrpvuL5t3r37q0yZcro9OnTatiwoSpVqiRJ6tChg65fv66WLVsqLCxMYWFhunjxolViBAAAAP5p7Nix+uGHHxQcHKx69epp0KBBql69uqRbCZCgoCCFhYWpXbt2+uijj+57/g8AAID8xTMyYDUNGzZUaGioOnTooKlTpyo1NVWvvfaaIiMjzbeKatCggSZNmqQvvvhCderU0cKFC3Xw4EFVq1YtT/u9V2+88Ya6dOmi8PBwPfHEE1q0aJF++eUXVahQwVynUqVKWrBggcLDw5WcnKx33nlHzs7OGdrq0aOHmjVrprS0NHXp0uW+z/PfmDFjhmbMmJFhf2arYQAAAABrio+PN//8yCOP6Lvvvsu03sqVK/MpIgAAAOQ2VmTAakwmk1asWKFixYopIiJCDRs2VIUKFbR48WJzncaNG2vo0KEaMGCAatasqb/++kudO3fO837vVbt27fTee+/p3XffVY0aNXTy5En16tXLos7nn3+uS5cuqVq1aurUqZP69u2b6TMmGjZsKG9vbzVu3Fg+Pj73HRMAAAAAAAAAFAQm458PIABgVX///bd8fHz0+eefq3Xr1vd0bHJysjw8PNRx0io5Omf/3JDPekf9iygBAADwMLs970z6qKLcnQvlfgfdjuR+mwAAAHhgcWspwEakp6fr7Nmzmjx5sjw8PNSiRQtrhwQAAAAAAAAAVsetpVDgLFq0SK6urpluQUFB99VmUFBQlm0uWrQoV+JOSEhQ6dKltWTJEn3++eeytyfPCAAAAAAAAAD8pRQFTosWLVSrVq1MyxwcHO6rzdWrV2f5oOtSpUrdV5v/5OfnJ+70BgAAAAAAAACWSGSgwHFzc5Obm1uutlmuXLlcbQ8AAAAAAAAAkDPcWgoAAAAAAAAAANgsk8G9bIACIzk5WR4eHkpKSpK7u7u1wwEAAEABxbwTAAAA+YkVGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABslr21AwAAAAAAPKAWVJecC93fsd2O5G4sAAAAKLBYkQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMnBPNm3aJJPJpMuXL2dbz8/PT1OnTs2VPocPH66wsLBcaetu/hm3yWTSihUr8qVvAAAAAAAAAEBGJDKQraioKPXr18/8+vHHH1diYqI8PDwkSfPmzVPRokXzNIb+/ftr/fr1edoHAAAAANvy1FNPKTQ0VGFhYapXr57i4uIkSd26dVNAQIDCwsIUERFh3i9Jn3/+uUJCQmRvb6+PPvrIOoEDAAAg19lbOwA8WBwdHeXl5ZWvfbq6usrV1TVf+wQAAABgXUuWLDF/aWrFihXq1q2b9u3bp1atWmn27Nmyt7fXqlWr1LZtWx09elSSVKNGDS1ZskTjxo2zYuQAAADIbazIQJa6du2qmJgYTZs2TSaTSSaTSfPmzTPfWmrTpk166aWXlJSUZC4fPnx4pm0lJSXplVdeUcmSJeXu7q4GDRrop59+ylEc/7y11KZNm/TYY4/JxcVFRYsWVd26dXXy5Mm7tnPs2DG1bNlSpUqVkqurq2rWrKl169blKIbbTp8+rRdeeEHFixeXi4uLwsPDtWvXrhy37+fnp1GjRunFF1+Uq6urfHx89OGHH2Y437Jly8rJyUk+Pj7q27fvPcUIAAAAFAR3rvxOSkqSnd2tj68tWrSQvf2t7+TVrl1bJ0+eVHp6uiSpatWqCgwMNNcFAABAwcDsDlmaNm2a6tSpo5dfflmJiYlKTEyUr6+vufzxxx/X1KlT5e7ubi7v379/hnYMw1DTpk119uxZrV69WrGxsapevbqefPJJ/fnnn/cUU2pqqlq1aqXIyEj9/PPP2rFjh1555RWZTKa7HnvlyhU1adJE69at0/79+9W4cWM1b95cCQkJOer7ypUrioyM1JkzZ/Ttt9/qp59+0oABA8wfmnLa/qRJkxQaGqp9+/Zp0KBBevPNNxUdHS1J+u9//6sPPvhAs2bN0m+//aYVK1YoJCQky5hSUlKUnJxssQEAAAC5zVrzzs6dO8vX11dDhgzR/PnzM5RPmzZNTZo0IXEBAABQwHFrKWTJw8NDjo6OKlKkiPl2Ur/++qu53NHRUR4eHjKZTNnebmrjxo06cOCAzp07JycnJ0nS+++/rxUrVui///2vXnnllRzHlJycrKSkJDVr1kwVK1aUJAUGBubo2KpVq6pq1arm16NHj9by5cv17bffqk+fPnc9/ssvv9T58+e1Z88eFS9eXJJUqVKle26/bt26GjhwoCTJ399f27Zt0wcffKBGjRopISFBXl5eatiwoRwcHFS2bFk99thjWcY0btw4jRgxIkfnDwAAANwva807v/jiC0nS/Pnz9c4772j16tXmsoULF2rJkiXasmVLvscFAACA/MXXVpDnYmNjdeXKFXl6epqfd+Hq6qoTJ07o2LFj99RW8eLF1bVrV/Nqh2nTpikxMTFHx169elUDBgxQlSpVVLRoUbm6uurXX3/N8YqMuLg4VatWzZzEuN/269Spk+H14cOHJUnPP/+8rl27pgoVKujll1/W8uXLlZqammVMgwYNUlJSknk7depUjs4FAAAAuBfWnnd26dJFGzdu1MWLFyVJixcv1ogRIxQdHa2SJUvmaywAAADIf6zIQJ5LT0+Xt7e3Nm3alKHszvve5tTcuXPVt29frVmzRosXL9aQIUMUHR2t2rVrZ3vcO++8ox9//FHvv/++KlWqJGdnZ7Vp00Y3btzIUb/Ozs551v7tW2P5+vrqyJEjio6O1rp16/Taa69p0qRJiomJkYODQ4bjnJyczKtcAAAAgLyS3/PO5ORkXblyRT4+PpKk5cuXy9PTU8WLF9eSJUs0ZMgQrVu3TmXLls23mAAAAGA9JDKQLUdHR6Wlpd13uSRVr15dZ8+elb29vfz8/HIlrmrVqqlatWoaNGiQ6tSpoy+//PKuiYwtW7aoa9euevbZZyXdeqZFfHx8jvsMDQ3Vp59+qj///DPTVRk5bX/nzp0ZXleuXNn82tnZWS1atFCLFi3Uu3dvVa5cWQcOHFD16tVzHCsAAADwIEtKStJzzz2na9euyc7OTiVKlNCqVatkMpnUoUMHeXl5qWXLlub669evl6enpxYuXKiBAwfq0qVLWrlypcaPH6/vvvtO1apVs+LZAAAA4N8ikYFs+fn5adeuXYqPj5erq6v5wdZ3ll+5ckXr169X1apVVaRIERUpUsSiTsOGDVWnTh21atVKEyZMUEBAgM6cOaPVq1erVatWCg8Pz3E8J06c0OzZs9WiRQv5+PjoyJEjOnr0qDp37nzXYytVqqRly5apefPmMplMGjp0aIbzyU779u01duxYtWrVSuPGjZO3t7f2798vHx8f1alTJ8ftb9u2TRMnTlSrVq0UHR2tb775Rt9//70kad68eUpLS1OtWrVUpEgRLViwQM7OzipXrlyO4wQAAAAedL6+vtq9e3emZTdv3szyuI4dO6pjx455FRYAAACshGdkIFv9+/dXoUKFVKVKFZUoUSLD8x4ef/xx9ezZU+3atVOJEiU0ceLEDG2YTCatXr1aERER6tatm/z9/fXCCy8oPj5epUqVuqd4ihQpol9//VXPPfec/P399corr6hPnz569dVX73rsBx98oGLFiunxxx9X8+bN1bhx43ta5eDo6Ki1a9eqZMmSatKkiUJCQjR+/HgVKlTontp/++23FRsbq2rVqmnUqFGaPHmyGjduLOnWrbbmzJmjunXrKjQ0VOvXr9d3330nT0/PHMcJAAAAAAAAAAWJyTAMw9pBAA8LPz8/9evXT/369cuT9pOTk+Xh4aGkpCS5u7vnSR8AAACAed75UUW5Oxe6v0a6HcndoAAAAFBgsSIDAAAAAAAAAADYLBIZsLqgoCC5urpmui1atCjf2wEAAAAAAAAA2A4e9g2rW716dZYP7LuXZ2jkVjt5KT4+3tohAAAAAAAAAMADhUQGrK5cuXI21Q4AAAAAAAAAwHZwaykAAAAAAAAAAGCzWJEBAAAAALg/nfZJ7u7WjgIAAAAFHCsyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBm2Vs7AAAAAADAA2pBdcm5UOZl3Y7kbywAAAAosFiRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMAAAAAAAAAANgsEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyUCBERUWpX79+1g7DLCfxzJs3T0WLFs2XeAAAAABb0rdvX/n5+clkMungwYPm/VFRUapQoYLCwsIUFhamDz74wFw2ePBghYSEmMsWL15sjdABAABgBSQygH9h06ZNMplMunz5ssX+ZcuWadSoUebXfn5+mjp1av4GBwAAANioNm3aaOvWrSpXrlyGsunTpysuLk5xcXF68803zfvfeecdHThwQHFxcVq9erVefvllXbp0KT/DBgAAgJXYWzsAoCAqXry4tUMAAAAAbFZERMQ9H3Pnaua//vpLJpNJ6enpuRgVAAAAbBUrMlBgpKena8CAASpevLi8vLw0fPhwc9mUKVMUEhIiFxcX+fr66rXXXtOVK1fM5SdPnlTz5s1VrFgxubi4KCgoSKtXr862v/j4eNWvX1+SVKxYMZlMJnXt2lWS5a2loqKidPLkSb355psymUwymUxZtvndd9+pRo0aKly4sCpUqKARI0YoNTU1y/opKSlKTk622AAAAIDclp/zznfeeUchISFq166djh8/blE2ffp0BQQEqHr16po9e7Y8PT3zLA4AAADYDhIZKDDmz58vFxcX7dq1SxMnTtTIkSMVHR0tSbKzs9P06dN18OBBzZ8/Xxs2bNCAAQPMx/bu3VspKSnavHmzDhw4oAkTJsjV1TXb/nx9fbV06VJJ0pEjR5SYmKhp06ZlqLds2TKVKVNGI0eOVGJiohITEzNt78cff1THjh3Vt29fHTp0SLNmzdK8efM0ZsyYLGMYN26cPDw8zJuvr+9dxwkAAAC4V/k171ywYIEOHz6sn3/+WfXq1VOzZs0syvv27asjR45o+/btGj16tC5evJgncQAAAMC2kMhAgREaGqphw4bp0UcfVefOnRUeHq7169dLkvr166f69eurfPnyatCggUaNGqUlS5aYj01ISFDdunUVEhKiChUqqFmzZndd7l6oUCHzLaRKliwpLy8veXh4ZKhXvHhxFSpUSG5ubvLy8pKXl1em7Y0ZM0YDBw5Uly5dVKFCBTVq1EijRo3SrFmzsoxh0KBBSkpKMm+nTp266zgBAAAA9yq/5p23EyQmk0l9+vTR8ePHM01WVK1aVaVLl9amTZvyJA4AAADYFp6RgQIjNDTU4rW3t7fOnTsnSdq4caPGjh2rQ4cOKTk5Wampqbp+/bquXr0qFxcX9e3bV7169dLatWvVsGFDPffccxnay2uxsbHas2ePxQqMtLQ0Xb9+XX///beKFCmS4RgnJyc5OTnlZ5gAAAB4COXHvDM1NVUXL15UqVKlJElLly5VqVKlzLePOnz4sAIDAyVJx44d0/79+1WlSpU8jQkAAAC2gUQGCgwHBweL17cf/nfy5Ek1adJEPXv21KhRo1S8eHFt3bpV3bt3182bNyVJPXr0UOPGjfX9999r7dq1GjdunCZPnqzXX3893+JPT0/XiBEj1Lp16wxlhQsXzrc4AAAAgLzWu3dvrVy5UmfPnlXDhg3l6uqqn376SU2bNlVKSors7Oz0yCOP6NtvvzUfM3DgQP3vf/+Tg4OD7O3t9dFHH5kTGwAAACjYSGSgwNu7d69SU1M1efJk2dndupvanbeVus3X11c9e/ZUz549NWjQIM2ZM+euiQxHR0dJt1ZO3K3e3epUr15dR44cUaVKlbKtBwAAADzoZsyYoRkzZmTYv3fv3iyPWblyZV6GBAAAABvGMzJQ4FWsWFGpqan68MMPdfz4cS1YsECffPKJRZ1+/frpxx9/1IkTJ7Rv3z5t2LAhR9/uKleunEwmk1atWqXz58/rypUrmdbz8/PT5s2b9fvvv+vChQuZ1nnvvff0xRdfaPjw4frll190+PBhLV68WEOGDLn3kwYAAAAAAACAAoJEBgq8sLAwTZkyRRMmTFBwcLAWLVqkcePGWdRJS0tT7969FRgYqKeffloBAQGaOXPmXdsuXbq0RowYoYEDB6pUqVLq06dPpvVGjhyp+Ph4VaxYUSVKlMi0TuPGjbVq1SpFR0erZs2aql27tqZMmaJy5crd+0kDAAAAAAAAQAFhMgzDsHYQAHJHcnKyPDw8lJSUJHd3d2uHAwAAgALKPO/8qKLcnQtlXqnbkfwNCgAAAAUWKzIAAAAAAAAAAIDNIpEBZKNnz55ydXXNdOvZs6e1wwMAAAAAAACAAs/e2gEAtmzkyJHq379/pmXcugkAAAAAAAAA8h6JDCAbJUuWVMmSJa0dBgAAAAAAAAA8tLi1FAAAAAAAAAAAsFmsyAAAAAAA3J9O+yRuuQoAAIA8xooMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLRAYAAAAAAAAAALBZJDIAAAAAAAAAAIDNIpEBAAAAAAAAAABsFokMAAAAAAAAAABgs0hkAAAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGQAAAAAAAAAAwGaRyAAAAAAAAAAAADaLREYBFxUVpX79+lk7jFw3b948FS1a1NphZGnTpk0ymUy6fPmytUMBAAAAAAAAgAcaiQzgX8osWfT4448rMTFRHh4e1gkKAAAAAAAAAAoIe2sHABREjo6O8vLysnYYAAAAAAAAAPDAY0XGQyA9PV0DBgxQ8eLF5eXlpeHDh5vLpkyZopCQELm4uMjX11evvfaarly5Yi4/efKkmjdvrmLFisnFxUVBQUFavXp1jvo9dOiQmjRpIldXV5UqVUqdOnXShQsXJN269ZKjo6O2bNlirj958mQ98sgjSkxMlCRdvnxZr7zyikqVKqXChQsrODhYq1atyrSvY8eOqWXLlipVqpRcXV1Vs2ZNrVu3zqKOn5+fRo8erc6dO8vV1VXlypXTypUrdf78ebVs2VKurq4KCQnR3r17zcdcvHhR7du3V5kyZVSkSBGFhIToq6++Mpd37dpVMTExmjZtmkwmk0wmk+Lj4zO9tdTSpUsVFBQkJycn+fn5afLkyRniGzt2rLp16yY3NzeVLVtWs2fPznaMU1JSlJycbLEBAAAAuY15JwAAAKyJRMZDYP78+XJxcdGuXbs0ceJEjRw5UtHR0ZIkOzs7TZ8+XQcPHtT8+fO1YcMGDRgwwHxs7969lZKSos2bN+vAgQOaMGGCXF1d79pnYmKiIiMjFRYWpr1792rNmjX6448/1LZtW0n/dzumTp06KSkpST/99JMGDx6sOXPmyNvbW+np6XrmmWe0fft2LVy4UIcOHdL48eNVqFChTPu7cuWKmjRponXr1mn//v1q3LixmjdvroSEBIt6H3zwgerWrav9+/eradOm6tSpkzp37qyOHTtq3759qlSpkjp37izDMCRJ169fV40aNbRq1SodPHhQr7zyijp16qRdu3ZJkqZNm6Y6dero5ZdfVmJiohITE+Xr65shvtjYWLVt21YvvPCCDhw4oOHDh2vo0KGaN2+eRb3JkycrPDxc+/fv12uvvaZevXrp119/zXKcx40bJw8PD/OWWd8AAADAv8W8EwAAANZkMm7/xRYFUlRUlNLS0ixWPjz22GNq0KCBxo8fn6H+N998o169eplXToSGhuq5557TsGHD7qnf9957T7t27dKPP/5o3nf69Gn5+vrqyJEj8vf3140bN1S7dm09+uij+uWXX1SnTh3NmTNHkrR27Vo988wzOnz4sPz9/TO0P2/ePPXr1y/bh2kHBQWpV69e6tOnj6RbKx7q1aunBQsWSJLOnj0rb29vDR06VCNHjpQk7dy5U3Xq1FFiYmKWt4Zq2rSpAgMD9f7770u6NcZhYWGaOnWquc6mTZtUv359Xbp0SUWLFlWHDh10/vx5rV271lxnwIAB+v777/XLL79kGp9hGPLy8tKIESPUs2fPTGNJSUlRSkqK+XVycrJ8fX2VlJQkd3f3LMcGAAAAuBfMOwEAAGBNPCPjIRAaGmrx2tvbW+fOnZMkbdy4UWPHjtWhQ4eUnJys1NRUXb9+XVevXpWLi4v69u2rXr16ae3atWrYsKGee+65DO1lJjY2Vhs3bsx09caxY8fk7+8vR0dHLVy4UKGhoSpXrpxFIiAuLk5lypTJNImRmatXr2rEiBFatWqVzpw5o9TUVF27di3Diow7Yy9VqpQkKSQkJMO+c+fOycvLS2lpaRo/frwWL16s33//3fwBzsXFJUdx3Xb48GG1bNnSYl/dunU1depUpaWlmVea3BmfyWSSl5eX+VplxsnJSU5OTvcUCwAAAHCvmHcCAADAmri11EPAwcHB4rXJZFJ6erpOnjypJk2aKDg4WEuXLlVsbKxmzJghSbp586YkqUePHjp+/Lg6deqkAwcOKDw8XB9++OFd+0xPT1fz5s0VFxdnsf3222+KiIgw19u+fbsk6c8//9Sff/5p3u/s7HxP5/jOO+9o6dKlGjNmjLZs2aK4uDiFhIToxo0bWY6FyWTKcl96erqkW7d6+uCDDzRgwABt2LBBcXFxaty4cYZ278YwDHPbd+77p6yuFQAAAAAAAAA8rEhkPMT27t2r1NRUTZ48WbVr15a/v7/OnDmToZ6vr6969uypZcuW6e233zbf/ik71atX1y+//CI/Pz9VqlTJYru9muHYsWN68803NWfOHNWuXVudO3c2/9E+NDRUp0+f1tGjR3N0Llu2bFHXrl317LPPKiQkRF5eXoqPj8/5YGTTbsuWLdWxY0dVrVpVFSpU0G+//WZRx9HRUWlpadm2U6VKFW3dutVi3/bt2+Xv75/lcz8AAAAAAAAAACQyHmoVK1ZUamqqPvzwQx0/flwLFizQJ598YlGnX79++vHHH3XixAnt27dPGzZsUGBg4F3b7t27t/7880+1b99eu3fv1vHjx7V27Vp169ZNaWlpSktLU6dOnfTUU0/ppZde0ty5c3Xw4EFNnjxZkhQZGamIiAg999xzio6O1okTJ/TDDz9ozZo1mfZXqVIlLVu2THFxcfrpp5/04osv5spKhkqVKik6Olrbt2/X4cOH9eqrr+rs2bMWdfz8/LRr1y7Fx8frwoULmfb79ttva/369Ro1apSOHj2q+fPn66OPPlL//v3/dYwAAAAAAAAAUJCRyHiIhYWFacqUKZowYYKCg4O1aNEijRs3zqJOWlqaevfurcDAQD399NMKCAjQzJkz79q2j4+Ptm3bprS0NDVu3FjBwcF644035OHhITs7O40ZM0bx8fGaPXu2JMnLy0uffvqphgwZori4OEnS0qVLVbNmTbVv315VqlTRgAEDslz58MEHH6hYsWJ6/PHH1bx5czVu3FjVq1f/dwMkaejQoapevboaN26sqKgoeXl5qVWrVhZ1+vfvr0KFCqlKlSoqUaJEhudySLdWqCxZskRff/21goOD9d5772nkyJHq2rXrv44RAAAAAAAAAAoyk5HZjfoBPJCSk5Pl4eGhpKQkubu7WzscAAAAFFDMOwEAAJCfWJEBAAAAAAAAAABsFokM3JeePXvK1dU1061nz57WDg8AAAAAAAAAUEBwayncl3Pnzik5OTnTMnd3d5UsWTKfI4LEEn8AAADkD+adAAAAyE/21g4AD6aSJUuSrAAAAAAAAAAA5DluLQUAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMvCvRUVFqV+/ftYOw6YMHz5cYWFh1g4DAAAAAAAAAB54JDKAf8lkMmnFihUW+/r376/169dbJyAAAAAAAAAAKEDsrR0AUBC5urrK1dXV2mEAAAAAAAAAwAOPFRnIFenp6RowYICKFy8uLy8vDR8+3Fw2ZcoUhYSEyMXFRb6+vnrttdd05coVc/nJkyfVvHlzFStWTC4uLgoKCtLq1atz1O/q1avl7+8vZ2dn1a9fX/PmzZPJZNLly5clZX6Lp6lTp8rPz89i39y5cxUYGKjChQurcuXKmjlzprnsxo0b6tOnj7y9vVW4cGH5+flp3LhxkmRu59lnn5XJZDK//me/6enpGjlypMqUKSMnJyeFhYVpzZo15vL4+HiZTCYtW7ZM9evXV5EiRVS1alXt2LEjR+MAAAAAAAAAAAUViQzkivnz58vFxUW7du3SxIkTNXLkSEVHR0uS7OzsNH36dB08eFDz58/Xhg0bNGDAAPOxvXv3VkpKijZv3qwDBw5owoQJOVrNcOrUKbVu3VpNmjRRXFycevTooYEDB95z7HPmzNHgwYM1ZswYHT58WGPHjtXQoUM1f/58SdL06dP17bffasmSJTpy5IgWLlxoTljs2bNH0q1ESGJiovn1P02bNk2TJ0/W+++/r59//lmNGzdWixYt9Ntvv1nUGzx4sPr376+4uDj5+/urffv2Sk1NzTL2lJQUJScnW2wAAABAbmPeCQAAAGvi1lLIFaGhoRo2bJgk6dFHH9VHH32k9evXq1GjRhYPAi9fvrxGjRqlXr16mVc9JCQk6LnnnlNISIgkqUKFCjnq8+OPP1aFChX0wQcfyGQyKSAgwJwIuRejRo3S5MmT1bp1a3OMhw4d0qxZs9SlSxclJCTo0Ucf1RNPPCGTyaRy5cqZjy1RooQkqWjRovLy8sqyj/fff1/vvvuuXnjhBUnShAkTtHHjRk2dOlUzZsww1+vfv7+aNm0qSRoxYoSCgoL0v//9T5UrV8603XHjxmnEiBH3dL4AAADAvWLeCQAAAGtiRQZyRWhoqMVrb29vnTt3TpK0ceNGNWrUSKVLl5abm5s6d+6sixcv6urVq5Kkvn37avTo0apbt66GDRumn3/+OUd9Hj58WLVr15bJZDLvq1Onzj3Fff78eZ06dUrdu3c3P9fC1dVVo0eP1rFjxyRJXbt2VVxcnAICAtS3b1+tXbv2nvpITk7WmTNnVLduXYv9devW1eHDhy323TmO3t7ekmQex8wMGjRISUlJ5u3UqVP3FBsAAACQE8w7AQAAYE0kMpArHBwcLF6bTCalp6fr5MmTatKkiYKDg7V06VLFxsaaVyDcvHlTktSjRw8dP35cnTp10oEDBxQeHq4PP/zwrn0ahnHXOnZ2dhnq3e5XuvXsCunW7aXi4uLM28GDB7Vz505JUvXq1XXixAmNGjVK165dU9u2bdWmTZu79v1PdyZcbsf/z313juPtstsxZsbJyUnu7u4WGwAAAJDbmHcCAADAmkhkIE/t3btXqampmjx5smrXri1/f3+dOXMmQz1fX1/17NlTy5Yt09tvv605c+bcte0qVaqYkw23/fN1iRIldPbsWYtkRlxcnPnnUqVKqXTp0jp+/LgqVapksZUvX95cz93dXe3atdOcOXO0ePFiLV26VH/++aekW8mHtLS0LON0d3eXj4+Ptm7darF/+/btCgwMvOt5AgAAAAAAAMDDjGdkIE9VrFhRqamp+vDDD9W8eXNt27ZNn3zyiUWdfv366ZlnnpG/v78uXbqkDRs25OgP/D179tTkyZP11ltv6dVXX1VsbKzmzZtnUScqKkrnz5/XxIkT1aZNG61Zs0Y//PCDxTfIhg8frr59+8rd3V3PPPOMUlJStHfvXl26dElvvfWWPvjgA3l7eyssLEx2dnb65ptv5OXlpaJFi0qS/Pz8tH79etWtW1dOTk4qVqxYhljfeecdDRs2TBUrVlRYWJjmzp2ruLg4LVq06N4HFQAAAAAAAAAeIqzIQJ4KCwvTlClTNGHCBAUHB2vRokUaN26cRZ20tDT17t1bgYGBevrppxUQEGB+EHh2ypYtq6VLl+q7775T1apV9cknn2js2LEWdQIDAzVz5kzNmDFDVatW1e7du9W/f3+LOj169NCnn36qefPmKSQkRJGRkZo3b555RYarq6smTJig8PBw1axZU/Hx8Vq9erXs7G797zN58mRFR0fL19dX1apVyzTWvn376u2339bbb7+tkJAQrVmzRt9++60effTRHI8lAAAAAAAAADyMTEZOHjQAPCA2bdqk+vXr69KlS+YVEw+T5ORkeXh4KCkpifsWAwAAIM8w7wQAAEB+YkUGAAAAAAAAAACwWSQyYLN69uwpV1fXTLeePXtaOzwAAAAAAAAAQD7g1lKwWefOnVNycnKmZe7u7ipZsmQ+R2T7WOIPAACA/MC8EwAAAPnJ3toBAFkpWbIkyQoAAAAAAAAAeMhxaykAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFn21g4AQO4xDEOSlJycbOVIAAAAYKvc3NxkMpn+VRvMOwEAAHA3uTHvvI1EBlCAXLx4UZLk6+tr5UgAAABgq5KSkuTu7v6v2mDeCQAAgLvJjXnnbSQygAKkePHikqSEhAR5eHhYOZoHS3Jysnx9fXXq1Klc+wf2YcC43T/G7v4wbvePsbs/jNv9Y+zuT36Mm5ub279ug3mn7eD/NdvAdbANXAfbwHWwDVwH2/CwX4fcmHfeRiIDKEDs7G499sbDw+Oh/McxN7i7uzN294Fxu3+M3f1h3O4fY3d/GLf7x9jdH1sfN+adtsfWf2ceFlwH28B1sA1cB9vAdbANXId/j4d9AwAAAAAAAAAAm0UiAwAAAAAAAAAA2CwSGUAB4uTkpGHDhsnJycnaoTxwGLv7w7jdP8bu/jBu94+xuz+M2/1j7O7PgzJuD0qcDwOuhW3gOtgGroNt4DrYBq6DbeA65B6TYRiGtYMAAAAAAAAAAADIDCsyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJtFIgMoQGbOnKny5curcOHCqlGjhrZs2WLtkKxq8+bNat68uXx8fGQymbRixQqLcsMwNHz4cPn4+MjZ2VlRUVH65ZdfLOqkpKTo9ddf1yOPPCIXFxe1aNFCp0+fzsezyH/jxo1TzZo15ebmppIlS6pVq1Y6cuSIRR3GLnMff/yxQkND5e7uLnd3d9WpU0c//PCDuZxxy5lx48bJZDKpX79+5n2MXeaGDx8uk8lksXl5eZnLGbes/f777+rYsaM8PT1VpEgRhYWFKTY21lzO2GXOz88vw++cyWRS7969JTFuWUlNTdWQIUNUvnx5OTs7q0KFCho5cqTS09PNdR60sWPemXvyc+516dIlderUSR4eHvLw8FCnTp10+fLlvD7FB1Jezke4DtnLr/dorkPW8vN9i+vwf/Lrbxg5GfOEhAQ1b95cLi4ueuSRR9S3b1/duHEjL07bJmV3LW7evKl3331XISEhcnFxkY+Pjzp37qwzZ85YtMG1yAMGgALh66+/NhwcHIw5c+YYhw4dMt544w3DxcXFOHnypLVDs5rVq1cbgwcPNpYuXWpIMpYvX25RPn78eMPNzc1YunSpceDAAaNdu3aGt7e3kZycbK7Ts2dPo3Tp0kZ0dLSxb98+o379+kbVqlWN1NTUfD6b/NO4cWNj7ty5xsGDB424uDijadOmRtmyZY0rV66Y6zB2mfv222+N77//3jhy5Ihx5MgR4z//+Y/h4OBgHDx40DAMxi0ndu/ebfj5+RmhoaHGG2+8Yd7P2GVu2LBhRlBQkJGYmGjezp07Zy5n3DL3559/GuXKlTO6du1q7Nq1yzhx4oSxbt0643//+5+5DmOXuXPnzln8vkVHRxuSjI0bNxqGwbhlZfTo0Yanp6exatUq48SJE8Y333xjuLq6GlOnTjXXeZDGjnln7srPudfTTz9tBAcHG9u3bze2b99uBAcHG82aNcvX830Q5PV8hOuQtfx8j+Y6ZC0/37e4Dv8nv/6GcbcxT01NNYKDg4369esb+/btM6Kjow0fHx+jT58+eT4GtiK7a3H58mWjYcOGxuLFi41ff/3V2LFjh1GrVi2jRo0aFm1wLXIfiQyggHjssceMnj17WuyrXLmyMXDgQCtFZFv++caTnp5ueHl5GePHjzfvu379uuHh4WF88sknhmHcenNycHAwvv76a3Od33//3bCzszPWrFmTb7Fb27lz5wxJRkxMjGEYjN29KlasmPHpp58ybjnw119/GY8++qgRHR1tREZGmv9wwNhlbdiwYUbVqlUzLWPcsvbuu+8aTzzxRJbljF3OvfHGG0bFihWN9PR0xi0bTZs2Nbp162axr3Xr1kbHjh0Nw3jwfueYd+atvJp7HTp0yJBk7Ny501xnx44dhiTj119/zY9TeyDk9XyE65C9/HqP5jpkL7/et7gOWcurv2HkZMxXr15t2NnZGb///ru5zldffWU4OTkZSUlJeXK+tiyzpNI/7d6925Bk/lIH1yJvcGspoAC4ceOGYmNj9dRTT1nsf+qpp7R9+3YrRWXbTpw4obNnz1qMmZOTkyIjI81jFhsbq5s3b1rU8fHxUXBw8EM1rklJSZKk4sWLS2LsciotLU1ff/21rl69qjp16jBuOdC7d281bdpUDRs2tNjP2GXvt99+k4+Pj8qXL68XXnhBx48fl8S4Zefbb79VeHi4nn/+eZUsWVLVqlXTnDlzzOWMXc7cuHFDCxcuVLdu3WQymRi3bDzxxBNav369jh49Kkn66aeftHXrVjVp0kTSg/U7x7wz7+XV3GvHjh3y8PBQrVq1zHVq164tDw8Prt0d8no+wnXIXn69R3Mdspdf71tch5zLzzHfsWOHgoOD5ePjY67TuHFjpaSkWNzmDf8nKSlJJpNJRYsWlcS1yCv21g4AwL934cIFpaWlqVSpUhb7S5UqpbNnz1opKtt2e1wyG7OTJ0+a6zg6OqpYsWIZ6jws42oYht566y098cQTCg4OlsTY3c2BAwdUp04dXb9+Xa6urlq+fLmqVKlinogwbpn7+uuvtW/fPu3ZsydDGb9zWatVq5a++OIL+fv7648//tDo0aP1+OOP65dffmHcsnH8+HF9/PHHeuutt/Sf//xHu3fvVt++feXk5KTOnTszdjm0YsUKXb58WV27dpXE/6vZeffdd5WUlKTKlSurUKFCSktL05gxY9S+fXtJD9bYMe/MW3k59zp79qxKliyZoc+SJUty7f6//JiPcB2yl1/v0VyH7OXX+xbXIefyc8zPnj2boZ9ixYrJ0dGR65KJ69eva+DAgXrxxRfl7u4uiWuRV0hkAAWIyWSyeG0YRoZ9sHQ/Y/YwjWufPn30888/a+vWrRnKGLvMBQQEKC4uTpcvX9bSpUvVpUsXxcTEmMsZt4xOnTqlN954Q2vXrlXhwoWzrMfYZfTMM8+Yfw4JCVGdOnVUsWJFzZ8/X7Vr15bEuGUmPT1d4eHhGjt2rCSpWrVq+uWXX/Txxx+rc+fO5nqMXfY+++wzPfPMMxbfEJMYt8wsXrxYCxcu1JdffqmgoCDFxcWpX79+8vHxUZcuXcz1HqSxY96ZN/J67pVZfa7dLfk5H+E6ZC0/36O5DlnLz/ctrsO9ya8x57rkzM2bN/XCCy8oPT1dM2fOvGt9rsW/w62lgALgkUceUaFChTJkY8+dO5chc4tbvLy8JCnbMfPy8tKNGzd06dKlLOsUZK+//rq+/fZbbdy4UWXKlDHvZ+yy5+joqEqVKik8PFzjxo1T1apVNW3aNMYtG7GxsTp37pxq1Kghe3t72dvbKyYmRtOnT5e9vb353Bm7u3NxcVFISIh+++03fuey4e3trSpVqljsCwwMVEJCgiT+ncuJkydPat26derRo4d5H+OWtXfeeUcDBw7UCy+8oJCQEHXq1Elvvvmmxo0bJ+nBGjvmnXknr+deXl5e+uOPPzL0e/78ea6d8m8+wnXIXn69R3Mdspdf71tch5zLzzH38vLK0M+lS5d08+ZNrssdbt68qbZt2+rEiROKjo42r8aQuBZ5hUQGUAA4OjqqRo0aio6OttgfHR2txx9/3EpR2bby5cvLy8vLYsxu3LihmJgY85jVqFFDDg4OFnUSExN18ODBAj2uhmGoT58+WrZsmTZs2KDy5ctblDN298YwDKWkpDBu2XjyySd14MABxcXFmbfw8HB16NBBcXFxqlChAmOXQykpKTp8+LC8vb35nctG3bp1deTIEYt9R48eVbly5STx71xOzJ07VyVLllTTpk3N+xi3rP3999+ys7P86FWoUCGlp6dLerDGjnln7suvuVedOnWUlJSk3bt3m+vs2rVLSUlJXDvl33yE65C9/HqP5jpkL7/et7gOOZefY16nTh0dPHhQiYmJ5jpr166Vk5OTatSokafn+aC4ncT47bfftG7dOnl6elqUcy3ySF49RRxA/vr6668NBwcH47PPPjMOHTpk9OvXz3BxcTHi4+OtHZrV/PXXX8b+/fuN/fv3G5KMKVOmGPv37zdOnjxpGIZhjB8/3vDw8DCWLVtmHDhwwGjfvr3h7e1tJCcnm9vo2bOnUaZMGWPdunXGvn37jAYNGhhVq1Y1UlNTrXVaea5Xr16Gh4eHsWnTJiMxMdG8/f333+Y6jF3mBg0aZGzevNk4ceKE8fPPPxv/+c9/DDs7O2Pt2rWGYTBu9yIyMtJ44403zK8Zu8y9/fbbxqZNm4zjx48bO3fuNJo1a2a4ubmZ/+1n3DK3e/duw97e3hgzZozx22+/GYsWLTKKFCliLFy40FyHsctaWlqaUbZsWePdd9/NUMa4Za5Lly5G6dKljVWrVhknTpwwli1bZjzyyCPGgAEDzHUepLFj3pm78nPu9fTTTxuhoaHGjh07jB07dhghISFGs2bN8vV8HyR5NR/hOmQtP9+juQ5Zy8/3La7D/8mvv2HcbcxTU1ON4OBg48knnzT27dtnrFu3zihTpozRp0+f/BsMK8vuWty8edNo0aKFUaZMGSMuLs7ivTslJcXcBtci95HIAAqQGTNmGOXKlTMcHR2N6tWrGzExMdYOyao2btxoSMqwdenSxTAMw0hPTzeGDRtmeHl5GU5OTkZERIRx4MABizauXbtm9OnTxyhevLjh7OxsNGvWzEhISLDC2eSfzMZMkjF37lxzHcYuc926dTP/P1iiRAnjySefNCcxDINxuxf//MMBY5e5du3aGd7e3oaDg4Ph4+NjtG7d2vjll1/M5Yxb1r777jsjODjYcHJyMipXrmzMnj3bopyxy9qPP/5oSDKOHDmSoYxxy1xycrLxxhtvGGXLljUKFy5sVKhQwRg8eLDFh90HbeyYd+ae/Jx7Xbx40ejQoYPh5uZmuLm5GR06dDAuXbqUD2f5YMqr+QjXIXv59R7Ndchafr5vcR3+T379DSMnY37y5EmjadOmhrOzs1G8eHGjT58+xvXr1/Py9G1KdtfixIkTWb53b9y40dwG1yL3mQzDMPJ0yQcAAAAAAAAAAMB94hkZAAAAAAAAAADAZpHIAAAAAAAAAAAANotEBgAAAAAAAAAAsFkkMgAAAAAAAAAAgM0ikQEAAAAAAAAAAGwWiQwAAAAAAAAAAGCzSGQAAAAAAAAAAACbRSIDAAAAAAAAAADYLBIZAADcg+HDh8tkMmXYKleunOt9TZ06VatXr871du9XVFSUmjVrZu0w7snw4cO1fft2a4fxr6xatUo+Pj5KSUnJ037i4+NlMpn03//+N0+O27Rpk8aOHZth/8KFCxUYGKi0tLR76hcAgIKOeSfzzvzGvBOALSORAQDAPXJ2dtaOHTsstsWLF+d6P7b2gfJBNGLEiAf6A6VhGBo8eLDeeustOTk55Wlf3t7e2rFjhxo0aJAn7Wf1gbJ9+/a6fv265s+fnyf9AgDwIGPe+eBg3plzzDsB3A97awcAAMCDxs7OTrVr17Z2GPfs2rVrcnZ2tnYY+aKgnOvGjRt16NAhde3aNc/7cnJyssrvdaFChdS5c2dNmzZN3bp1y/f+AQCwZcw7bV9BOVfmnQBsHSsyAADIZd9//71q1aolZ2dnlShRQr169dLVq1fN5VevXlWfPn0UEBCgIkWKyM/PTz179lRSUpK5jp+fn06ePKkZM2aYbyMwb948SZLJZNL7779v0ef7778vk8lkfr1p0yaZTCZ9//33atOmjdzd3fX8889Lki5fvqzXXntN3t7ecnJyUo0aNbR27dp7Ps958+bJZDJp9+7devLJJ1WkSBH5+/vrxx9/VHp6uoYOHSovLy+VLFlSgwYNUnp6uvnY4cOHy9XVVXv27NFjjz2mwoULKzAwUKtWrcrQz+zZsxUYGCgnJyeVLVtWQ4YMUWpqaoY4duzYoUaNGsnFxUX9+/c3j8c777xjHsNNmzZJkiZPnqyaNWvKw8NDJUuWVLNmzXT06FGLfrt27arg4GBt2rRJ1apVk4uLix577DHFxsZa1EtPT9eUKVPMMXp5een555+3uJ6HDx9Wy5Yt5eHhIRcXFzVt2lTHjh276xjPnz9fkZGReuSRR8z7KlasqPfee8/8esWKFTKZTHrrrbfM+9atWyeTyaTTp0+b993t9zKzpfo3btxQ3759Vbx4cXl4eKh79+6aP3++TCaT4uPjLWK9fv26+vTpo2LFisnb21v9+/c3X6fhw4drxIgRunr1qvlaREVFmY99/vnn9fPPPysuLu6uYwIAAP4P807mncw7mXcCDwsSGQAA3IfU1FSLzTAMSdJ///tftWjRQiEhIVq+fLkmTpyoZcuWqXv37uZj//77b6WlpWnMmDH64YcfNHr0aMXExOjZZ58111m+fLm8vLzUpk0b820EmjZtes9xvvrqq6pUqZKWL1+ut99+Wzdu3FCjRo20atUqjRkzRt9++62qVKmipk2b6sCBA/c1Fl27dlWrVq20fPlylS5dWm3atNEbb7yhhIQEzZ8/X3369NH48eP19ddfWxx38+ZNtWvXTl26dNGyZctUqVIlPfvsszp48KC5zocffqhXX31VDRo00LfffquePXtq4sSJevXVVzPE0aFDBz355JNatWqVOnXqpB07dkiSXn/9dfMYVq9eXZJ0+vRp9enTRytXrtSnn36q9PR0Pf744/rzzz8t2jx79qz69u2rd955R4sXL9bff/+tZ599Vjdv3jTXef311zVgwAA1a9ZM3333nWbMmCE3NzdduXJFknT8+HFz2/PmzdOXX36p8+fP68knn7zr/YfXr1+vunXrWuyLiIhQTEyM+fXmzZtVuHDhDPvKly+vMmXKSMrZ72VmBg4cqFmzZundd9/VkiVLJElDhgzJtO7gwYNlZ2enJUuW6NVXX9XkyZP16aefSpJ69Oih7t27W9weY+bMmeZjg4KCVLRoUUVHR2cbDwAADyPmnf+HeSfzTol5J/DQMgAAQI4NGzbMkJRhW7BggZGenm6UK1fOaN++vcUx33//vWEymYyDBw9m2ubNmzeNrVu3GpKMI0eOmPeXK1fO6N27d4b6koxJkyZZ7Js0aZJx59v6xo0bDUnGa6+9ZlHv888/N+zt7Y1ffvnFYv9jjz1mPP/889mee2RkpNG0aVPz67lz5xqSjI8//ti878CBA4Yko1atWhbH1qhRw2jVqpX59e1x/Oyzz8z7UlNTDT8/P/P4paamGo888kiGuMaOHWuYTCbj2LFjFnFMnDgxQ8yZjdU/paamGn///bfh6upqzJo1y7y/S5cuGa5bdHS0IcnYsmWLYRiGceTIEcNkMhljx47Nsv3OnTsb5cuXN65du2bed+7cOcPFxcWYMWNGlsedOXPGkGR88803Fvs///xzw8nJydxejRo1jD59+hh2dnbG5cuXDcO4da26dOliGIaR49/LEydOWPR38eJFo3DhwsbIkSMtjouMjDQkGSdOnLA47p/XqW7dusaTTz5pfj1s2DDDxcUly/ONiIgwnnvuuSzLAQB42DDvZN7JvJN5J4D/w4oMAADukbOzs/bs2WOxNWnSREePHtXJkyfVtm1bi2/NRUZGymQyae/eveY2FixYoGrVqsnV1VUODg564oknJCnDMvN/q0mTJhav165dq5CQEPn7+1vE+OSTT2rPnj331UfDhg3NP/v7+2fYd3v/qVOnMhx757cBCxUqpBYtWmjnzp2SpF9//VUXLlxQu3btLI5p3769DMPQtm3bLPb/81yzs3PnTjVq1Eienp6yt7dXkSJFdOXKlQzj7+Pjo6CgIPPrKlWqSJJ56fyGDRtkGEa23zBbu3atWrZsKXt7e/N4FytWTFWrVs12zBMTEyVJJUqUsNgfERGhlJQU7dq1S3/99Zfi4uLUs2dPeXp6auvWrbpx44Z27dqliIgISbqn38s7HThwQNevX1eLFi0s9rds2TLT+k899ZTF6ypVqljcYuBuHnnkEZ09ezbH9QEAeBgw77TEvJN5p8S8E3hY8bBvAADukZ2dncLDwzPsP3z4sCTLD0l3uv2Bavny5ercubNeeeUVjRkzRp6enkpMTNSzzz6r69ev52qsJUuWtHh94cIF7d+/Xw4ODhnqFipU6L76KFq0qPlnR0fHDPtu7//nuTk4OKhYsWIZ4r39QerSpUuSJC8vL4s6t1//czn+P881KwkJCXrqqacUHh6uWbNmycfHR46OjmratGmGGDM7D0nmehcvXpS9vX22fV+4cEFTp07V1KlTM5Rl92DI2304OTlZ7K9YsaLKlCmjzZs369q1aypWrJiqVKmievXqafPmzfLw8ND169cVGRlp7l+6++/lP2X1gTarc83JNc9O4cKFde3atRzXBwDgYcC80xLzTuadEvNO4GFFIgMAgFxSvHhxSdJHH32kWrVqZSj38fGRJH3zzTcKCwvTrFmzzGV33mf2bpycnHTjxg2Lff/8cHXbnQ9ivB1jaGioPvvssxz3l1du3rypS5cuWXyoPHfunLy9vSX933j+8ccfFsfd/vbU7fLb/nmuWVmzZo2uXLmiZcuWmT8EpaamZjmG2fH09FRqaqrOnTuX5Qet4sWLq2nTpnrttdcylLm5uWXZ9u3zu3z5coayevXqKSYmRteuXVO9evVkMpkUERGhr776Sh4eHvLx8VHFihUt2rnb7+U/3b4O58+ft6hz7ty5LGP+Ny5duiRPT888aRsAgIKGeee9Yd7JvPNOzDuBBxOJDAAAcknlypVVpkwZHT9+XL17986y3rVr18zfsLpt0aJFGepl9c2iMmXKmL+Fd9u6detyFGPDhg21evVq+fj4ZPlBIj8tX75c3bp1kySlpaXp22+/Ve3atSVJAQEBKlGihJYsWaLWrVubj1m8eLFMJpP5tgjZcXBwyDCG165dk8lksvh24JIlS5SamnrP8Tdo0EAmk0lz587Vu+++m2mdhg0b6uDBg6pWrdo9ffuwfPnycnR01IkTJzKURURE6O2331ZycrI6dOggSYqMjFT//v1lb29vXt4v5fz38p9CQkJUuHBhrVy5UlWrVjXvX7FiRY7buJOjo2O2D5k8ceJEhltDAACAzDHvvHfMO7PGvBPAg4BEBgAAucRkMmnKlCl68cUXdfXqVTVt2lQuLi46efKkvv/+e40dO1b+/v5q1KiRevfurZEjR+rxxx/XDz/8oPXr12doLzAwUBs2bFB0dLSKFSum8uXLy9PTU23atNHUqVP12GOPyd/fX1988UWO7/HauXNnzZo1S1FRUerfv7/8/f11+fJl7d+/Xzdu3NC4ceNye1iy5OjoqNGjR+v69esqX768Zs6cqdOnT2vQoEGSbt1y4L333tPrr7+uEiVKqHnz5tq3b5+GDRuml156SeXLl79rH4GBgVq5cqXq1asnFxcXBQQEqEGDBpKkl156Sa+++qoOHTqk999/P8MS9Zzw9/dXz549NWTIEP3555968skn9ffff+v777/X8OHDVbp0aY0YMUI1a9ZU48aN9corr6hUqVI6e/asYmJiVK9ePbVv3z7Ttp2cnFSjRg3FxsZmKIuIiNDff/+tPXv2mL9hGRoaKldXV23btk0zZ840183p7+U/FS9eXL169dKYMWNUuHBhhYWFafHixTp+/LikW7e6uBeBgYFKTU3VtGnT9Pjjj8vd3V0BAQGSpOTkZB05ckQjRoy4pzYBAHhYMe+8N8w7mXcy7wQKAOs+axwAgAfLsGHDDBcXl2zrrF271oiMjDRcXFwMFxcXIygoyHj77beNy5cvG4ZhGKmpqcbbb79tlChRwnBzczPatGlj7Ny505BkfPPNN+Z2Dh48aNSrV89wc3MzJBlz5841DMMwrly5Yrz00ktG8eLFjRIlShiDBw82JkyYYNz5tr5x40ZDkrFnz54M8SUlJRlvvvmmUbZsWcPBwcHw9vY2mjRpYqxatSrb84qMjDSaNm1qfj137lxDknH+/HmLepKMSZMmWezr0qWLERQUlGEcd+7cadSoUcNwdHQ0AgICjJUrV2bo95NPPjECAgIMBwcHo0yZMsbgwYONmzdv3jUOwzCMLVu2GNWrVzecnZ0NScbGjRsNwzCM+fPnGxUqVDAKFy5s1K5d29i9e7dRrlw5o3fv3lnGbBiGcf78eYtrYRiGkZaWZkycONF49NFHDQcHB8PLy8to166dkZSUZK5z9OhRo23btoanp6fh5ORk+Pn5GZ07dzYOHjyY2VCbTZ482ShdurSRnp6eoaxEiRKGh4eHkZaWZt7XrFkzQ1Km7d7t9/LEiRMZfgdTUlKMPn36GEWLFjXc3d2NLl26GNOmTTMkZXucYRhG7969jXLlyplf37x503jttdeMUqVKGSaTyYiMjDSXLV682HBxcTGSk5OzHQ8AAB4mzDuZdzLvZN4J4P+YDMMw8itpAgAAIEnDhw/X+++/rytXrlg7FJt2/vx5+fr6au3atRbL9q2pY8eO2rZtW6a3HrhfrVu3VtGiRfX555/nWpsAAAAS886cYt4JwNZxaykAAAAbVaJECfXq1UuTJ0+2ygfKmJgYbdu2TTVq1FB6erpWrVqlL7/8UlOmTMm1Po4fP64ffvhBBw8ezLU2AQAAcG+YdwKwdSQyAAAAbNh//vMfffzxx0pJSZGTk1O+9u3q6qpVq1Zp4sSJ+vvvv1W+fHlNmTJF/fr1y7U+fv/9d82ZM0cVK1bMtTYBAABw75h3ArBl3FoKAAAAAAAAAADYLDtrBwAAAAAAAAAAAJAVEhkAAAAAAAAAAMBmkcgAAAAAAAAAAAA2i0QGAAAAAAAAAACwWSQyAAAAAAAAAACAzSKRAQAAAAAAAAAAbBaJDAAAAAAAAAAAYLNIZAAAAAAAAAAAAJv1/wAePmcz4ohReAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1600x800 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Binary feature importance plot saved.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import os\n",
+    "\n",
+    "FEATURE_NAMES = [\n",
+    "    \"title_len\", \"has_question\", \"has_exclamation\", \"title_has_number\", \"title_is_allcaps\",\n",
+    "    \"has_title\", \"is_text_post\", \"selftext_len\",\n",
+    "    \"is_known_bot\", \"is_anonymous_author\",\n",
+    "    \"hour_of_day\", \"day_of_week\",\n",
+    "    \"author_post_count\", \"author_mean_score\",\n",
+    "    \"subreddit_post_count\", \"subreddit_median_score\", \"subreddit_median_comments\",\n",
+    "    \"title_sentiment\", \"selftext_sentiment\"\n",
+    "]\n",
+    "\n",
+    "def get_feature_importance(model, feature_names):\n",
+    "    booster = model.get_booster()\n",
+    "    scores = booster.get_score(importance_type=\"weight\")\n",
+    "    importance = {feature_names[int(k[1:])]: v for k, v in scores.items()}\n",
+    "    return {name: importance.get(name, 0) for name in feature_names}\n",
+    "\n",
+    "importance_A_bin = get_feature_importance(model_A_bin, FEATURE_NAMES)\n",
+    "importance_B_bin = get_feature_importance(model_B_bin, FEATURE_NAMES)\n",
+    "\n",
+    "# Sort by Config B binary importance\n",
+    "sorted_features = sorted(FEATURE_NAMES, key=lambda f: importance_B_bin[f])\n",
+    "vals_A = [importance_A_bin[f] for f in sorted_features]\n",
+    "vals_B = [importance_B_bin[f] for f in sorted_features]\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(16, 8), sharey=True)\n",
+    "\n",
+    "for ax, vals, title, color in zip(\n",
+    "    axes,\n",
+    "    [vals_A, vals_B],\n",
+    "    [\"Config A (Conservative)\", \"Config B (Aggressive)\"],\n",
+    "    [\"steelblue\", \"darkorange\"]\n",
+    "):\n",
+    "    bars = ax.barh(sorted_features, vals, color=color, alpha=0.85)\n",
+    "    ax.set_title(title, fontsize=13, fontweight=\"bold\")\n",
+    "    ax.set_xlabel(\"Feature Importance (weight)\", fontsize=11)\n",
+    "    ax.spines[\"top\"].set_visible(False)\n",
+    "    ax.spines[\"right\"].set_visible(False)\n",
+    "    for bar, val in zip(bars, vals):\n",
+    "        if val > 0:\n",
+    "            ax.text(bar.get_width() + max(vals)*0.01, bar.get_y() + bar.get_height()/2,\n",
+    "                    f\"{int(val)}\", va=\"center\", fontsize=8)\n",
+    "\n",
+    "axes[0].set_ylabel(\"Feature\", fontsize=11)\n",
+    "plt.suptitle(\"XGBoost Feature Importance — Binary Engagement Classification\\n(Pushshift Reddit, 276M Training Rows)\",\n",
+    "             fontsize=14, fontweight=\"bold\", y=1.01)\n",
+    "plt.tight_layout()\n",
+    "\n",
+    "os.makedirs(\"../outputs/figures\", exist_ok=True)\n",
+    "plt.savefig(\"../outputs/figures/xgboost_binary_feature_importance.png\", dpi=150, bbox_inches=\"tight\")\n",
+    "plt.show()\n",
+    "print(\"Binary feature importance plot saved.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33719acb-13d0-495a-b426-960fd0a68878",
+   "metadata": {},
+   "source": [
+    "### Binary Model Feature Importance Analysis\n",
+    "\n",
+    "The binary feature importance rankings are strikingly consistent with the 4-class results, confirming that the predictive hierarchy of features is stable across label granularities. `subreddit_post_count`, `author_mean_score`, and `author_post_count` remain the top three features in both configs, meaning community size and author history dominate regardless of whether the task distinguishes four engagement tiers or a single high/low boundary.\n",
+    "\n",
+    "Two notable differences emerge when comparing binary to 4-class importance rankings. First, `selftext_len` rises to the fourth position in the binary Config A ranking, above `subreddit_median_comments` and `subreddit_median_score`. This suggests that post length carries more direct signal for the binary high/low distinction than for finer-grained class separation. Longer self-posts may correlate more cleanly with high engagement in the aggregate than within specific engagement categories. Second, the absolute weight counts in the binary models are substantially lower than their 4-class counterparts (Config B top feature: 12,625 vs 54,721), reflecting the simpler decision boundary. Fewer splits are needed to separate two classes than four.\n",
+    "\n",
+    "`has_question` and `has_exclamation` remain zero-weight features in Config A and near-zero in Config B across both tasks, reinforcing their status as candidates for removal in Milestone 4. The consistency of low-weight features across both label granularities strengthens the case that these structural title signals carry no meaningful engagement information independent of community and author context."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb8d6727-e72e-45fe-9884-eb1b29a2cf76",
+   "metadata": {},
+   "source": [
+    "### Fitting Analysis — Train vs. Validation vs. Test Error\n",
+    "\n",
+    "The plots below visualize where each model configuration sits on the underfitting/overfitting spectrum by comparing weighted F1 across train, validation, and test splits. A model that overfits would show high train F1 with significantly lower val/test F1. A model that underfits shows uniformly low F1 across all splits with val/test potentially exceeding train due to distribution differences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "4acd733e-e762-4ab0-9845-c6c3d81fc3c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAJpCAYAAADWoRArAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd1RUx98G8GdpS+9VQcCOFbtiwd57NLYoGo0mGo0lyS9qrInRGDWWJCYxKrHFGruxNxB7j71joQgIiNKZ949992YvuwsLooA+n3P2uDt37ty5bXf8MndGIYQQICIiIiIiIiIiIqIiwaiwK0BERERERERERERE/2HQloiIiIiIiIiIiKgIYdCWiIiIiIiIiIiIqAhh0JaIiIiIiIiIiIioCGHQloiIiIiIiIiIiKgIYdCWiIiIiIiIiIiIqAhh0JaIiIiIiIiIiIioCGHQloiIiIiIiIiIiKgIYdCWiIiIiIiIiIiIqAhh0JaIiKiIOXz4MBQKBRQKBXx8fAq8fB8fH6n8w4cPF3j5byP18VIoFLh///5r315wcLC0vaZNm7727b2tmjZtKh3H4ODg17695ORkTJo0CeXKlYNSqZS2HR8fj4EDB0qfp06dWqDbfd3fGe+6hw8fon///vDy8oKxsTEUCgX8/f0BvN7v06lTp0plDxw4sEDLJiIioqKPQVsionfIlStXYG5uLv0n8LffftPK8/XXX0vLHRwc8OjRI9nyjIwMbNiwAT169ICPjw+srKxgZWWF0qVLo0mTJpgyZQrOnDkjW0czWKF+GRkZwdbWFlWqVMHIkSPx4MGD17rvryo+Ph5Tp06VXnmh+R9vfa+uXbsaVFZwcLBUhwsXLhRoPYuSYcOGyY5P1apVC7tKlAeawVJdwabclhdXEydOxLfffovbt28jLS3NoHUMuWcPHz4sLd+yZUvBVfg1mDhxIhQKBRYuXChLv3PnDsaMGYNq1arBzs4OSqUSJUqUQMeOHbFq1SpkZGQUUo1zJoRA9+7dsWrVKjx69AhZWVkGrXfhwgXpnOn7g0Fu3+dF2bNnzzB+/HhUqVIFVlZWMDc3h4eHB/z9/dG/f3+sXr26sKuYo/v370vHfv78+YVdHSIiIt0EERG9U+bMmSMACADCyspK3Lp1S1p24sQJYWxsLC1ftWqVbN1bt26JmjVrSsv1vby9vWXrBQUF5bqOk5OTCA8PfxOHIF/u3bsnq29eTJkyJdf979Kli5Q/Pj5ehISEiJCQEHH69GlZWYGBgdI6y5cvz1c9T58+LZUfHx+fp315E5KTk4W9vb3WMTpz5kyh1UmzHvfu3Xvt24uKipLO0aVLl1779gqa5nUaFBSU5+Wvox667peCVqpUKWl7X331lTh69KgICQkRGRkZ4ubNm9I5ffDggbSOIfes5neIruOV03fGm1axYkUBQPZ9vnjxYmFmZpbjd2C9evXEkydPCrHmut29e1eqo4mJiVi5cqUICQkR58+fF0Lo/z5dvny5tF5gYKDOsnO7Ph88eCCVffPmzdewd/kTFxcnypYtm+P51LfPRcWhQ4f0tlmIiIiKCpN8xHmJiKgYGzNmDLZv344jR47gxYsXGDBgAEJCQpCamooBAwYgMzMTANCjRw/069dPWi86OhotWrRAeHg4AMDU1BQDBgxA27Zt4ezsjPj4eFy4cAFbtmxBfHy83u37+/tj0aJFyMrKwunTp/Hll18iKysLsbGxWL58OSZPnvxa97+wubu7Y8OGDVrpTk5O0ns7Ozs0atTotdWhdu3ar63sgrB582ad11BwcDBq1ar15itUCFxdXeHq6lrY1SADJCUlwdraGoDqMXq1oUOHwtfXV/pcrlw5lCtX7rXU4XV/Zxjq+vXruH79OmrXrg0vLy8AwMaNG/HJJ59IeZo0aYIRI0bAyckJoaGhmD17Nl6+fImTJ0+iU6dOOH78OExNTQtrFyTq86p5TkuUKIEPPvhAlu91fp+WKlUKpUqVem3l59fChQtx+/ZtAKo6Tpo0CaVLl0ZcXBzu3r2L7du3w8jo7X2gMysrC6mpqbCwsCjsqhAR0duusKPGRET05t2/f1/Y2NhIvUxmzJghRowYIX12d3cXMTExsnWGDRsm6220b98+veWfPXtW9lmzp2323je1atWSlg0bNkyrrNDQUNGzZ09RokQJYWpqKuzs7ESDBg3EwoULRVpamlb+6Oho8b///U9UrlxZWFpaCqVSKcqWLSuGDx+u1UMyKytL/PTTT6JevXrC1tZWGBsbCycnJ1G1alUxaNAgcfz4cSGEvDeUrtehQ4dyONryXnKG9OjR1QNIs9eWrldQUJDB9fT29tZZ9+y9vv744w9RrVo1oVQqhYeHh/jyyy9Fenq6rK6ZmZli9uzZokyZMkKpVIpy5cqJefPmiQMHDuS7F1Pr1q2ldQcNGiTrjZ2amqqVX3N/9u3bJ2bPni3KlSsnzMzMhI+Pj/jhhx9k+TMyMsSoUaNE48aNRcmSJYWlpaUwMzMTJUuWFN27dxdHjx7V2obmcbx37554/vy5sLW1ldKy94LbsmWLtKxKlSpS+po1a0RgYKBwdHQUxsbGwsHBQfj5+Ym+ffuKXbt2Sfn09dIz9JotbPntaZv92n/w4IHo16+fcHR0FObm5qJhw4bi5MmTWuVduXJFdOjQQVhbWwtbW1vRuXNnce3atRx7MsbGxoqvv/5aVKtWTVhZWQlzc3NRqVIlMWXKFPH8+XNZ3uzn4/Tp06Jly5bCxsZG2Nvb5/g0gfr8aeaZMmWK1nHQ9crtvlffW/p6DWbvxRsTEyOGDx8u3N3dhZmZmfD395ddd2oPHz4Uffv2FQ4ODsLKyko0a9ZMnDhxQuc+aPr2228FAPHdd98JIYRIS0uT9T6uU6eO1nfIpk2bZHX87bffhBBC9O7dW0r75ptvZOukpqbKeuNfvHhRWnb16lUxePBg4evrK5RKpbCxsREBAQFi+fLlIisrS1ZO9v1ZtWqV8Pf3F0qlUnTp0kX23ZL9pd5/Xd+nOZ0zQ86r+p7Q18M6+/V4+fJl0blzZ2FrayssLS1F27ZtdfbMPXbsmAgMDBSWlpbC0dFRfPDBB+Lx48d6fxP0adeunZR/wYIFOvMkJibKPmffl6NHj4rAwEBhZWUl7O3tRa9evXQ+bZOX+1QI1XfkypUrRatWrYSLi4swNTUVLi4uIjAwUKxfv17rnOl6qdsKmmkXL14Uo0aNEiVKlBBGRkZi8+bNOfbWNfTcnThxQjRu3FhYWFiIkiVLiilTpoiMjAzx5MkT0adPH2Fvby+srKxEu3btilRvayIiejMYtCUiekctW7ZM+o+DqampUCgU0uedO3fK8qalpcmCvIMGDcrTtnQFbTMzM8WpU6eEtbW1tOyXX36Rrffjjz/K6pX91bBhQ/HixQsp//Xr14W7u7ve/La2tiIkJETKP3Xq1Bz/4zZz5kwhxLsZtC1XrpzOMmbMmCGr69ChQ3Xm0wzG5yVo++jRI2FkZCQA1R8Hnj59Kvz8/KSyNm7cqLWO5v7oq/fq1aul/MnJyTkeJ4VCITZv3izbhq7/0H/66adS2ldffSXL/8EHH0jL5s6dK4QQIjg4OMftav7RQl/Q1tBrtrAVRNDW1tZWuLq6au2jk5OTSEhIkNa5evWqsLOz08rn4OAgfHx8pM+aQdtbt24JT09PvcexSpUqIjY2VsqveT7UgX71Zzs7u2ITtNV1f5iZmcn+oBUVFSW8vLy08imVSlG5cmWtfdCkHj7n+vXrQgghjhw5Iivj77//1nm9VKlSRcrTokULIYQQ+/fvl9IqVqwoy79582ZpWZ06dWTp5ubmeo9Xv379ZIFbzXOS/dgUl6Cth4eHsLKy0iqjYsWKIiMjQ1rn0KFDOoeo8PHxEY6Ojlr7kJNevXpJ+StUqCDWrl0rIiMjc1xHc1/KlSsnTExMtOri6ekpoqKipHXyep+mpKTIAsr6jmt+grbZr4+CCNp6enrKvkvUr2HDhglfX99czykREb393t7nVoiIKEeDBg2SJr9KT0+HEAIA8NFHH6F9+/ayvLdu3cLz58+lz23atJEtDwsLQ2hoqOwVHR2tc7tHjhyBQqGAsbEx6tati6SkJACq4RgGDx4s5bt06RLGjRsn1atv377YuXMnfvzxR1hZWQEAjh07JhtO4YMPPkBkZCQAoEyZMli9ejX+/vtv6fHVxMRE9OnTBykpKQAgDVNgbGyMhQsX4uDBg9i0aRPmzJmD1q1bw9zcHACwaNEirSENQkJCpFeNGjX0H+hsHjx4oHMistwmF2rfvj1CQkKkGcsBYMKECVIdJk6cWKD1vHXrFkaOHImdO3fivffek9I1Jxc6duwYfv/9d+lzv379sHPnTsyYMQOXL182eFuaVqxYIU3006ZNGzg7O8uG6dA3oY/a3bt3MWXKFOzYsQNNmjTRWW8TExNMmjQJq1atwq5du3D48GHs3r0bM2bMAAAIIfD111/nWtcRI0ZI7//8809paJHU1FRs27ZN2pb6cWrNczNlyhQcOHAAW7ZswcKFC9GlSxfY2Njkuk1Dr9m3QWJiIqysrLBmzRosX74ctra2AIDY2FisWbNGyjdq1CgkJCQAANzc3LBs2TJs2bIFlStXxv3793WW/cEHH0iTLDZr1gybN2/Gtm3bEBgYCAD4999/MXr0aJ3rPn78GA4ODliyZAn27t2L6dOnY+LEiQgJCZHl27BhA0JCQrBo0SK9+5jbPdutWzeEhIRg0KBB0vJ27dpJyzdu3Ki3bF2ePXuGJUuWYP369ShRogQAIC0tDb/++quUZ+LEidKQAFZWVpg/fz62b9+OVq1a4cqVK3rLfvDgAc6dO4dKlSqhQoUKAFTf45r0DSWgmX7x4kUAQPPmzaXhJa5fv45z585JeTQnuVL/bjx9+hT9+/eXvt8//vhj7N69GytWrJCGGFi9ejWWL1+usw63bt1Cw4YNsW7dOuzcuRO9e/fGxo0bZd8d7u7u0rH/8MMP9R6LkJAQTJgwQfrs7+8vO6+GfJ8bKiIiAhUqVMCmTZswf/58aWiJ69evY9++fQBU32nDhg2TJscrU6YM/vrrL6xfvx5KpRJxcXEGbw8AOnToIL2/ceMGevfuDXd3d3h6eqJPnz7Ytm2b9Nuty61bt9ChQwfs2LEDCxculIYXefTokWzf83qfTp8+Hf/88w8AQKFQYPDgwdi6dSv+/vtvfPnll3BwcACAHM9rSEgIPDw8tOp8584djBs3Dv/88w9WrlyJMmXK5OmY6fLo0SM0aNAA27dvx8cffyyl//bbb0hISMCyZcuwYsUK6Xtd85wSEdE7olBDxkREVKh2796t1ZND8zFTtdDQUFme7EMjKJVKnT2J1HKbiEyhUIj3339f1mNm7Nix0vJKlSrJekfNnj1bWubs7CyysrLEpUuXZGVqPkL96NEjYWpqKi3bvn27EEKIgIAAAUBYWlqKffv2ibi4OL3H6nVPRKbZszOn3jsFMRGZIT1tO3ToIKVHRETIylQ/9jpy5Egpzc/PT3aOxowZo3cfclKhQgVpvb/++kvaJ3WPaxMTE60eXZr7M2LECCn9+PHjUrqjo6NsnWPHjomePXuKUqVK6bx+NfdTCP0TkbVo0UJK37ZtmxBCiG3btklpmhPM9e3bV0pft26diI6O1nsc9PW0zcs1q8+lS5ekyY3y89LsCadPQfS0BSCbVEtziJaxY8cKIYSIiYmR9cbfsGGDlP/p06fCwsJC6365fPmylGZqair27Nkj7dvGjRtly9SPX2ueD4VCofN7UoicJ6zTN7RAQUxEZmhPW83jM3PmTCm9e/fuQgjVExCavZZnzZol5U9JSREeHh4690EIIebNmycAiK+//lpKUw+XoH6lpKTo3L///e9/suOuNn36dK1znpCQIPWmtbS0lHpdL1q0SMpbpUoV2TU7ceJEaVn9+vV1npOSJUuK5ORkg4+tmr7v04KYiMyQ3pqmpqbi8ePH0rI2bdpIyxYuXCiEUA1ZpHkeTpw4IeW/ePGibJkhPW2FEGL48OE5PgnTpUsX2W+C5r6UKFFCNtSN5gSp9vb2IjMzM8/3aVZWlqxn/siRI3OsvyETkWnuj/r6M7QMQ86dubm51O6JioqSbU/zyaMOHTponVMiIno3cCIyIqJ3VHJyss6eZCNGjMCRI0dkk4jY29vL8uS1V44m9URkgKrH2rfffot///0X69evR3R0NA4dOgQAuHbtmrROw4YNoVAopM+aPShjYmIQExMjy29mZoY6depIn0uWLIkyZcrg+vXrUtkdO3bE8OHDERYWhpcvX6JVq1YAABcXF1SvXh0dO3bE0KFDC3yiEX0TkVWqVKlAt/OqmjdvLr13dnaWLYuLi4ONjQ1u3bolpTVq1Eh2jgIDA/Hjjz/maZvHjx/HjRs3AADW1tbo3LkzAMDHxweNGjVCSEgIMjIysGrVKowbNy5P9da8Zvfu3Yv27dtLPWP1efbsWa69X0eMGIEDBw4AAJYuXYpOnTrJej9q9pAcNmwY1q1bh8zMTPTq1QuA6t6qUqUK2rRpgxEjRkg9wfQpiGt25MiROHLkSI55crJ8+XIMHDgwxzya3x9CR487dW/q7Hk12djYyHpg6jqft2/flpUfEBAgy1+hQgVcuHBBVu7Vq1el9+np6VpPDmguu3nzJmrWrClLL1u2LKpVq6ZznaIut/vj6dOnUq9lAGjcuLH0XqlUol69enqfCvj7778BAN27d5fS7OzsZHmio6OlCco0RUVF6Vxn0KBBmDp1KrKysrB27Vr88MMP2LRpk9SbtkePHlIPbM3z+u+//8rqrklfb+H27dsXy57qFStWlHpNA7rPq+Z3tZmZGerWrSt9rlatGuzt7XOcQFSXn3/+GZ9++ik2btyIkJAQnDp1SnbtbN26FevWrUPv3r211q1Xrx7MzMykz5qT6MXHxyMmJibP96mXl5fsCR/N67AgaD5xUlAqVKgAR0dHANq/sw0aNJDe6/stIyKitx+HRyAiekd99dVXUhDTxcVFGnIgNDQUc+bMkeUtX768LHi1f/9+2fKUlBQIIeDm5pbrdtWznDdq1Ai9evWSPV5/+PBh3L17N9cydAWBNGkGD3Nap1+/fggNDcXw4cNRv359ODk54enTp9i/fz9Gjx6tNUt4QVAqldL+a77U/3ErKjTrY2Ii/xuvrmOZ/Zjndo500Rz6ICkpCVZWVtLwEZqPnuc0REJO9VabM2eOFLCtXbs21q9fj6NHj0p/MFDTDCzq07lzZykItXPnTjx8+FAaGsHV1VU21EiTJk1w/vx5jB07Fo0bN4a7uzvi4+MRGhqKSZMmoU2bNrkGkgvjms0Pze+Lp0+fai3XTFMH3bLLfk9onk9915eue/9VaA4Lo6br0eniQt/9Yejx1JcvKioKYWFh8PX1lQ3Dkj24febMGZ3rnz17Vuc6np6eaN26NQDgyZMnOHTokGxohCFDhugsLye6zilQfM9rXu8TQ38fDeHn54dJkyZh7969iI2NxZ49e2R/eDp58mS+ys2r58+fa+1DQX8X6Lo+NLeRkZEhW6brey87zT+IZ//jVfY/lqvl91wREVHxxKAtEdE76ODBg7JxFv/44w/MmzdP+jx58mTZmKSmpqbo27ev9PnPP//EsWPHCqQu2f8Dov6Pjp+fn5QWFhYmyxcaGiq9d3Z2hrOzsyx/amqqLDjw5MkTWTC4YsWK0rYbNmyIn3/+GcePH0dMTAxu3rwpja+3ZcsWvHz5EoD2f6gMCei9Dpr10FWHN1nP8uXLS++PHz8uW3b06NE8lZWSkoL169cblPfff/+VBXnyKjw8XHo/efJk9OzZU2+vvNwYGxtLYxFmZGQgKChI6rH2wQcfSONLAqrrrWrVqpg7dy6OHj2KiIgIPHnyBD4+PgCA06dPy3rE6ZKXa1afw4cPQ6gmo83XK7detgBQuXJl6f2xY8dkvfhu3LiBmzdvSp+rVKmSa3n6lC1bVhY4CQsLk97HxsZKPbc1aX5XWFhYID4+Xud+JiYmSmNnairoYJAh92xu931BcXV1lQWLNI9namoqTp06pXO9LVu2ICsrC926dZOlN2jQQNaz9vvvv9cKbm3ZskX2e6Puha6mGZidM2eO9MeVcuXKye5bzfMaEBCg9/pNTEzUuQ+v87zqO2dv6rxqflenpqbKxge+dOmSrIesIQ4dOoRnz57J0oyNjdG6dWvUq1dPStO3T6dOnUJ6err0WbM9YW9vr/Wbbsh96uLiAldXV2kddc9vTZrtiLwee13Xh2aAOiYmBqmpqQBUvwW7d+/OtUwiIqLccHgEIqJ3TGJiIgYNGiT95+XDDz+UHkPftm0bdu7cidTUVPTv3x+nTp2SHmGcNm0adu3ahYcPHyItLQ0tW7bE0KFD0aJFC9ja2uLx48d48eJFrttPSEiQgq5PnjyRJn8CVD2EypUrBwAICgrCjz/+CCEErly5ggEDBqBv3764desWpk2bJq0TFBQEhUKBqlWronbt2lKwtl+/fpg2bRrMzc0xa9Ys6T+IJUuWlB4r79mzJxQKBZo3b46SJUvCxsYGZ8+elYJeWVlZSE1NhaWlJRwdHaFQKKTj9uOPP6Ju3bowMjJCw4YN83k28s7JyUl6v2HDBvj4+MDMzAwVKlSAi4vLG61nr169pMlcLl++jA8//BA9e/bEhQsX8PPPP+eprM2bN0uBPUdHR9k5Vvvzzz+l8xscHIxatWrlq96lS5eWgnnz5s2DqakpHj9+jEmTJuWrvCFDhmDatGlIS0uT9dbNHtwcPXo0bt++jdatW8PLywsODg64deuWrEeW+rFvffJyzRamvn37YtasWVJQpU6dOujevTvS09OxZs0aKUhiaWkpTYiYH05OTmjZsqU0Oc/IkSPx/PlzODo6Yu7cuUhOTtZap2rVqqhTpw5Onz6N5ORkNG/eHKNGjYKXlxeePn2Ke/fuYceOHTAzM8PBgwfzXTdDGXLPat73ISEh2LlzJ+zs7ODu7o6yZcsWWF0UCgV69uyJJUuWAFBN7GRubg4fHx/89ttviIiI0LmerqERANUf/ObMmSMFYk+ePIlWrVph+PDhcHR0RFhYGL7//nspf40aNbTum86dO8PFxQVPnz6VBcI0J64EVN9HEyZMQFJSEsLCwtCjRw/07dsXdnZ2ePz4Ma5du4a///4bffr0wdSpU/N1fPJC85xdunQJf//9txQUV/+hIrfv84Li7++PChUqSN97/fr1w/Tp06FQKGSTeRpq6dKl2Lx5Mzp06IBmzZqhbNmyEEIgNDRU9iSO5iP+mh4/foxevXphyJAhuHfvnuz7vmfPnjAyMsrzfaqeeGzmzJkAgJ9++gkpKSno2LEjsrKycPr0abx48UIatkfz2D958gQrVqxA6dKlYWFhYfBvS+nSpWFiYoKMjAykpqaiZ8+eaNu2LTZs2GDQU0NERES5KqjBcYmIqHgYMGCANKGFj4+PbLKlyMhI4ezsLC3/6quvZOveuHFDVK1aVe/EI5qv1atXS+vlNhGZ+jVp0iTZ9ubNm5fjRCcNGzYUL168kPJfu3ZNuLu7681vY2MjQkJCpPyaE7boenXt2lVWnwYNGmjlMTY2zvWYa05IYsikXDlNbvLbb7/prOvKlSsNrqchE5FlnxRHsyzNCZaGDh2qsz41atTI0z63bt1ayv/hhx/qzLNkyRIpj5OTkzSRjb790TfB0969e3XWuXnz5nr3U1+6Wr9+/WR5atWqpZVHcyItXa+aNWuKzMxMIYT+SYzyes0Wpu+++y7HupqYmMiuWyHyN7HP1atXZZNnqV9WVlaiZMmSOq/pmzdvCk9Pzxzrp3ncDZlUSoj8TUQmRO737NWrV4WRkZFWnsGDB+d43HKa5EzfPkVFRek8NkqlUlSqVElrH549eyZMTU2Fu7u7dP1m99NPP8kmg9T1ql27tmxCLU2aE1Oqr52IiAitfH///bc0SZm+l+axz+mcqOV3IrK4uDhhaWmptf0WLVpIeXL7PjdkMqvs16O+fTp06JAwMzPT2pa3t7dwdHTUuQ/6ZP++0/Vq0qSJyMjIkNbR3JdKlSrpnADS09NTNtFhXu/TlJQU2W9J9pfmMczIyNBZdpkyZaQ8Od3Pah999JFWGQqFQlSuXDnP507f9gy5TomI6O3E4RGIiN4hW7ZswYoVKwCoHg38888/ZWNPurm5ycaY/eGHH2SPx5YvXx5nz57FypUr0alTJ5QsWRJKpRJmZmbw8PBAYGAgJkyYgFOnTsmGU9DHxMQE7u7uaN++PTZu3Ijp06fLlo8ZMwZHjx5Fjx494OHhARMTE9jY2KB+/fpYsGABDh06JOtRWLFiRVy6dAlffvklKlWqBAsLCyiVSpQpUwaffPIJLl68KJvwZPjw4RgwYAD8/Pzg6OgIY2Nj2NjYoFatWpgxYwb++usvWX1WrlyJ9u3b5zo51es0ePBgjB8/Hp6ennoncHqT9Vy8eDG+//57lC5dGmZmZihTpgxmz56NiRMnSnnU4yXr8+TJE1nvrB49eujM17VrVxgbGwNQPfq+ffv2fNW5VatW2Lp1K2rWrAkLCwuUKFECo0ePlsaizY9PP/1U9llzAjK1vn374qOPPkK1atXg7OwMExMTWFpaokqVKvjf//6HAwcO6D2nanm9ZgvT+PHjcfDgQfTs2RNeXl4wMzODUqmEr68vBgwYgJMnTxbIGLx+fn44duwY2rdvDysrK1hbW6Nt27Y4duyY3l6o5cqVw6VLlzB58mTUqFED1tbWUCqVKFWqFJo0aYIZM2bg119/feW6GSq3e9bPzw8rVqxA5cqVZUNuvA6urq4ICwtDnz59YG9vD0tLSwQGBuLgwYPSkxDAf/f19u3bkZ6ejq5du+q9fkeMGIErV65g1KhRqFKlCqytrWFqago3Nze0a9cOwcHBCAsLk02opSl7r9r27dvD3d1dK1+3bt1w/vx5DB06FGXLloW5uTmsrKxQtmxZdOzYEb/++iuGDx+e30OTJw4ODvj7779Ru3ZtKJVKnXkM+T4vKE2bNsXBgwfRpEkTWFhYwMHBAX369EFoaKhsLO3cvq8BYOrUqViwYAG6du0q+y6yt7dHgwYNMHfuXOzdu1f6vs6uTp06OHLkCJo3bw4rKyvY2dmhV69eOHbsmGyIg7zep0qlEv/88w+WL1+OFi1awMnJCSYmJnB2dkaTJk1kY4wbGxtj8+bNaNKkySs9mTBv3jx89NFHcHJygrm5OerXr49//vlH7+8YERFRXiiE4GjmRERElD9CCJ1j/Y0ZMwbz588HoHpketOmTW+4Zm+eu7s7oqKioFQq8eTJkyI3uRyRoXTd18nJyShbtiyePHkCQDWcTqdOndCtWzds2bIFe/fulYaeoaJH33f1xYsX4e/vD0AVyHz69KlsrNaCMnXqVGkYhKCgoBwnlCQiIiIVjmlLRERE+fbtt98iPj4eHTt2RJkyZZCQkIBt27bJxrQNCgoqxBq+XqmpqUhOTsbGjRsRFRUFQDUmIwO2VJw1b94cvXr1Qt26deHq6op79+5hxowZUsC2ZMmSaNmyJQDVuKX+/v5o1qxZYVaZcnHz5k2MHDkSH330EapUqQJzc3NcuHABX331lZSnc+fOryVgS0RERPnDoC0RERHl24sXLzBv3jzMmzdP5/IxY8ZIE929jYYNG4Y///xT+mxpaYkpU6YUYo2IXt21a9fwySef6Fxma2uLv/76CxYWFgCAL7/88k1WjfJJCIF9+/ZJk/Zl5+fnh8WLF7/hWhEREVFOOKYtERER5VvLli3RuXNnlCpVChYWFjAzM0OpUqXQs2dP7Nu3T28w921jaWmJhg0bYu/evXrHUSUqLj755BPUr18fLi4uMDExgbW1NapVq4YvvvgCV65cQePGjQu7ipRHrq6uGDp0KKpUqQJ7e3uYmJjA0dERjRo1wty5c3H27Fm4ubkVdjWJiIhIA8e0JSIiIiIiIiIiIipC2NOWiIiIiIiIiIiIqAhh0JaIiIiIiIiIiIioCGHQloiIqJi6ceMGTE1NoVAoMHHixMKuTo6mTp0KhUIBhUKBgQMHFnj56rIVCgXu37+fa/7Dhw9L+X18fLSW79q1CwEBAXBwcJDyzZ8/v8Dr/abl5zwMHDhQWmfq1KmvVBYVL7ndJ3kRHBwsldW0adMCqR/p9/XXX0OhUMDU1BQ3b94s7OoQERFRPjBoS0REVEx98cUXyMjIgKWlJUaPHi2l379/XxbEVL+MjIzg4OCAhg0bYtGiRUhPTy+8yhdh58+fR+fOnXH8+HHEx8drLZ8/fz6mTp2KqVOnGhQgVtMMgGm+lEolPD090aVLF+zevbvgdqQQqY/P1KlTdR7D/Dh69Cg+//xzNGjQAJ6enlAqlbC2tkaNGjXwzTff4MWLF7L8+o539peugHNWVhZWrlyJVq1awdnZGWZmZnBzc0NAQAC+++47WV7NoLZCoYCzszOSk5O1yvziiy+0tp0bQ+qf1z9YkNzbel+OHj0alpaWyMjIwJdfflnY1SEiIqJ8MCnsChAREVHenT9/Htu3bwcA9OrVCy4uLrmuI4RAfHw8wsLCEBYWhvXr12P//v1QKpWvu7pFTo0aNRASEgIAMDc3ly3bsmULMjMzAQB16tTBzJkzoVQqUbp0aQCqoO2DBw8AAE2bNn3lHohpaWl4/PgxHj9+jG3btmH58uXFoufqhx9+iJYtWwKA1qzz06ZNk94PHDgQ9vb2r7y97777Dnv27JGlpaWl4cKFC7hw4QLWr1+PsLAw2NjY5KlcU1NT2eekpCS899572Lt3ryw9Ojoa0dHRePLkCSZMmKC3vNjYWPz111/48MMPpbSXL19i6dKleapXUZDTfZJX7du3l8qys7N75bq9bsX1vlRzdnZG7969sWzZMmzduhUXL15E9erVC7taRERElAcM2hIRERVDixcvlt737ds3x7wLFy5EjRo1kJSUhNWrV2PVqlUAgNDQUPz2228YNWrUa61rUWRnZ4dGjRrpXPbw4UPpfbt27dCiRYvXUocNGzbA1dUVd+7cwcSJExEREQEAmDlzZrEIDpUqVQqlSpV6o9t0d3fHgAED0LhxYwDAn3/+iY0bNwIA/v33XyxYsABff/01AHnAUVN0dDR69OgBIQQA4P3335ctHzFihBSw9fb2xqhRo1C5cmWkp6fjzp07uHHjRq71XLRokSxou3r1ajx79izP+5u9/t999x3++ecfAIC/vz8WLVokW+7h4aGznOTkZCiVShgZ5e0hu5zuk7xydXWFq6trgZT1OhX3+1JTnz59sGzZMgDAr7/+KvvdICIiomJAEBERUbGSkZEh7OzsBABhZWUlMjIyZMvv3bsnAEivQ4cOScuysrKEj4+PtKxLly4619G0fPlyKT0wMFBW1k8//STq1asnbG1thbGxsXBychJVq1YVgwYNEsePH5fyTpkyRSojKChInDx5UrRs2VJYWVkJOzs70bNnTxEZGSnb7o0bN0T//v1FqVKlhJmZmbCwsBBeXl6idevWYvLkybK8mnW/fv26mDJlivD29hZmZmaiQoUK4s8//5TlP3TokJTf29tbK03XKygoKMflU6ZMyfG8ZS//3r170rIffvhBSlcqlVrrvnjxQnz//feiTp06wsbGRpiZmYmyZcuKMWPGiOjoaK38cXFx4uOPPxaurq7C3Nxc1KtXT+zcuVPrPGgKDw8Xffr0EQ4ODsLKyko0a9ZMnDhxQrbfmvuoq6zcjtHy5ctzPEY52bNnj0hJSZGlZWVliWrVqknlt2vXLtdyJk2aJOWvXr26bNmVK1eEQqEQAISrq6uIiIjItTzNfba1tZXeh4SESHmqVq2qtTw/zXDNbWnei0JoX9M3b94U3bp1E/b29gKAePbsmbh9+7b48MMPRc2aNYWbm5t0X5UvX14MGzZMdk3qKlMt+/dFTEyMGD58uHB3dxdmZmbC399f7Nq1S1aWvu+R7Nt48OCB6Nevn3B0dBTm5uaiYcOG4uTJk1rH4sqVK6Jjx47C2tpa2Nrais6dO4vr16+LwMDAPF1vr3JfPn/+XMyYMUPUqlVLWFtbCzMzM+Ht7S0GDBggLl26JMtbtmxZqayzZ89K6W3atJHSb9y4IaU3bNhQSt+5c6cQQoj4+Hjx5ZdfCj8/P2FhYSHMzMyEu7u7aNCggRg1apTW9ZqRkSEsLS0FAOHo6CgyMzNzPR5ERERUdLCnLRERUTFz4cIFJCQkAABq1aoFY2Njg9dVKBSyx8fT0tLyXY/p06fLJqYCVI+Gx8bG4vLlyyhfvjzq16+vtd7x48fx119/yba9YcMGxMfHSz0cY2NjERAQgNjYWNm6Dx8+xMOHD3HkyBHZI/iaevTogX///Vf6fOPGDQQFBaFMmTJo2LBhfnf3tcrKypLee3p6ypbFxMSgWbNmsn0CgNu3b+PHH3/E+vXrERISAl9fXwCqXpXNmjXDxYsXpbwnT55Ex44d9T4eHR0djYCAADx69EhKO3ToEAIDA1GmTJlX3r+C0Lp1a600hUKB8uXL49KlSwAAa2vrHMtITk6W9TYcN26cbPnff/8t9cCtUaMGvvjiCxw6dAgxMTHw9fVF//798cUXX2gNqaDWvHlznDt3DuHh4fjpp5/QqFEjHD58GJcvXwYADBo0CAsWLDB8p/MpPj4eDRs2xNOnT2Xpt27dknpearp58yZu3ryJDRs24OzZs3ke8qNBgwa4deuW9PnChQvo2rUrbty4kaeynj17hjp16iA6OlpKO3bsGNq3b4+7d+/C1tYWAHDt2jUEBARI34MAsG3bNoSGhhbo0As53ZfR0dFo0qSJVs/rBw8eYMWKFVi7di1WrVqFnj17AlBdG7dv3wagGp+5Zs2ayMzMRFhYmLTukSNHUL58eaSkpODMmTMAABMTEzRp0gQA0LVrVxw+fFi2vcjISERGRuL48ePo06cP3N3dpWXGxsaoVasWQkJCEBcXh0uXLsHf3//VDgoRERG9MZyIjIiIqJhRB4AAoHz58gavl5SUhMWLF8vWr1GjRr7rsWHDBgCqwMDChQtx8OBBbNq0CXPmzEHr1q31joF58+ZNBAYGYtu2bZg0aZKUvm/fPly/fh2AKmCoDtg2bdoU27dvx969exEcHIwRI0bkGEi8e/cu5s2bh61bt6Jy5cpSevZHybNTP07frl07KW3QoEEICQlBSEgIpk2bhpCQEFlQZOHChdJyzcfhDXHmzBkcPXoUwcHB+PHHH6X0zz77TJZvxIgRUsDW398fa9euxT///IPu3bsDAB4/foygoCAp/7x586SArampKaZPn45du3Zh8ODBuHDhgs66TJw4UQrYWltbY8GCBdixYwfatm2Lq1evGrxPEydO1Hqkf8OGDdIxat++vcFlGSImJgYHDhyQPnfr1i3H/H/++SdiYmIAqIJwvXv3li1XB38BYM+ePVi1ahUeP36M1NRUXL9+HRMnTkTHjh2lMY+zMzY2xscffwwA2LRpE548eSJdd6VKlUKnTp3yvpP5kJCQgPT0dMyfPx979+7FggULoFQq4e3tjZkzZ2LDhg3Ys2cPDh8+jG3btqFfv34AgLi4OMyZMyfP23v27BmWLFmC9evXo0SJEgBUfxD69ddf81ROYmIirKyssGbNGixfvlwK0sbGxmLNmjVSvlGjRkkBWxcXF/zxxx/YsmULKlSogHv37uW5/poMvS+HDx8uBWxdXFywZMkSbNu2DW3atAGg2v9BgwYhKioKAGTDrKjvkfPnz+P58+dS+pEjRwAAJ06cQGpqKgCgbt26sLa2RkxMjBSw9fT0xNq1a3HgwAGsWbMGkyZNQu3atXUOf1GhQgXpveb1TUREREUfe9oSEREVM5q955ycnHLN36xZM53p7u7urzSerbpHm1KphJ+fH/z9/eHg4ABAuwejJmdnZ2zduhUWFhbo1KkT1q9fLwU/bt26hYoVK8p6y3l6eqJixYrw9fWFsbGxLECpy7Rp0zBmzBgAqgmg+vTpI5Wd2/40atRINu5mqVKlZGN6ent7yyZuq1q1ar7H/FT3wFMrUaIEvv32WwwaNEhKi4+Px6ZNm6TPX375JUqWLAkAGDlyJLZv34709HSEhITgxo0bqFChAtatWyflHzp0qBQYb9euHS5cuCD14FPLysqSAvAAMGXKFOm6aNWqFXx9ffHkyROD9qlcuXIoV66cLK127dqvPFmbLnFxcejQoYM0Vmz79u21grCahBCyINyoUaO0esxmH3e2a9euGDp0KC5cuICvv/4aWVlZ2Lt3L1atWqX3Ovzoo48wffp0pKSkYMKECdi6dSsAVZAvL73iX9WKFSukIHGrVq0AAH5+fjh79ix+++03XLp0CXFxccjIyJCtd/z48Txva/HixejRowcA4M6dOxg/fjyA3O85XdavX4/atWsDUAUvf/vtN1lZsbGxskD9okWL0KtXLwCqHr/e3t5ISUnJ83bVDL0vt2zZIn3+6aefpLGRW7RoAW9vb8TExODFixfYsGEDPv30UzRr1gwKhQJCCCloe/ToUQBAtWrVcOnSJSloq04HVD10AdUfU4yNjZGZmQknJyeUL18eFStWhIWFBQDVkw+6ODo6Su/VAWQiIiIqHtjTloiIqJhRP76d/b2hTE1N0b17d4SFhcHNzS3f9Rg+fDgAVWC0VatWcHR0hKurK1q1aoUFCxYgOTlZ53oNGjSQAg2AKoirFhcXBwBo3LgxqlatCgBYtWoVypUrBwsLC1SqVAlDhw7F6dOn9dZLHeTQV3ZRFRERodUT9ubNm7JenX379kXjxo3RuHFjNGvWDOnp6dKyK1euAJAHygICAmTl6QowP336VPaYueY6ZmZmqFu3bv526DW6c+cOGjRogFOnTgEAWrZsiQ0bNkChUOhdZ9u2bbh58yYAwMbGBkOHDtXKo9k73NTUFCtWrEC7du0wfvx4dOjQQVq2a9cuvdtxdnaWgsd//vknMjMzYW5ujiFDhuRtJ1+BUqlEx44dtdInT56M/v37Y//+/YiOjtYK2ALagWtDFNQ9Z2NjIwVs9ZV1+/Zt2feeelI6QDXZWcWKFfO0zdwYcl9q3leWlpayfbh27RoAVW/cKlWqAFDdc9evX5eCs59++ins7Ozw6NEj3Lt3Txa0VffQNTc3l3rzX7x4ETVr1oSVlRW8vb3Ro0cP2R93NGkeq5zuDyIiIip6GLQlIiIqZjR7ghoSFFE/wn/s2DFcvnwZiYmJ2LRpkzQGKqD9n3nNYE72cTHV+vXrh9DQUAwfPhz169eHk5MTnj59iv3792P06NH44IMPdK6n2fMLUI3ZqKYOMJibmyM0NBTz589H586dpWEgrl27hiVLlqBhw4Y4e/ZsruXrKruouHfvHhITEzFjxgwAqvotXLgQf/zxR77K03zMWi0/QZqiHtg5fvw4GjRoIAVg+/bti507d8LS0jLH9ebOnSu9/+ijj3SOfert7S29d3Jyko3/rDkkR3x8fI7bGjlypOxz3759DeoVX1Dc3Ny0zmN6ejrmzZsnfe7Tpw927tyJkJAQWbrmOK6GKqh7zpDvhuyy7+er3ucFcV/qq4PmEAlHjhxBaGgoANUQMOo/luzfvx8nTpwAAFhYWKBBgwbSOr/++ivWrl2Lfv36oXr16rC0tER4eDg2bdqEHj166BwCRvM3wsXFxeB9ICIiosLHoC0REVExo+6BCkBrEhx9+Rs1aoSAgABUqVJF51iz6mEN1DQnpNqxY4fOcoUQaNiwIX7++WccP34cMTExuHnzpjQZ1JYtW/Dy5UuD9klX2ba2tvjss8+wdetW3LhxA0lJSVIwLD09XfZI/5ukOW5kfgJcmmxsbDBhwgTZWKxff/211Eu5fPnyskfqb9y4ASGE1isxMVF6XF9znGPNSY50fQZUgRx7e3udedLT03Ps1ayPZiDtVY+Rpk2bNqF58+bSHxLGjx+PVatWwczMLMf1Tp8+LT2SbmJigtGjR+vM17RpU+l9bGwskpKSpM93796V3uc23EPNmjVlPZazB3FfN12B99jYWLx48UL6/Ntvv6F9+/Zo1KiRrKd1UVeuXDnZ/mler9HR0QZ9J+Ymr/flsWPHpPfJyck4d+6c9Fmz569mj+Rff/0VsbGxcHd3R7ly5aTJxubPny+dp4CAANlwLAqFAr169cKqVatw4cIFPH/+HGvXrpWWr169WmtfNI+H5m8HERERFX0c05aIiKiY8ff3h52dHRISEnDu3DlkZma+8liZtra2cHNzk8Y8/OCDD9CvXz/s3btX9qiupp49e0KhUKB58+YoWbIkbGxscPbsWSlQm5WVhdTU1Fx7QOpy6tQpDB48GF27doWfnx/c3d3x4sULWe/aVxm38lU4OTlJkx39+eefMDIygomJCapVqyZNnJRX33zzDbZs2QIhBKKiovDrr79izJgxsLe3R/fu3aUAdfv27fHFF1+gbNmyiI+Px4MHD7Bnzx7cvXtXGhahV69e0oRDv//+O9zd3VGrVi1s3rxZGk5Ak5GREXr27IklS5YAUI2NqVQqUbp0afzxxx94/Phxvo6ResKvX3/9FR07doSRkRHq1q0LMzMzBAcHS2OEBgYGShMs5eTnn3/GyJEjpV6MgwYNQvv27WUBM3Nzc9mj6WqavWzff/99eHl56dxG586d4ePjg/v37yM9PR1BQUH46KOPcPHiRezcuVPK17dv31zrO2fOHOzZswcODg7w9/fPNf/r5ubmBisrKykgOH78eHTp0gUnTpzAzJkzC7l2hnN0dETLli2xb98+AKqAeFJSEuzt7fH9998X6PdCTvdl165dpSEJRo4ciefPn8PV1RW//PKL9EcFKysraaxbQHWtq8elVQ+5oB7eQf2v5sR/mj1zAVVv77Zt26J27dooUaIEjIyMsHfvXml59n3PzMyUAsh2dnZF4jokIiKiPBBERERU7AwZMkQAEADEvn37ZMvu3bsnLQMgDh06ZFCZM2bMkK2nflWtWlV6HxgYKOVv06aNzvzqV9euXaW8U6ZMkdKDgoJk2w0MDJSWLV++XAghxPHjx3Ms29TUVJw6dUoqQ3PZvXv3pPRDhw5J6d7e3rmmCyFEUFCQtGzKlClax2n8+PE66xQSEpLj8dXcZvZ6CiFEz549pWUeHh4iOTlZCCFEdHS0qFKlSo7HQ3MfXr58KapXr64zX4UKFXSeh6ioKOHp6amV38TERJQpU0bn8cjpnPbp00fn9h8+fCiEEGL58uU6r6mcaF4nhhwHtfv37wtjY2Mpz7lz53LczvHjx4Wtra3ebfzvf/+T5de8Xt57770cy85+DeSV5rayH7ecrmm1CRMm6Nyn5s2b5+k+yf4do0nfudWXnlO99V1jV69eFXZ2dlr74eDgIHx8fLS+T3KS3/syMjJSdj9lf5mZmYn169drba9evXqyfIsWLRJCCJGamiosLCxky06cOCFbV6lU5nj9z58/X5Z/37590rKPPvoo12NBRERERQuHRyAiIiqGPvnkE+n9mjVrCqTML7/8Ev/73//g7u4OMzMzVK9eHatWrcLYsWN15h8+fDgGDBgAPz8/ODo6wtjYGDY2NqhVqxZmzJiBv/76K991KVu2LL7++ms0a9YMJUuWhLm5OUxMTODp6YkePXogNDQUderUyXf5r+Lrr7/GsGHD4OrqWqDjv06aNEkqLyIiQur56uLiglOnTmHOnDmoX78+7OzsYGpqihIlSqB+/fqYOHGibBIiCwsLHDx4EMOGDYOLiwuUSiVq1aqFDRs2SBNkZefq6oqwsDD07t0bdnZ2sLS0RKNGjbB3716dk5flZsGCBejVqxccHR11HiPNSZx0DddRkBYsWCBtr3nz5qhRo0aO+evXr4/z58/jww8/hKenJ0xNTWFvb4+WLVti69atmDVr1mut7+s0bdo0zJo1C2XLloVSqUTFihXx008/YdKkSYVdtTzx8/NDWFgYOnToAGtra9jY2KBDhw44duyYbKxiKyurV96WvvvSzc0NZ86cwbfffitNCmZqagovLy/0798fp0+fRs+ePbXKy957Vj0sgpmZGerVqyel29raavUanzlzJrp06QJfX1/Y2NjA2NgYTk5OaN68OdasWYPPPvtMll/zO1jzN4OIiIiKB4UQRWxWDiIiIjJI586dsX37dlhaWuL+/fucZIaKjU8++QS//vorFAoFjhw5Ij0aTvQqIiMj4evrKw0TcOnSpXd2HNeYmBh4e3vj5cuX6Ny5M7Zu3VrYVSIiIqI8Yk9bIiKiYmr27NkwMTHBy5cv8eOPPxZ2dYgMtn//fgCq4C0DtpRXKSkpqFevHlasWIFLly4hPDwce/fuRefOnaWAbc2aNd/ZgC2g6mH+8uVLmJiYYPbs2YVdHSIiIsoH9rQlIiIiojcmPDwc3t7eKFWqFP7991/Y2NgUdpWomElJSYGFhYXe5R4eHjh48CAqVqz4BmtFREREVLAYtCUiIiIiomIjMzMTY8eORWhoKB48eICEhARYWVmhfPny6NixI0aOHAkHB4fCriYRERHRK2HQloiIiIiIiIiIiKgI4Zi2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkSFpG3btlAoFNLr+vXreS5j//796NOnD3x9fWFhYQF7e3tUrlwZH3/8MU6ePCnl8/HxkbZTlAUHB8uOia5XfHx8YVeTsomPj8fUqVMxdepUBAcH53n9hw8f4quvvkLNmjVhb28Pc3Nz+Pj4oEOHDli6dCkyMzMBAFOnTpWug/xs53XQd2+9fPkSn376KUqVKgVTU1MoFAr4+/sDgJTfx8fntddv/vz50rnJ7vDhw1JdBg4c+NrrQkREbx/N32b1y8TEBE5OTmjUqBF++uknZGVlydZ5k7+DbwrbsMUT27BswxIVdSaFXQGid9Hy5cuxZ8+efK+flpaGQYMGYc2aNbL0lJQUJCQk4OrVq4iMjMSWLVtesaZEuYuPj8e0adMAAIGBgXlqPK1btw6DBw/GixcvZOkPHjzAgwcPsGvXLrz33nuwt7cvwBq/ft988w1+/vnnwq4G5s+fjwcPHgCAzkYvERFRQcvMzERcXByOHTuGY8eOITw8HLNnzy7sahFpYRtWG9uwREULe9oSvWFPnjzB2LFjYWRkBHNz83yVMXLkSClga21tjd9++w1Pnz5Famoqrly5gmnTphW7BkJ2gYGBEEJovYr7ftF/QkJC8MEHH0iN3f79++PatWtIS0tDZGQk1qxZg1q1ahVyLXN2//596drUdPbsWen9oUOHIITAhQsXAEDKf//+/TdYU21NmzaV6lJUen0QEVHxFRQUBCEEkpOTMWHCBCk9+29MUfkdBIDk5OQCL5Nt2Lcf27D332BNtbENS+8SBm2J3rCPP/4Y8fHxGDt2LNzc3PK8/o0bN7BkyRLp8x9//IGhQ4fC2dkZZmZmqFSpEiZPnow//vgjx3JSUlIwaNAg+Pv7w8XFBWZmZrCyskK1atUwefJkrb8a79ixA4GBgXBwcJAee/P398fgwYPx7NkzKV9wcDDq1asHW1tbmJqawtXVFXXr1sXw4cO1GgWv4v79+9JjMU2bNsWePXvQoEEDWFhYwMfHBxMmTEB6erpsnatXr6Jt27awsrKCs7Mzhg4dinPnzsnKUbty5Qp69uyJChUqSPtsb2+PRo0aYdmyZVr78ujRI7z//vuwtbWFnZ0devXqhYcPH+p9jCgpKQnTpk1DtWrVYGVlBQsLC1StWhWzZs1CWlqaLK9mGWFhYdJ+litXTmqoLF++HBUrVoSVlRVq1aqFffv2aR2ze/fuYdiwYShdujSUSiVsbW3RpEkTbNiwQZYv+yNHq1evRvXq1aVt/vjjj9L+Dxw4EL6+vtK6R44c0Xk8dfnqq6+QkZEBAGjXrh1WrFiBihUrwtTUFG5ubujTpw9OnToFOzu7HMv5/fff0aJFC3h6esLKygpmZmbw9PRE7969cenSJVnex48fIygoCF5eXjAzM4O1tTVKly6Nrl27Yu/evVK+a9eu4b333oO7uztMTU1hZ2eH8uXL4/3338eZM2ekfNkfLVMfO83j36xZM9njW/quieTkZHz//feoU6cObGxsoFQq4e3tjV69eiElJQWA4del+jFNdQ8Fze1mr6uuR8tu376NwYMHw8fHB2ZmZrC1tUVAQACWLFkiu/bzcx8SEdHbzdzcHB988IH0+eXLl7Llun4HNYcXmDJlChYsWIAKFSrAwsIClStXxurVq2VlHD16FF26dEGZMmVgZ2cHExMTODs7o1WrVlpPmmUve/bs2ShbtixMTEywdu1amJiYQKFQoF69erL1oqOjpcfDa9SoUTAHB2zDsg37H7Zh2YYlypUgojdm1apVAoAoX768ePnypfD29hYABABx7do1g8r44YcfpHXKlClj0Dqa21F79uyZlKbr1bp1aynvmTNnhImJid68t27dEkIIsXnz5hzLTE9Pz7Gey5cvl/IGBgbmmPfevXtSXltbW2FkZKS1ve+++07Kf/fuXeHg4KCVx8vLS+c2c9sXzbKfPXsmfHx8cizb29tbyh8bGysqVaqkt+wmTZqI1NRUKb863crKSlhYWGjlf//997XSzMzMxL1796QyTp06JWxsbPRu86uvvpLyHjp0SErXdcwAiDVr1gghhAgKCtJbZk7nMDo6WigUCinv0aNHczzfQggxZcoUKf/y5cul9C5duuitg7W1tbh586aU19/fX2/eiRMnCiGESE5OFu7u7nrzLVmyRCov+72leeyyv4KCgmTnU/OaiIuLE9WqVdO77rNnz4QQhl+XmveSrlf2uqrrJoQQx48fF9bW1nrX7dmzp8jKyhJC5P0+JCKit4vmb7P6tyQlJUVMmjRJSh84cKBsHV2/g5q/W/raHseOHZPy//jjjzn+zqnbKdnLdnZ2luVbvny5rB118uRJab0FCxZI6b/++muOx4FtWLZhc8I2LNuwRPnFoC3RGxIZGSmcnJyEkZGRCA0NFUKIfAVthw8fLq3TqVMng9bRFbRNSUkRq1evFnfu3BHPnz8XaWlp4vbt27IGwaVLl4QQQsydO1dKW7dunUhLSxPR0dEiLCxMTJ48WURERAghhBg5cqSU7/jx4yItLU1ERESIgwcPii+++EJkZmbmWM/cfqQ1G1CaP7QAxLhx40RcXJzYsmWLlFahQgUp/4ABA6T0Nm3aiCdPnoi7d++K2rVr6yz/9u3bYufOneLx48ciJSVFJCcni7CwMGFpaSkACCcnJ+lHf/LkyVIZNWrUELdu3RKRkZGiffv2Ohs3n376qZT+008/icTERBEfHy9GjRolS1fT3M8RI0aI+Ph4WfAegPjiiy9EQkKCGDFihJQ2c+ZMqYwqVaoIAMLe3l7s379fpKSkiPDwcNG4cWMBQCgUCnH58mUhhHajbd68eSIhIUEsWrRIdgx1nYvc/qOidurUKdk2YmNjc11HX4N3z5494syZMyImJkakp6eL2NhY8fXXX0t5x44dK4RQ/UdDnfbee++JhIQEkZSUJK5fvy5+//13sXnzZiGEEGfPnpXyjRo1Srx48UIkJCSIy5cviwULFojDhw9L29Z1bwkhRGBgoJSu+R8PIXQ3eDXvnfLly4ujR4+KFy9eiNu3b4tvv/1WJCUlCSHydl3mVD8h9Dd4Nf8zNn78eBEfHy/Onj0r+w/c+vXrhRB5vw+JiOjtovnbrOtVs2ZNkZiYKFtH1++gZhvQ2NhY/PXXXyIhIUF8+eWXUvqwYcOk/OfPnxcHDhwQkZGRIjU1Vbx48UJs375dtl1dZQMQP/zwg4iLixMRERHi0aNH4vTp09Ky/v37S+vVrVtXABA2Njbi+fPnOR4HtmHZhs0J27BswxLlF4O2RG/Ie++9JwCI0aNHS2n5Cdp+8skn0jqdO3c2aB19P3pLly4VjRo1Eg4ODjr/urh27VohhJD9eDVp0kR88803Yv369bK//gohxPz586V8nTp1ErNmzRKbN28W4eHhBtUzvw1eFxcXWS9eJycnAUAolUopTfOvzhcvXpTS//nnH53lJyUliUmTJolq1aoJKysr2V/U1a/IyEghhBD169eX0rZu3SqVce3aNZ2Nm5IlS+a4nwBEx44dpfzqNBMTE+k/DVevXpXSTU1NxYsXL4QQQuzevVtKV//n5tatW7luD4CYM2eOEELeEKpRo4ZUj+fPn+tsxOSnwXvy5MkCa/BevHhR9O7dW3h5eQkzMzOt/Wrbtq0QQojMzEzh6OgoAAh3d3cxbtw48ccff4hjx46JlJQUqbzo6GhhamoqAIiyZcuK8ePHi+DgYHHmzBmRkZEhq1NBNXg9PT2ldM0GdXZ5uS5zqp8Quhu8mteKs7OzbH81ezV98MEHQoi834dERPR2yS1oC0A0bdpU9nui63dQsw3YrVs3Kf3y5ctSumaw7enTp2L06NGiYsWKOntwmpub6yy7efPmOvejadOm0m9WdHS0uHnzprTOxx9/nOtxYBuWbdicsA3LNixRfpmAiF67M2fOYNOmTbC3t0e3bt2k8YQ0x326cuUKsrKyUKlSJUydOlWayVQtKCgIwcHBKFOmjGyd/Jo7dy4+//zzHPOoJ2fo0qULxo0bh8WLF+Po0aM4evSolKdmzZrYvn07SpQogU8++QRnz57F2rVrsX37dmzfvl3K16JFC2zZsgXW1tYG1S8wMBCHDx82KG+5cuVgYvLf15mVlRViY2ORmpoqpcXExEjvvb29pffZx2RS6927N3bs2JHjdtXHJ69lR0VF5Vhu9jLV3NzcpONnYWEhpbu6usLS0hIAoFQqpXT1GFKGbE/fNv38/KT3VlZWWmXnl6+vLxQKhTS21NWrV9GoUaM8l/PgwQMEBARojcGsSX2ejIyMsHbtWnz88ce4e/cu5s6dK+Wxt7fH4sWL0bt3b7i4uGD58uX4/PPPcfv2bcycOVPK5+HhgdWrV6NZs2Z5rmtOIiMjpfdVq1bVmy8v12V+aF4rnp6eMDY2lj5rXs+6rilD7kMiInp7qduqGRkZOH/+PDp06ICnT5/i8OHD2LFjB7p06WJQObm1PbKystCiRQutMT816Wun6Jsc6vPPP8fhw4eRmpqKJUuWyNroH3/8sUH1VmMblm1YQ7ANq41tWCJtnIiM6A1ISkoCAMTHxyMwMBB16tRBnTp1EBERIeXp0aMH+vbtm2tZHTt2hJGR6ta9c+eO1gD8aurB8fVZtWqV9H7BggV4+fIlhBDo3r27zvxz5sxBXFwcTp8+jfXr12PEiBEAgHPnzmH69OkAADMzM6xYsQLPnj1DWFgYVq9ejT59+gAADhw4gJ9++inX/csPU1NT2Wf1IPWaXFxcpPcPHz6U3t+7d08rb3x8vNSoUCqVCA0NRXp6OoQQcHR0fKWyAUgT0CkUCjx58kTnDMNhYWFa62k2JgxJz749AKhYsaLO7Qkh8N1332mtq3lsdR3XnNJz4uLigoCAAOmzZqNSU1ZWVo4T2G3ZskVq7DZv3hyPHz+GEALbtm3Tmb9Vq1a4c+cObt++jZ07d2LevHlwd3dHfHw8hgwZgszMTABAv3798OTJE1y9ehVbt27Fd999B2tra0REROCTTz7J8/7mxt3dXXr/77//6syT1+sSyPu50bxWHj16JB0PALKZgnVNomjIfUhERG8/ExMT1KlTB02aNJHSrl+/bvD6ubU9Ll++LAVs3dzccPnyZWRkZCAxMTHXstUBwuzat2+PSpUqAQB+/fVXaeKzBg0aoHr16gbXPa/YhmUbFmAbVhe2YYlUGLQlKoKmTp2q1RhRz7BaoUIFfPTRR1LeIUOG4I8//kBsbCzS0tJw9epVTJs2DUOGDMlxG5qNJGtraygUCmzduhU7d+7UynvkyBF89913uHLlCnx8fNC1a1d07dpVWh4eHg4A2LRpExYsWIB79+7Bz88P7733Hlq2bKmVrzC0bt1aej9hwgRERUXh/v37mDx5slZe9SzCgOov2zY2NkhOTsaUKVMQFxeXY9nffvst7t+/j6ioKL09mbt16wYAEEIgKCgI165dQ3p6OiIjI7Fx40a0bdsWK1eufKX91VS2bFlUqVIFgOo/TZ9//jkiIiKQnp6Ou3fv4pdffkG1atVks7TmhZOTk/T+wYMHePbsmUHrzZw5U7oOd+3ahQ8//BA3btxAeno6oqKi8Ndff6FOnTpISEjQW4bmdWxmZgYrKyvcuXMH3377rc78I0aMwO7du2FmZoaWLVuiV69eKFGiBADgxYsXiI2NRUxMDMaOHYsjR47Azs4O7dq1w/vvvw8HBwcAr+c61vxjybBhw3Ds2DEkJyfj/v37mDVrFl68eJHn6xKQn5sLFy7kWo+yZctKPVNiYmIwZcoUJCQk4MKFC/jxxx+lfJ07d87PbhIR0TsgMzMTp0+flj2Z5eHhUWDla/72Gxsbw9raGgkJCRg7dmy+y1QoFFK77eHDh7h9+zaAvPeyfR3YhmUbFmAbNjdsw9Jb6zUOvUBEucjPmLZCCJGWlib69OmT49hOXbp00bkdtVmzZmmtY2RkJMqUKaM15tLKlStz3NaiRYuEEEJ88803Oebbvn17jvuV23hgAMShQ4eEEDmPQaVrf/XNvKs5NlfTpk2l/G3bttXK6+rqKuzt7bXGedI3865m2T4+PlLZsbGxonLlyjnup+Z4V+o0zfGjNPdfM13fwPynTp0Stra2OW5TvT/6ytBXFyGEqFq1qlZ5U6ZMyel0CyGEWLt2rbCyssqxXupZZ3WNB3b37l1pAgPNV/ny5XVeH8bGxnq3U6tWLSGEEA8fPsyxPu+9955UXkGNB2bozLt5uS6FkE8Okf146DvPx44d03lM1a/u3bvrnHnXkPuQiIjeLoaMaVu6dGnZRF66fgc124Ca7QddvzMZGRnS5FT6fvs1f3v0lZ1damqqKFGihJTX0dFRJCcnG3Qc2IZlGzan9hvbsGzDEuUXe9oSFUOmpqZYs2YN9u7di969e6NUqVJQKpWwtbWFn58fhg4diq+++irHMj7//HNMnz4dPj4+UCqVqF69OjZv3qxzTKZatWphyJAhqFq1KhwdHWFsbAwbGxvUr18fv//+Oz799FMAqnFr+/fvj4oVK8LOzg5GRkZwcHBA06ZN8ffff6Njx46v5XgYwtfXFyEhIWjdujUsLCzg6OiIQYMGYcmSJVIeZ2dn6f3KlSsRFBQEFxcXWFpaolWrVjh8+DDs7Oy0yra3t8fRo0fRo0cP2NjYwMbGBt27d8fmzZt1lu3o6IiTJ0/im2++QY0aNWBlZQWlUglvb2+0atUKc+fORbt27Qp0/+vUqYNLly5h+PDhKFu2LJRKJaytrVGuXDn07NkTwcHB0l/r82PlypVo2rSpzuOTk169euHatWv43//+B39/f9jY2MDMzAylSpVCu3btsGTJEtjY2Ohd39fXF7t27UL9+vVhaWkJDw8PfP7551i4cKHO/OPHj0fTpk3h4eEBMzMzmJmZoUyZMlLvBQBwcHDAuHHj0KBBA7i5ucHU1BTm5uaoVKkSxo8fjxUrVuRpHw3h4OCAEydOYObMmahVqxasra2l49CzZ0+Ym5sDyNt1Cah67ffr1w9ubm4GP+oVEBCA8+fPY+DAgfDy8oKpqSmsra1Rr149LF68GBs2bOBjY0RElCMLCwtUrFgRY8aMwfHjxw2e08AQxsbG2L59O7p27QoHBwfY2trivffew8GDB1+pXDMzM4wcOVL6HBQUJP3+Fia2YdmGBdiGNQTbsPQ2UgiRw0ArRERvkT179qB+/fpS4+Dp06cYNGiQNCTEkiVLch1WQp/Dhw+jcuXK0thgz58/x5gxY7B06VIAwMSJE/U+7kREREREhW/06NFYsGABjI2Ncf36dZQtW7awqwSAbVgioncVg7ZE9M7w8fFBeHg4nJ2dYWJigqioKGRlZQFQDe6/a9euXCdE0Kdp06Y4cuQIHB0dYWFhgaioKGkyuOrVq+Po0aOwtbUtsH0hIiIiooLRokULXLt2TZokeMiQIbKerIWNbVgioncTh0cgonfGBx98gGrVqiE9PR3R0dGwt7dHYGAgfvvtN/zzzz/5buwCqokZ6tSpAwCIjIyElZUV6tWrh9mzZ+PEiRNs7BIREREVUXfu3EFERARcXFwwbNgwLFq0qLCrJMM2LBHRu4k9bYmIiIiIiIiIiIiKEPa0JSIiIiIiIiIiIipCGLQlekv4+PhAoVAY9AoODi6w7U6dOvW1lJtd//79oVAocPnyZZ3LBw8eLNXjyy+/1Jln6dKlUp5mzZrlafuHDx+W1h04cKDB6929excKhQLvvfderuUa8ipo8fHxmDp1KqZOnWrw+Zs8ebJUn+nTp8uWjRkzRlrWuXNn2bLVq1dLy/IzWcbAgQOl9Q8fPpzn9QHg/v37UhlNmzY1aB318Zk/f36+tmmIpk2bSvW6f/9+jnkNuWYuXLgg5T9z5gwGDx6MqlWrwtjY+I3cr0RERPnB9izbs/nB9mzu2J4lKp4YtCWiIi8tLQ3bt29HhQoVULVqVZ15NBuea9askSZn0LRy5Uqd+V+nDRs2AAB69uz5RraXV/Hx8Zg2bRqmTZtmcKOnSZMm0vuQkBDZMs3Px44dg+YIPEePHpXeN27cOJ81fvPUx+d1NnJfp9DQUCxbtgz//vuvzvuCiIiIXj+2Z18ftmdzx/YsUfHEoC3RW+L+/fsQQkgvb29vadmhQ4dky/Q18F6+fJnn7U6dOjXXcl/Vvn37kJCQgB49eujN07hxY5QtWxYA8PjxYxw8eFC2PDw8XGpkWVtb51hWQdq4cSPMzc3RsWNHncubNm0qOzeHDh2Slnl7e8uWFZUhyBs0aCBNeHH8+HFphuHnz5/L/iIeFxeHK1euSJ9ftZEbHBwsHQdDexW87XRdI0II+Pv7S3kqVKiASZMmYdu2bWjXrl3hVZaIiCgXbM+yPfumsD1bdLA9S6Qfg7ZE7yD14yQ+Pj44fvw4AgMDYWVlhfbt2wMANm/ejHbt2sHb2xs2NjYwNTWFu7s7OnfuLGuoAPofJ9N8vO3mzZvo1q0b7Ozs4OLigl69eiE6Otrg+m7cuBFA7n/dHzBggPResxcCAKxatUpqJPbo0QNWVla4cuUKevbsiQoVKsDBwQEmJiawt7dHo0aNsGzZslduVN6/fx9nzpxB27ZtYW1t/UplqV28eBH9+vWDp6cnzMzM4OjoiLZt2+LAgQOyfOnp6ZgwYQL8/PxgYWEBc3NzlCxZEi1atJBmRB44cCB8fX2ldY4cOWLQo1ZWVlaoWbMmAODFixc4d+4cACAsLAyZmZlwc3OTZiFW91R4+vQprl+/DgAoUaIESpcuLZW3detWtGnTBk5OTjA1NUXJkiUxYMAA3Lp1S7ZdfY+Tpaam4osvvoCHhwcsLCzQqFEjhIaGGvSIVkhICJo0aQJLS0v4+PhgwoQJSE9PB/Dfta324MED2b2jlpSUhGnTpqFatWqwsrKChYUFqlatilmzZiEtLU22vZSUFIwbN06qa4MGDXDkyBG9x7ogtGvXDtOnT0enTp04AzQREb012J5lexZge1ZdP7Znid5SgojeSt7e3gKAACAOHTokW6ZOt7S0FBYWFtLnwMBAIYQQn332mZSW/WVsbCyOHj0qlTVlyhRp2fLly3Vu38HBQauc1q1bG7QfaWlpwsHBQZQrVy7XvA8ePBAKhUIAENbW1uLFixfSMj8/P2nbhw8fFkIIsXnzZr37CUB899130vqHDh2S0oOCggyq+w8//CAAiNWrVxuUP/t2vL29Zcu2bt0qTE1NddZVoVCIxYsXS3lHjx6td78aNmwohBAiKChIbx71taDP559/LuX94YcfhBBCTJgwQQAQPXr0EOPGjRMARJ8+fYQQQmzcuFHK36tXL6mc//3vf3rrYG1tLU6fPi3l1ayv5jXdtWtXrXXNzMyEq6ur9PnevXtCCCHu3bsnpTk5OQkTExO9513z2s7+Up+b2NhYUalSJb35mjRpIlJTU6W6du7cWSuPqampcHFx0aprfq6R3PTq1Uvn/UpERFQUsT3L9izbs2zPZsf2LL1L2NOW6B328uVL1K9fHzdv3sSLFy/wyy+/AFD95f7YsWOIiopCWloaEhISsHjxYgBAZmZmnsdCql69Oh4+fIjr16/D1dUVALB3715ERkbmuu6BAwfw7Nkzgx7/KlWqlDQhQ1JSEjZv3gxANXD9tWvXAAC+vr7SGFZVq1bFzp078fjxY6SkpCA5ORlhYWGwtLQEAMydO/eVeids3LgRSqUSnTp1yncZasnJyRgyZAjS09Ph4+OD06dPIzU1FTdu3ECFChUghMDYsWMRExMDAFJPBV9fXzx69AgpKSm4f/8+Nm7cKE0iERwcjHv37knbCAwMlB5Hym1iBF3jgKn/bdy4sbRcnabrUbIzZ87g+++/BwC0bdsW9+/fR2pqKg4cOAAzMzMkJSXhk08+ybEehw4dwpYtWwAA9vb2OHToEOLj4zF+/Phce7/Exsbis88+Q1xcnFQGAPz5558A/ntUUk3z0S11T4cpU6bg6tWrAICffvoJiYmJiI+Px6hRo6T9XrJkiVTXbdu2AQAcHR0REhKChIQETJkyBU+fPs2xrvpo9pbQ1WuCiIjobcf2LNuzbM+yPUv0tmLQlugd9+eff6JcuXKwtLREpUqVAACenp5YtmwZGjRoABsbG9jZ2ckaG+ofdUMtWLAAnp6eqFChgmzsp9xmFQUMf5RMTXMcMvUjZZqPlgUFBUmPCLm7u+PEiRNo164dnJycYGlpiYCAAGkstNjY2Dw99qbp4cOHOHXqFNq0aQMbG5t8laHp2LFjUkPo/v37qFOnDpRKJSpUqIAbN24AUDWE1Y8mlSlTBoBqPLRp06bh999/x40bN9CiRQuMGTPmlevTqFEj6TiGhoYiOTkZp06dAqBqxDZu3BgKhQKPHj3C/fv3dTZyNRuWu3fvho+PD5RKJVq0aCE9hnXmzBmp4a7L3r17pfeDBg1C06ZNYWdnh8mTJ6NEiRI57oOLiwtmzZoFBwcHdOnSBU5OTgAMuy7V1P+RAoBPP/0Utra2sLe3x8KFC2X7pquujRo1gq2tLSZMmICSJUsavE0iIiKSY3uW7dn8YHtWhe1ZoqLLpLArQESFx8XFBV5eXrK058+fIyAgABEREXrXS05OztN2/Pz8pPdWVlbS+5SUlBzXy8jIwJYtW1C6dGnUqFHDoG299957GDFiBJ4/f479+/fj4cOHWLt2LQDV2Gea44T17t0bO3bsyLG8vO6r2saNGyGEKLAJIqKiogzKp24Qzp8/HzExMQgNDZX+Mg4ApqamGDlyJObOnftK9XFwcECVKlVw+fJlxMXFYfny5UhNTYWtrS2qV68OIyMjVK5cGf/++y927NiBS5cuAVD1HqhSpUqe9ik2NhbOzs46l2k2gDUnKzEyMoKXlxeePHmit9xy5cpJE1AAqmszNjYWqampBtULMGwf1HXUrKvmfadQKODl5YXHjx8bvF01b2/vPDXKiYiI3jZsz7I9m19sz6qwPUtUdLGnLdE7TP3YlKaDBw9KDdzKlSvj7t27yMrKkhop+WFqaiq91xwIPzeHDh1CbGyswb0SANU+qfNnZmbiww8/lHoXBAYGShMVxMfHSw1cpVKJ0NBQpKenQwgBR0dHg7enz8aNG2FmZobOnTu/clkA4ObmJr1v06aNzhlWs7KyMGzYMACqxk9ISAiioqJw4MABLFmyBHXr1kV6ejrmzZuHEydOAMjb+chO85Gy2bNnAwAaNmwIIyMj2fI5c+YgKytLa7nmPs2cOVPvPlWoUEFvHVxcXKT3Dx8+lN5nZWUhPDw8x/prXpdA/o6Feh8UCgWePHmicx/CwsIAQNZQ16yrEEL2mYiIiAzH9izbs2zP/oftWaK3C4O2RCSj+ZdaExMTWFlZITIyEhMmTHjjdcnro2Rqmo+U7d+/X2e6iYmJ1KgxMjKCjY0NkpOTMWXKFMTFxeW/0gCePHmC48ePo3Xr1rCzs3ulstQaNmwoNej27t2LOXPmSH9Fv379Or7//nuULVtWyj979mysXr0aiYmJqF+/Pt5//31Ur15dWq5uAKofoQJU40k9e/bM4DppPhr44MEDrTR1I1e9LPvyrl27yuq7Y8cOvHjxAklJSThx4gQ+++wzdO/ePcc6tG7dWnofHByMsLAwJCYmYtq0aTn2rskL9TGKiYnR6j3QrVs3AKqGalBQEK5du4b09HRERkZi48aNaNu2rfQ4Y/a6Hjt2DM+fP8d3332Xr14JhkpNTUVMTAxiYmJks/8mJSVJ6er/hBAREb0N2J5le9ZQbM+yPUtUpBXsvGZEVFQYMtuurpk6nz17Jtzd3bVmBC1fvrzO9QyZbVeTvhlTs8vIyBAuLi7C19c3H3svRNmyZbVmbk1KSpLladu2rdZ+urq6Cnt7e62ZT/My2+6CBQsEABEcHJzneuc0k+q2bduEmZlZjjMEq7Vo0UJvHhsbG/HkyRMpb9WqVbXyTJkyJde6PnnyRGu90NDQHJcfO3ZMVsb48eNz3B/NWX/zMttu9hls79+/L4SQz7abfUZhfddsp06dtMpXXwOxsbGicuXKOe6D5n2hqyxjY2Ph6Oj42mbbXb58eY71M2SbREREhYHtWbZn2Z5le1YItmfp3cWetkQkY29vjz179qBFixawsbGBk5MTBg8ejHXr1r3Rehw5cgRPnz7N9xhaQUFBss89evSQjT8GqCZ0CAoKgouLCywtLdGqVSscPnz4lXsTbNy4EaampujSpcsrlZNdp06dcPbsWQwYMAClSpWCqakp7Ozs4OfnhwEDBsjO0cCBA9G5c2d4e3vDysoKxsbG8PDwwHvvvYeQkBB4eHhIeVeuXClNeJAXHh4est4Q5ubmqFOnTo7La9euLSvju+++w44dO9C+fXu4uLjAxMQELi4uqFmzJsaMGYOZM2fmWo+1a9di3LhxcHNzg1KpRP369bFv3z6pJ4dCoZD1wMirRYsWoVOnTjrLcHR0xMmTJ/HNN9+gRo0asLKyglKphLe3N1q1aoW5c+eiXbt2Uv7169dj7NixUl3r1q2LXbt2oWrVqvmuHxEREcmxPcv2rKHYnmV7lqgoUwghRGFXgogou+HDh2Px4sU4efIk6tatW9jVMVhkZCRKliyJNm3aYNeuXYVdnXfChQsXYGlpifLlywNQjf22dOlSaTy0hg0bIjQ0tDCrSERERO8gtmfJUGzPEpEuDNoSEVGxNnXqVEybNg3W1tZwcHBATEyMNEuyg4MDDh06JBv/jIiIiIioKGF7loh04fAIRERUrAUEBKBly5awtrZGZGQkFAoFKlWqhNGjR+Py5cts4BIRERFRkcb2LBHpwp62REREREREREREREVIkehp+8svv8DX1xfm5uaoVasWQkJC9OYdOHAgFAqF1qty5cqyfJs2bUKlSpWgVCpRqVIlbN68+XXvBhERERG9w/LSpgWA1atXo3r16rC0tISHhwcGDRqE2NhYWR62aYmIiIjeTYUetF23bh1Gjx6NiRMn4vz582jcuDHatWuH8PBwnfkXLFiAiIgI6fXw4UM4OjqiZ8+eUp7jx4+jV69e6N+/Py5evIj+/fvj/fffx8mTJ9/UbhERERHROySvbdrQ0FAMGDAAgwcPxpUrV7BhwwacPn0aQ4YMkfKwTUtERET07ir04RHq1auHmjVrYvHixVKan58funbtipkzZ+a6/pYtW9C9e3fcu3cP3t7eAIBevXohMTER//zzj5Svbdu2cHBwwF9//VXwO0FERERE77S8tmnnzJmDxYsX486dO1LaokWLMHv2bDx8+BAA27RERERE77JC7WmblpaGs2fPonXr1rL01q1bIywszKAyli5dipYtW0oBW0DVKyF7mW3atDG4TCIiIiIiQ+WnTRsQEIBHjx5h165dEEIgKioKGzduRIcOHaQ8bNMSERERvbtMCnPjMTExyMzMhJubmyzdzc0NkZGRua4fERGBf/75B2vWrJGlR0ZG5rnM1NRUpKamSp+FEEhLS4OzszMUCoUhu0NERERE76D8tGkDAgKwevVq9OrVCykpKcjIyEDnzp2xaNEiKQ/btERERETvrkIN2qplb0AKIQxqVAYHB8Pe3h5du3Z95TJnzpyJadOmaaXfvHkTNjY2udaFiIiIiN4Md3f3wq6CTnlpf169ehWjRo3C5MmT0aZNG0REROCLL77Axx9/jKVLl+arTIBtWiIiIqLiwJD2bKEGbZ2dnWFsbKzVWyA6OlqrV0F2QggsW7YM/fv3h5mZmWyZu7t7nsscP348xo4dK31OTEyEl5cXXFxcYGtra+guEREREdE7Jj9t2pkzZ6Jhw4b44osvAADVqlWDlZUVGjdujG+//RYeHh5s0xIRERG9wwo1aGtmZoZatWph37596Natm5S+b98+dOnSJcd1jxw5gtu3b2Pw4MFayxo0aIB9+/ZhzJgxUtrevXsREBCgtzylUgmlUqmVbmRkBCOjQh36l4iIiIiKsPy0aV++fAkTE3lT3NjYGICqcwLANi0RERHRu6zQh0cYO3Ys+vfvj9q1a6NBgwb4/fffER4ejo8//hiAqrfA48ePsWLFCtl6S5cuRb169VClShWtMj/77DM0adIE33//Pbp06YKtW7di//79CA0NfSP7RERERETvlry2aTt16oSPPvoIixcvloZHGD16NOrWrYsSJUoAYJuWiIiI6F1W6EHbXr16ITY2FtOnT0dERASqVKmCXbt2wdvbG4BqsrHw8HDZOgkJCdi0aRMWLFigs8yAgACsXbsWX3/9NSZNmoQyZcpg3bp1qFev3mvfHyIiIiJ69+S1TTtw4EA8f/4cP/30E8aNGwd7e3s0b94c33//vZSHbVoiIiKid5dCqJ+/IpnExETY2dkhISGB438RERG9JTIzM5Genl7Y1aAcmJqaSsME0Ktjm5aIiOjtwvZs0VdQ7dlC72lLRERE9LoJIRAZGYn4+PjCrgoZwN7eHu7u7lAoFIVdFSIiIqIige3Z4qUg2rMM2hIREdFbT93AdXV1haWlJYOBRZQQAi9fvkR0dDQAwMPDo5BrRERERFQ0sD1bPBRke5ZBWyIiInqrZWZmSg1cJyenwq4O5cLCwgIAEB0dDVdXVw6VQERERO88tmeLl4JqzxoVZKWIiIiIihr1mF+WlpaFXBMylPpccbw2IiIiIrZni6OCaM8yaEtERETvBD5CVnzwXBERERFpYxup+CiIc8WgLREREREREREREVERwqAtERERUS7SMjKx/9IjTN9wFl+sOI7pG85i/6VHSMvILOyqFQghBIYOHQpHR0coFApcuHABTZs2xejRowu7akRERERUQNimLV44ERkRERFRDo7fiMKcbReQlJIBhQIQAlAogGPXI7F4zxV80cUf9cu7vZZtR0ZGYsaMGdi5cyceP34MV1dX+Pv7Y/To0WjRokWBbWf37t0IDg7G4cOHUbp0aTg7O+Pvv/+GqalpgZT/6NEjlC5dGqVLl8b169cLpEwiIiIiMhzbtK/uTbdp2dOWiIiISI/jN6Iwbf0ZvEjJAKBq3Gr++yIlA1PXncHxG1EFvu379++jVq1aOHjwIGbPno3Lly9j9+7daNasGUaMGFGg27pz5w48PDwQEBAAd3d3mJiYwNHRETY2NgVSfnBwMN5//328fPkSx44dK5AyiYiIiMgwbNMWzzYtg7ZEREREOqRlZGLOtgsAAKEnjzp9zrYLBf5Y2fDhw6FQKHDq1Cn06NED5cuXR+XKlTF27FicOHFCyhceHo4uXbrA2toatra2eP/99xEV9V+De+rUqfD398fKlSvh4+MDOzs79O7dG8+fPwcADBw4ECNHjkR4eDgUCgV8fHwAQOtRsoiICHTo0AEWFhbw9fXFmjVr4OPjg/nz5+e4H0IILF++HP3790ffvn2xdOnSAjtGRERERJQztmmLb5uWQVsiIiIiHY5ejUBSSobexq2aAJCUkoGQqxEFtu24uDjs3r0bI0aMgJWVldZye3t71baFQNeuXREXF4cjR45g3759uHPnDnr16iXLf+fOHWzZsgU7duzAjh07cOTIEcyaNQsAsGDBAkyfPh2enp6IiIjA6dOnddZpwIABePLkCQ4fPoxNmzbh999/R3R0dK77cujQIbx8+RItW7ZE//79sX79eqlxTURERESvF9u0csWpTcsxbYmIiOid8+kfoXiWlJpjnsTktDyVOX/nZSw7eCPHPA7WSvw0pFGuZd2+fRtCCFSsWDHHfPv378elS5dw7949eHl5AQBWrlyJypUr4/Tp06hTpw4AICsrC8HBwdKjYf3798eBAwcwY8YM2NnZwcbGBsbGxnB3d9e5nevXr2P//v04ffo0ateuDQD4448/UK5cuVz3ZenSpejduzeMjY1RuXJllC1bFuvWrcOQIUNyXZeIiIiI9GOb9u1u0zJoS0RERO+cZ0mpiHmeUqBlpmVkFViZ4v8HGFMoFDnmu3btGry8vKTGLQBUqlQJ9vb2uHbtmtTA9fHxkY3l5eHhYVCPArUbN27AxMQENWvWlNLKli0LBweHHNeLj4/H33//jdDQUCntgw8+wLJlyxi0JSIiInpFbNO+3W1aBm2JiIjoneNgrcw1T2JyGtIysgwu08zECLYWZq+8XQAoV64cFAoFrl27hq5du+rNJ4TQ2QjOnp59xlyFQoGsLMP3Td3gNjRdbc2aNUhJSUG9evVk62RlZeHq1auoVKmSwXUgIiIiIjm2ad/uNi2DtkRERPTOMeRxrv2XHuGHrRcNLnN0h6poUc3zVaolcXR0RJs2bfDzzz9j1KhRWmOAxcfHw97eHpUqVUJ4eDgePnwo9Uy4evUqEhIS4OfnVyB1AYCKFSsiIyMD58+fR61atQCoHneLj4/Pcb2lS5di3LhxGDhwoCx91KhRWLZsGebMmVNgdSQiIiJ617BNmzfFrU3LiciIiIiIdGhSyQPW5ibI+WEuQAHA2twEjSt5FOj2f/nlF2RmZqJu3brYtGkTbt26hWvXrmHhwoVo0KABAKBly5aoVq0a+vXrh3PnzuHUqVMYMGAAAgMDpXG6CkLFihXRsmVLDB06FKdOncL58+cxdOhQWFhY6H3c7cKFCzh37hyGDBmCKlWqyF59+vTBihUrkJ6eXmB1JCIiIiJtbNP+p7i1aRm0JSIiItLBzMQYX3TxBwC9jVx1+hdd/GFmYlyg2/f19cW5c+fQrFkzjBs3DlWqVEGrVq1w4MABLF68WLV9hQJbtmyBg4MDmjRpgpYtW6J06dJYt25dgdYFAFasWAE3Nzc0adIE3bp1w0cffQQbGxuYm5vrzL906VJUqlRJ58QT6tmBt2/fXuD1JCIiIqL/sE0rV5zatAqR28AN76jExETY2dkhISEBtra2hV0dIiIiyqeUlBTcu3cPvr6+ehtjOTl+Iwpztl1AUkoGFApACEj/Wpub4Isu/qhf3u011Lxoe/ToEby8vLB//360aNGiQMt+1XNG/2GbloiIqPgriLYR27S6va42bUGcM45pS0RERJSDBhXc8NeYlgi5GoFjN6LwPDkNNhZmaFjBDY0reRR4b4Si6uDBg0hKSkLVqlURERGBL7/8Ej4+PmjSpElhV42IiIiIcsE2rUpxatMyaEtERESUCzMTY7So5llgkzIUR+np6ZgwYQLu3r0LGxsbBAQEYPXq1Vqz+BIRERFR0cQ2bfFq0zJoS0RERES5atOmDdq0aVPY1SAiIiIiyrfi1KblRGRERERERERERERERQiDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFiElhV4CIiIioSEoMB5JjDM9v4QzYlnp99SEiIiIiyiu2aYstBm2JiIiIsksMB5ZVADJTDF/H2Bz48EaxbOQKITBs2DBs3LgRz549w/nz5zF69Gj4+/tj/vz5hV09IiIiIsoPtmmLdZuWwyMQERERZZcck7fGLaDKn5deDAaIjIzEyJEjUbp0aSiVSnh5eaFTp044cOBAgW5n9+7dCA4Oxo4dOxAREYEqVarg77//xjfffPNK5U6dOhUKhUJ62dnZoXHjxjhy5EgB1ZyIiIiI9GKbtli3adnTloiIiKgIun//Pho2bAh7e3vMnj0b1apVQ3p6Ovbs2YMRI0bg+vXrBbatO3fuwMPDAwEBAVKao6NjgZRduXJl7N+/HwAQFxeHOXPmoGPHjnj06BHs7OwKZBtEREREVDSxTZt/7GlLREREVAQNHz4cCoUCp06dQo8ePVC+fHlUrlwZY8eOxYkTJ6R84eHh6NKlC6ytrWFra4v3338fUVFR0vKpU6fC398fK1euhI+PD+zs7NC7d288f/4cADBw4ECMHDkS4eHhUCgU8PHxAQA0bdoUo0ePlsqJiIhAhw4dYGFhAV9fX6xZswY+Pj65PmpmYmICd3d3uLu7o1KlSpg2bRqSkpJw8+bNAjtWRERERFQ0sU2bfwzaEhERERUxcXFx2L17N0aMGAErKyut5fb29gBU43Z17doVcXFxOHLkCPbt24c7d+6gV69esvx37tzBli1bsGPHDuzYsQNHjhzBrFmzAAALFizA9OnT4enpiYiICJw+fVpnnQYMGIAnT57g8OHD2LRpE37//XdER0fnab9SU1MRHBwMe3t7VKhQIU/rEhEREVHxwjbtq+HwCERERPTuWVUbeBGpf3lmWv7K3dQWMDbTv9zKHfjgTK7F3L59G0IIVKxYMcd8+/fvx6VLl3Dv3j14eXkBAFauXInKlSvj9OnTqFOnDgAgKysLwcHBsLGxAQD0798fBw4cwIwZM2BnZwcbGxsYGxvD3d1d53auX7+O/fv34/Tp06hduzYA4I8//kC5cuVy3ZfLly/D2toaAPDy5UvY2Nhg3bp1sLW1zXVdIiIiIsoB27RvdZuWQVsiIiJ697yIBJIeF3y5yU8LpBghBABAoVDkmO/atWvw8vKSGrcAUKlSJdjb2+PatWtSA9fHx0dq3AKAh4dHnnoU3LhxAyYmJqhZs6aUVrZsWTg4OOS6boUKFbBt2zYAwPPnz7Fu3Tr07NkThw4dkhrLRERERJQPbNO+1W1aBm2JiIjo3WOl+6/vksy0/DVWLVxy75VggHLlykGhUODatWvo2rWr3nxCCJ2N4OzppqamsuUKhQJZWVkG1UVdXl7SNZmZmaFs2bLS5xo1amDLli2YP38+Vq1aZXAdiIiIiCgbtmnf6jYtg7ZERET07sntca6oc8CqWnkv973dgFvN3PPlwtHREW3atMHPP/+MUaNGaY0BFh8fD3t7e1SqVAnh4eF4+PCh1DPh6tWrSEhIgJ+f3yvXQ61ixYrIyMjA+fPnUauW6rjcvn0b8fHx+SrP2NgYycnJBVY/IiIioncS27R5UtzatJyIjIiIiKgI+uWXX5CZmYm6deti06ZNuHXrFq5du4aFCxeiQYMGAICWLVuiWrVq6NevH86dO4dTp05hwIABCAwMLNDHtCpWrIiWLVti6NChOHXqFM6fP4+hQ4fCwsIi18fdMjIyEBkZicjISNy6dQvffvstrl69ii5duhRY/YiIiIioaGKbNv8YtCUiIiIqgnx9fXHu3Dk0a9YM48aNQ5UqVdCqVSscOHAAixcvBqB6JGzLli1wcHBAkyZN0LJlS5QuXRrr1q0r8PqsWLECbm5uaNKkCbp164aPPvoINjY2MDc3z3G9K1euwMPDAx4eHvD398f69euxePFiDBgwoMDrSERERERFC9u0+acQhgzc8A5KTEyEnZ0dEhISOLsxERFRMZaSkoJ79+7B19c318aYJL+Pkn1wtkAeJSsOHj16BC8vL+zfvx8tWrQo0LLzdc5IJ7ZpiYiIir98t43Yps3V62rTFkR7lmPaEhEREWVn4QwYmwOZKYavY2yuWu8tdfDgQSQlJaFq1aqIiIjAl19+CR8fHzRp0qSwq0ZEREREurBNq6U4tWkZtCUiIiLKzrYU8OENIDnG8HUsnFXrvaXS09MxYcIE3L17FzY2NggICMDq1au1ZvElIiIioiKCbVotxalNy6AtERERkS62pd7qBmtetWnTBm3atCnsahARERFRXrBNK1Oc2rSciIyIiIiIiIiIiIioCGHQloiIiIiIiIiIiKgIYdCWiIiI3glCiMKuAhmI54qIiIhIG9tIxUdBnCsGbYmIiOitpp5U4OXLl4VcEzKU+lwVxQkhiIiIiN40tmeLn4Joz3IiMiIiInqrGRsbw97eHtHR0QAAS0tLKBSKQq4V6SKEwMuXLxEdHQ17e3sYGxsXdpWIiIiICh3bs8VHQbZnGbQlIiKit567uzsASA1dKtrs7e2lc1ac/PLLL/jhhx8QERGBypUrY/78+WjcuLHOvAMHDsSff/6plV6pUiVcuXJF+jx//nwsXrwY4eHhcHZ2Ro8ePTBz5kyYm5u/tv0gIiKiooft2eKlINqzDNoSERHRW0+hUMDDwwOurq5IT08v7OpQDkxNTYtlD9t169Zh9OjR+OWXX9CwYUP89ttvaNeuHa5evYpSpUpp5V+wYAFmzZolfc7IyED16tXRs2dPKW316tX46quvsGzZMgQEBODmzZsYOHAgAODHH3987ftERERERQfbs8VHQbVnFYKjGOuUmJgIOzs7JCQkwNbWtrCrQ0RERERFWL169VCzZk0sXrxYSvPz80PXrl0xc+bMXNffsmULunfvjnv37sHb2xsA8Omnn+LatWs4cOCAlG/cuHE4deoUQkJCDKoX27RERERExRN72hIRERERvYK0tDScPXsWX331lSy9devWCAsLM6iMpUuXomXLllLAFgAaNWqEVatW4dSpU6hbty7u3r2LXbt2ISgoSG85qampSE1NlT4nJiYCALKyspCVlZWX3SIiIiKi18TIyCjXPAzaEhERERG9gpiYGGRmZsLNzU2W7ubmhsjIyFzXj4iIwD///IM1a9bI0nv37o2nT5+iUaNGEEIgIyMDn3zyiVZwWNPMmTMxbdo0rfSnT58iJSXFwD0iIiIiotfJkPFuGbQlIiIiIioA2WdxFkIYNLNzcHAw7O3t0bVrV1n64cOHMWPGDPzyyy+oV68ebt++jc8++wweHh6YNGmSzrLGjx+PsWPHSp8TExPh5eUFFxcXDo9AREREVIwwaEtERERE9AqcnZ1hbGys1as2Ojpaq/dtdkIILFu2DP3794eZmZls2aRJk9C/f38MGTIEAFC1alW8ePECQ4cOxcSJE3U+VqdUKqFUKrXSjYyMDHoMj4iIiIiKBrbciIiIiIhegZmZGWrVqoV9+/bJ0vft24eAgIAc1z1y5Ahu376NwYMHay17+fKlVqDV2NgYQghwLmEiIiKitxt72hIRERERvaKxY8eif//+qF27Nho0aIDff/8d4eHh+PjjjwGohi14/PgxVqxYIVtv6dKlqFevHqpUqaJVZqdOnTBv3jzUqFFDGh5h0qRJ6Ny5M4yNjd/IfhERERFR4WDQloiIiIjoFfXq1QuxsbGYPn06IiIiUKVKFezatQve3t4AVJONhYeHy9ZJSEjApk2bsGDBAp1lfv3111AoFPj666/x+PFjuLi4oFOnTpgxY8Zr3x8iIiIiKlwKwWerdEpMTISdnR0SEhI4aQMRERERFUts0xIREREVTxzTloiIiIiIiIiIiKgIYdCWiIiIiIiIiIiIqAhh0JaIiIiIiIiIiIioCGHQloiIiIiIiIiIiKgIYdCWiIiIiIiIiIiIqAhh0JaIiIiIiIiIiIioCGHQloiIiIiIiIiIiKgIYdCWiIiIiIiIiIiIqAhh0JaIiIiIiIiIiIioCGHQloiIiIiIiIiIiKgIYdCWiIiIiIiIiIiIqAhh0JaIiIiIiIiIiIioCGHQloiIiIiIiIiIiKgIYdCWiIiIiIiIiIiIqAhh0JaIiIiIiIiIiIioCGHQloiIiIiIiIiIiKgIMSnsChARERERERHRWygzHTg8Bri+RvW5Yj+g2Y+AkY5QxELrbOumAo5+QNCl/9JubwPCJgPPbgFKO6DBZKD6x/L10pOBFVWB5Bjg03hVWkYqcPBT4MF+Vbp1SaDOl0DVDwtsV4mIChqDtkRERERERERU8E58CzwOBYKuqD7/3Q44+Z0q2JrdqCT55z+rARV7//f53m7gwHCg/SqgZGMgLRF4EaVdTthkwNpTFZxVExmAlQfQcz9gVxqIOKmqi40n4NP61feTiOg1KBLDI/zyyy/w9fWFubk5atWqhZCQkBzzp6amYuLEifD29oZSqUSZMmWwbNkyaXlwcDAUCoXWKyUl5XXvChEREREREREBwL/LgPpfA9Yeqle9icDlpbmvF3EKiL0KVB74X9qxSapgr1dTwMgYMHcAnCrK14s6B9zbBdQbL083tQIaTgfsywAKBVCiPuDVTBVQJiIqogq9p+26deswevRo/PLLL2jYsCF+++03tGvXDlevXkWpUqV0rvP+++8jKioKS5cuRdmyZREdHY2MjAxZHltbW9y4cUOWZm5u/tr2g4iIiIiIiIj+X8ozIOkR4OL/X5qrP/A8HEhNUA1voM+/SwHfdoB1CdXn9BdA1FkgtRewrCKQGg94BgLNFwBW7qo8WRnA3o+AFj/nXreMFCDyFODXN587R0T0+hV60HbevHkYPHgwhgwZAgCYP38+9uzZg8WLF2PmzJla+Xfv3o0jR47g7t27cHR0BAD4+Pho5VMoFHB3d3+tdSciIiIiIiIiHdL+f7gDpf1/aer3ac/1B23TXwLX1wLtVvyXlvIMgACurQR67AHMnYD9HwO7+gM996nynJkLuFRT9cR9eFh/vYQA9g4BHMoB5brnZ8+IiN6IQg3apqWl4ezZs/jqq69k6a1bt0ZYWJjOdbZt24batWtj9uzZWLlyJaysrNC5c2d88803sLCwkPIlJSXB29sbmZmZ8Pf3xzfffIMaNWrorUtqaipSU1Olz4mJiQCArKwsZGVlvcpuEhEREVEBMjIqEiN8ERFRTsz+f2KxtATA0ln1PjXh/5fZ6F/vxnrA1BIo3eG/NNP/L6vGKMDWW/U+YBqwtJyqF+6LSODCz0D/8znXSQhg/ydA3A3V+LYK/p4QUdFVqEHbmJgYZGZmws3NTZbu5uaGyMhInevcvXsXoaGhMDc3x+bNmxETE4Phw4cjLi5OGte2YsWKCA4ORtWqVZGYmIgFCxagYcOGuHjxIsqVK6ez3JkzZ2LatGla6U+fPuVYuERERERFCJ+mIiIqBswdVBOCRV9QjSULAE8vADZeOQ+NcPkPoFIQYKQRrjC3B2xKAVBo5xcCeBQCJD8Fgiur0rLSgNREYLE70HUb4FFXle/ACNWwCD0P5FwHIqIioNCHRwBUQxloEkJopallZWVBoVBg9erVsLNTfcnOmzcPPXr0wM8//wwLCwvUr18f9evXl9Zp2LAhatasiUWLFmHhwoU6yx0/fjzGjh0rfU5MTISXlxdcXFxga2v7qrtIRERERERE9G6pMgg4OQMo2VD1+eR3QNUh+vPH3QCehAFtlmkvqzYUOL8Q8GkDmDsCx6cDpVqoevRW6AX4tv0v75MwYPcgYMAF1VAKAHDgU+DJMaDnQVVAmYioiCvUoK2zszOMjY21etVGR0dr9b5V8/DwQMmSJaWALQD4+flBCIFHjx7p7ElrZGSEOnXq4NatW3rrolQqoVQqda7LR/CIiIiIiIiI8qj+JCA5Fljup/rs1w+oN0H1ft/Hqn9b/fpf/stLAc/GgGN57bLqfgWkxAErqqs+l2oGtF+pem9qoXqpmTsCCsV/k5QlPgAu/gIYK4El3v/l8/tAvn0ioiKkUIO2ZmZmqFWrFvbt24du3bpJ6fv27UOXLl10rtOwYUNs2LABSUlJsLZWjWtz8+ZNGBkZwdPTU+c6QghcuHABVatWLfidICIiIiIiIiJtxqZAy59Vr+x0BUsDZ+svy8gYaDpX9cqNV1Pg0/j/Ptt6A+NE7usRERUhhd6FdOzYsfjjjz+wbNkyXLt2DWPGjEF4eDg+/lj1V7fx48djwIABUv6+ffvCyckJgwYNwtWrV3H06FF88cUX+PDDD6WJyKZNm4Y9e/bg7t27uHDhAgYPHowLFy5IZRIREREREREREREVVYU+pm2vXr0QGxuL6dOnIyIiAlWqVMGuXbvg7a16ZCEiIgLh4eFSfmtra+zbtw8jR45E7dq14eTkhPfffx/ffvutlCc+Ph5Dhw5FZGQk7OzsUKNGDRw9ehR169Z94/tHRERERERERERElBcKIQSfEdAhMTERdnZ2SEhI4ERkRERERFQssU1LREREVDwV+vAIRERERERERERERPQfBm2JiIiIiIiIiIiIihAGbYmIiIiIiIiIiIiKkEKfiIyIiIiIiIiISJIYDiTHGJ7fwhmwLfX66kNEVAgYtCUiIiIiIiKioiExHFhWAchMMXwdY3PgwxsM3BLRW4XDIxARERERERFR0ZAck7eALaDKn5eeuURExQCDtkRERERERERERERFCIO2REREREREREREREUIg7ZERERERERERERERQiDtkRERERERERERERFiElhV4CIiIiIiIiI3nHpycDjo8DVFflb/+AowLsV4F5H9bJ0Kdj6ERG9YQzaEhEREREREdGbJQQQewW4v0f1enQUyEzNf3lPjqlearY+gHtdVQDXoy7gWhMws37lahMRvSkM2hIRERERERHR65ccCzzYB9zfCzzYCyQ9fn3bSryvet1cr/qsMAKcKgFudf4L5DpXBYzNXl8diIheAYO2RERERERERFTwMtOBiBOqAO39PUDkGQBCd14bL8CnDWBfDgj5X9631WUrkJEMRJ4CIk8DUWeBjJf/LRdZQMy/qteV5ao0YyXg6q8K5HrUVf3rWF4V4CUiKmQM2hIRERERERFRwYi/+1+QNvwgkJaoO5+JBeDVVBWo9W4NOFYEFAog6hwQko/t2ngCbjWBir1Un7MygNhrqgCuOpAbc0mVrpaZCkScVL0u/H+amS3gXvu/oRXc6wLWJVV1IyJ6gxi0JSIiIiIiIqL8SUsCHh76b2za+Nv687pUA7zbAD6tgZKNABPz11cvIxPAparqVfVDVVp6MvD04n9B3MhTwLOb2fYnURVsDj/4X5qVuzyI61YbsHB8fXUnIgKDtkRERERERERkKJEFRF/4L0j7JAzISted18JZ1YvWp7XqX2uP3Mu3cAaMzYHMFMPrZGyuWi83phZAifqql1pKPBB1Rt4jN/tYuy8igTvbVC81+7L/BXHd6wCuNQBTS8PrTESUC4UQQs+AMu+2xMRE2NnZISEhAba2toVdHSIiIiKiPGOblogKxItI1eRh9/eoJhJLfqo7n5EJUCJANeSBTxtVIDM/48MmhgPJMYbnt3AGbEvlfTv6JD2RB3EjTwOp8TmvozAGnKvIA7nOVVTHhIgoHxi01YMNXCIiIiLKi19++QU//PADIiIiULlyZcyfPx+NGzfWmXfgwIH4888/tdIrVaqEK1euSJ/j4+MxceJE/P3333j27Bl8fX0xd+5ctG/f3qA6sU1LRPmSkQo8Dv1vbNqnF/XntS/z/0MetAFKNQPMbN5cPd8UIVTDPmgGcqPPARm59AY2sVAFrjWHVrAvw/Fxicgg/JMPEREREdErWrduHUaPHo1ffvkFDRs2xG+//YZ27drh6tWrKFVKu/fXggULMGvWLOlzRkYGqlevjp49e0ppaWlpaNWqFVxdXbFx40Z4enri4cOHsLF5CwMiRFS4hADibvwXpH14GMh4qTuvmQ3g1fz/e9O2VgUh33YKBeBQTvXy66tKy0wHYq/Ix8eN+Vc1fIRaRrJq+IgnYf+lmTsAbnXkPXINGTaCiN457GmrB3slEBEREZGh6tWrh5o1a2Lx4sVSmp+fH7p27YqZM2fmuv6WLVvQvXt33Lt3D97e3gCAX3/9FT/88AOuX78OU1PTfNWLbVoi0islHgg/8N/YtM/D9WRUAG61/gvSejQAjPP3nfTWS38BRJ0Hok4DEadU/8bfyX09a095ENe9NqC0e/31JaIijUFbPdjAJSIiIiJDpKWlwdLSEhs2bEC3bt2k9M8++wwXLlzAkSNHci2jU6dOSE1Nxd69e6W09u3b4//Yu+/wuMoz/ePfGfXee3ORXGTJ3ZYLNrhgIM3AJpACCaQtSXaTwIZdSMgGkhASIAvkF2oCCyShJEsIJKG5Ai64YpC75SZZvfc2M+f3x5FGGs3Ikmx13Z/rmkua0/yODdI79zzneSMjIwkMDOS1114jJiaGL37xi/zXf/0XXl5eHq/T2tpKa2ur83ldXR0pKSlUV1drTisy0TnsZoh45h0sZ9+Bkl1YuleFdmMEJUDaOoy0yyHt8v4t8iWeNVc6FzqzlJr9cS1NpX2eZkRMh/hFGJ1VuTFzwNt/GAYsIsPBau2737faI4iIiIiIXISKigrsdjtxcXEu2+Pi4igpKenz/OLiYt58801eeOEFl+2nTp1i8+bNfOlLX+KNN97gxIkTfOc738Fms/Hf//3fHq913333cc8997htLy8vp6VlACuxi8i4YG0sxK94K37FW/EteR9rW63H4wyrH22xObQmXEZbwmXYwmd09V2td0B92TCOehwKnAdT5sGUb4JhYG0qwqfyQ3wqP3J+tdoaXE6xVB+D6mNYjvwRAMPijS1iJu1R82iPmkt71DxsoRlg9fwhnoiMbvHx8X0eo9BWRERERGQQWHosLGMYhts2T5599lnCw8O5+uqrXbY7HA5iY2N56qmn8PLyYsGCBRQVFfHAAw/0Gtreeeed3Hbbbc7nnZW2MTExqrQVmQjam+Dcu2Yl7dkNWKqO9HqoETnTrKadtA6SVuLjE4iaHgyXOJg8r+up4cBRdQxK92DpqMql/AAWe5vzEIthw6cqF5+qXDjxvHmaTxDELoD4hV0VuaGTtNCZyDih0FZERERE5CJER0fj5eXlVlVbVlbmVn3bk2EYPPPMM9x44434+vq67EtISMDHx8elFcLMmTMpKSmhra3N7XgAPz8//Pz83LZbrdZ+3YYnImOMYUBFLpzpWECs8H2wt3o+1j8CUteavWnT1mEJTQFA8d5oYIWYWeYj6yZzk70Nyj/uWuSsZA9UHga6Olxa2huh8D0ofK/r3zEgukd/3EUQGDvMr0dEBoNCWxERERGRi+Dr68uCBQvYsGGDS0/bDRs2sH79+vOe++6775KXl8fXvvY1t33Lly/nhRdewOFwOAPX48ePk5CQ4DGwFZEJoqkczm6Es2+bYW1jsefjLFZIWNKxgNgVELdQt9KPJV6+5oJk8QuBb5nb2uqhdH9XiFuyG+rOup7XXAGn3zQfnULTuoW4iyFuPviGDNtLEZELo4XIeqGFyERERESkv15++WVuvPFGnnjiCZYuXcpTTz3F7373Ow4dOkRaWhp33nknhYWFPP/88y7n3XjjjZw4cYIPPvjA7ZoFBQVkZmZy00038e///u+cOHGCr371q3z3u9/lRz/6Ub/GpTmtyDhgb4finWYl7Zm3zdCOXt7Gh6Y5K2lJXQP+4cM5UhkJTWUdAW63itzmij5OskBUpmtFbsxsMygWkVFDlbYiIiIiIhfp+uuvp7Kykp/+9KcUFxeTlZXFG2+8QVpaGmAuNpafn+9yTm1tLa+88gqPPPKIx2umpKTwzjvvcOuttzJ79mySkpL43ve+x3/9138N+esRkRFWc7IrpM3fDO0Nno/zDoTUVWZIO+kKiJimfqYTTWAsTPmk+QCzZUbdGTO8Ld4NpXugdB+0N3Y7yYDKQ+bj0LPmJi9fiJnrGuRGTjcrtkVkRKjStheqShARERGRsU5zWpExoq3eDGfPvA1n3zFD297EzOlqeZC4HLzd+1iLuHDYoepIV4hbvBsqPgaH7fzn+YZC3ALX1gohyfpgQGSYKLTthSa4IiIiIjLWaU4rMkoZDrPNQWdIW7Sj9wAtIAYmdVTSpl0OQfHDO1YZn2wtUHbArMjtDHKrj/V9XmBcV4ibsNjslRwQNeTDFZmIFNr2QhNcERERERnrNKcVGUUaiuDsho6gdkPvfUetPpC0HNI6qmlj5+gWdRkeLTVmK4Xu/XEbzvV9XvhUiOsMcReZC535BA75cEXGO4W2vdAEV0RERETGOs1pRUaQrQUKt3X1pq3I7f3YiIyukDblMvANHrZhipxXQ7FriFu6B1qqz3+OxQuiZ3VV5MYtgugs8PIZnjGLjBMKbXuhCa6IiIiIjHWa04oMI8OAqqNdIe25d8HW7PlY31BIXdPV9iBs8vCOVeRCGYbZc7kzxC3ZDWX7zQ8pzsfbH2LmmdW4nf1xw9PVH1fkPBTa9kITXBEREREZ6zSnFRliLdVwdmNXb9r6gl4OtJhB1aR1ZkVtQo6qDmX8sLdD5SHXityKg2DYz3+eX3hHgLuoqyo3OHFYhiwyFii07YUmuCIiIiIy1mlOKzLIHDZzwabOkLZkt7momCfBiV0tD9LWarEmmVjam6Dsw24VuXugJq/v84KTXEPcuIXgHz7kwxUZjRTa9kITXBEREREZ6zSnFRkEdWc7Wh68A/mboLXG83He/pC00gxpJ10BUZm69Vuku+YqKN3r2lqhsaTv8yKmdYW48Yshdq75/5vIOKfQthea4IqIiIjIWKc5rcgFaG+Egne7etNWH+v92KhZXSFt0grwCRi+cYqMdYYBDYWuIW7JXmirO/95Vm+Inu1akRuVCVav4Rm3yDBRaNsLTXBFREREZKzTnFakHwwDyj/uaHnwNhRuA3ub52P9IyHt8o6WB5dDSPLwjlVkvDMcUHUcSveYrUhK95htFnr7f7KTdyDELXANcsMmq9pdxjSFtr3QBFdERERExjrNaUV60VQGZzd0tT1oKvV8nMULEpdC2jozqI1boGo+keFmb4OKXDPE7azIrTwM9BFn+Ue5hrjxiyAobliGLDIYFNr2QhNcERERERnrNKcV6WBvg6IdXSFt2f7ejw2d1NXyIHU1+IUN2zBFpJ/aGsz/j7sHuXVn+j4vJBUSFkPcoo6vC8A3ZMiHK3IhFNr2QhNcERERERnrNKeVCcswzJXqO0Pagi3Q3uD5WJ8gSFnVFdSGp+uWapGxqKm8I8Dd09Unt7m8j5MsEDXTtSI3ejZ4+w3LkEXOR6FtLzTBFREREZGxTnNamVBaayF/M5x9xwxra0/3fmzsvK6QNnEZePkO3zhFZHgYBtSddQ1xS/eaiw2ej5cvxMxxbasQOQMs1uEZt0gHhba90ARXREaUvR223gpHXzCfz/gSrHrIXCnVk7zXYcd/Q/UJ8xa+pf8Nc27p37XqC2HTd6DwfcACqatg9W+7+j3VnIRN/wbFH4BPIMz7Hiz+zyF76SIiMng0p5VxzWE3b48+87b5KNoJht3zsYFxMGmd2Zs27XL1tRSZqBx2qDraFeKW7DYXInS0n/8835COhc4Wd1XlhqSoKl+GlELbXmiCKyIjavtP4ORrcO2b5vO/XgUZ15phbE+n34J3vg6f+CMkrYC2OmgshagZ/bvW39YDFvN8DPjnl8xw9lMvmZOa52dD+tWw9G6oPQX/dzms+CXM/OLQ/h2IiMhF05xWxp36wq5K2rMboaXS83FWH0i6pKuaNma2quRExDNbC5R/5FqRW3W07/MCY11D3PhFEBA19OOVCaOXki0RERlRB58xq2GDE8znOT+Cd3/gObTd/mNze8pl5nP/CPPR32vVnobFd4BvsPl8xvWw6z7z++pjUHUMlv4EvHwgcjpkfQ0+fkqhrYiIiAy99mbzbqDOatrKQ70fGzGtK6RNuczsVSsi0hdvf0jIMR+dWmuhdJ9rkFtf4HpeUxmc+of56BQ2xTXEjZuvn0VywRTaioiMNi3V0HAOYuZ2bYudC/X55uSh+wrG7Y3mZKL1enhmBrTWQPKlsPoRCIrv37UW3AbH/wJTPmn2fTr6ovk9gOHo+NrtpgzDARUfD8lLFxERkQnOMKDycEcl7Ttw7l2zCs4TvzBIXWOGtGnrIGzSsA5VRMYxvzBIXW0+OjWWuIa4JbvN91vd1Z4yH8deNp9brBA1y7UiNzrLLIgR6YNCWxGR0aatY2Vjv/CubZ3ft9W7hrYt1YABR/4An30b/KNg4y3wxo3wuQ39u1bScsj9Hfy2ozo3YQksucv8PmI6hE02++Uu+6m5CvPBZ6C1blBfsoiIiExgzZVmq4Oz78CZd8wPnD2xWM3QI62jmjZhce/9/kVEBltQPEz9tPkA80Om2lNQvBtK95hfy/aDrbnrHMMBFbnm4+DT5jZvf7OopnuQG5GuFi4DNZB1YH4T3OPcVoicCV/pUYzU3gzPZ0NzBfxbjft1ets/0DVp+km/4URERpvONgVttRAYbX7fWtuxL8T1WJ+OY+d9F0LTzO+X3QNPZ5hVuH1dy3CYPWqnXQef3WBu33E3/N8V8MUd5ifAV78OW74PTyVDcBJk3QwfPznYr1pEREQmCocNind1tTwo2QP0stRKcHJHy4N1kLoWAiKHdahycWx2B0+8c5gtB4sAWJ2dyC3rMvGyuodT63/5lsvzdruD1OhgnvjXlS7bW9vt/OuT71HX1MZf//MK5/ZH3zrIjmOlNLXYCPDzYsXMBL6+diY+Xuaf9eBrH7HlYCHeXl1/9n035JCZHIHIBbFYIHyq+Zj5BXObwwYVh1wrcityXRdJtLWYizwXf9C1zS8M4ha5tlYISRre1zPWfPBzKNwGX+lom/PXq2DXLzy3FPxug+vz52bDjM+7H7fjv83fO80Vnv/M3vYPZCwDoNBWRGS08Y8wfxGUHTAnAADlB8zVSbtX2QL4h0NIKuBh1VLD6PtaTRVQdxbmf9dcfAxg3r/D3gfMfYHREDXTrOLt9N5/mS0YRERERPqr9kxXSJu/yVw41RNvf0i+zAxpJ11hVkJpdfYx64X38zhUUM1Tt5jB610v7uHFbSe5YWWG27Gv3XGly/NbnnyPS2cluh33/LvHiQn1p66pzWX7pxek8bXVM/D39aamsZV7X9nPX3ac5Isruv6sTy1M41tXzBqMlybimdUbYueYj9lfN7e1N5nvx7q3VajJcz2vtRbyN5qPTsGJZpCbsLgj0F3ounbJRDeQdWC6K95ttuGZdZPr9tL9cPoNuOx/4B/Xu593vv0XOpY+KLQVERmNsm6GXfearQvA/JQu++uej539TfjwN+YbG/9I2PlTs79bZ5Xt+a4VGA3h6XDgUXOxMTC/D07uqswt/9gMfK0+ZpP9g8/A5zYNzesWERGR8aGtAQq2dvSmfRuqT/R+bHRWV8uD5BVmcCvjwtsfFXDL5ZlEhZj/pl+4JJ3fbTziMbTt7mhhDWfLG1g3J9ll+4niWnafKONf12Xyi1f2u+xLjXG9I81qsVBY1TgIr0LkIvkEQtIy89GpuQpK93aryN1t9sztrqEIGl6Dk691bYvIcG2rEDMXfAKG5WWMKgNZB6ang0/D5KvMULyTwwbvfAPWPOr5nPPtv5ix9EGhrYjIaLTkx2Z/t/+daT6f+SXI+aH5/YZbzK+XP2F+XXwHtFTB83PM56mr4BN/6N+1AK5+DbbcCk8mme0SYueZLRE6HfszfPQY2FohZg6s/xvEzB70lywiIiJjmOGAso+6QtrC7eBo93ysfxSkXd7V9iDYvZpSxr765nYq6lqYEh/q3DY1LpSy2mYaW9oJ8u99Iaa3DxSwKD3GGfYC2B0OHv7Hx/zbVVm9nvfy9jxe3JZHc5ud0AAfvrZmhsv+jR8XsvHjQiKD/bhibgrXLpmMVZXcMhICIjvuKFhnPjcMaCjsCHE7gtzSvV2t7TpVnzAfR/5kPrd6Q3S2GeJ2VuVGZY7/ft8DWQemu/YmOPoSXPW86/a9vzbf46ZcZn7g2NP59l/oWPphnP8rioiMUV4+sPZR89FTZ1jbyeoFl/3afAz0WmD+Uu/e/qCnS35uPkRERES6ayyFsxs6gtp3oKnM83FWb0hY2hHSXmF+QGz1Gt6xyrBrbrMBENwtnA3yNyOIpjZbr6FtS7udrYeKuH39HJft/7fzNJPjQpkzKYqPzlR6PPf65elcvzyd/PJ6Nh8sIiLYz7lv/eJJfH3tDEICfDleVMO9r+zHaoFrl0y5qNcpMigsFghJNh8Z15jbDIcZ0Hbvj1v2obmIVieHzdxW9iHwlLnNOxDi5rv2xw2bMr5azQxkHZjujv3ZrHye8smubTUnzbtNb/zQ8zl97b/QsfSDQlsRERERERHpm60VinZ09aYtP9D7sWFTzIA2bR2krga/0N6PlXEpwNeMGxpb2gkL9DW/bzWD3EDf3qOI9w4X4e/jRU5GrHNbUVUjf997hse+saJff3ZqTAhT4kJ58PWP+NUNSwDISOiqdpuZHMH1y6ey8eNChbYyelmsEDndfGTeYG6zt0HFQdf+uJWHzYC3k63JXBSrcFvXNv9I1xA3fhEExQ/v6xlMA1kHprvc30PmV1wrkc+9D83l8GxHv2tHG7TWwePx5h2olYfPvz9h8YWNpR8U2oqIiIiIiIg7wzCrvDpbHhRshfZeeoT6BJvhbFrHAmIR6cM5UhmFQgJ8iA7152RpHYmRQQCcKqkjJtT/vK0R3vqwgLWzk/GyWp3bDhZUUdvUxjefeA+AdruDplYbn/+fjdx9/UJmJIW7Xcdmd1BU1dTrn2MZT1WHMnF4+ZpVtHHzYU5H27y2Bijbb4a4xbuhdA/UnnY9r6Wq6wO3TiEprv1x4xaMrQ/YBrIODEDVMfODxyuecd0+/XqY3G0hxKId8NbN8OUDZjuf6Ozz77+QsfSTQlsRERERERExtdZC/qaON/fvQN2Z3o+NW9AV0iYuNcMEkW7WzUnmpW15zEoxV7x/aXseV85L7fX4gooGDhdUc9unXddPuDQzkYVTY5zPDxdU8+u/f8xj37yE0ABfmttsvHe4mOUz4gny8+ZMWT0vbstjwZRo5znvHipiYXoMgb7enCiu5c/bT/LphWmD/IpFRoBvMCSvNB+dmsrNnridIW7xbrNatLv6AvNx4pWODRaInOFakRszB7z9GJUGsg4MQO7T5mKXkdNcr+MT4LqYm3+k2UqisxLZy+f8+/say0WwGIZhXPRVxqG6ujrCwsKora0lNHQMfdIgIiIiItJBc1rpk8NuvrHvDGmLPwDD7vnYoPiukDbtcgiM8XycSAeb3cET7xxmy8FCAFZlJfGtKzLxslp55J+5AHzvk9nO43+/8QhHC2t48CtLz3vdj85Ucs+f9/LX/7wCgJY2G3f/eR95JbW02xyEB/lyycwEbrx0Gv4+Zv/k/3huJ6dL67A7DKJD/LliXgqfXTpFC5HJxGAYUJ9vhrcle8wgt2QvtDec/zyrjxncdm+rEDlDfcmHiULbXmiCKyIiIiJjnea04lH9OTOgPfM25G80b5v1xMsXklZ0LSAWnT2+FrIREZnIHHaoPtYV5JbshvKPwNF+/vN8gs07LTqD3ITFEJKq3w9DQKFtLzTBFREREZGxTnNaAaC9GQrf6+pnWHm492MjZ3SFtMkrwSdo+MYpIiIjy9ZqBredIW7JHqg6CvQRHQbEmOFt3KKur4HR5z9H+qTQthea4IrImFSXD80V/T8+IBpCe+8rJiIiY5vmtBOUYUDloa6Q9tx7YG/1fKxfOKSt7Wp7oHmBiIh011oHpfu6QtyS3WYv3L6ETe4KceMXQex8s/+u9JtC215ogisiY05dPjwzHewt/T/Hyx++ekxv0ERExinNaSeQ5ko4u8EMac++Aw1Fno+zWCE+ByZ1hLTxi8Cq9alFRGQAGks6AtxuFbm9tdrpZLFCVGa3/riLzbY7Xj7DM+YxSL+dRUTGi+aKgQW2YB7fXKHQVkREZKyxt5uLhnWGtCV76fX21ZCUrpYHqWvAP2JYhyoiIuNMUDxM/bT5APMOj9rTrtW4pfvB1tR1juGAioPm4+Az5jYvP4id1xXixi+CiAwz4BWFtiIiIiIiImNCzamukDZ/M7TVeT7OOwBSLjND2rQrIHK6FogREZGhY7FA+BTzMePz5jaHzeyh3r0at/xjMOxd59lbzQ8giz/o2uYXBnELXYPc4KQJ+XtMoa2IiIiIiMho1FYPBVu7etPW5PV+bMxsM6CddAUkLQdv/+EapYiIiDurt/m7KWY2ZH/N3NbeDOUHXCtyq0+4ntdaC/mbzEenoATXEDd+0YXfNTKG1oFRaCsiIiIiIjIaGA4oO9AV0hbtAEe752MDorsWD0u7HIIThnWoIiIiA+YTAIlLzUenlmqzxU/pHijebQa5jcWu5zUWw8nXzUen8HTX/rix88zrn88YWwdGoa2IyHjQ3gRlH13YuR/8HBJyIHyq+YsvfCr4hgzu+ERERMSzxhI4805H24MN0Fzu+TirNyQu71pALHaeev7JhNBms/Pe4WJ2HCulvrmNkABflk2PY2VmAr7eXiM9PBG5WP4RMOly89GpvtC1rULpHrMCt7uaPPNx9AXzucXLXNise0Vu9CzXxTbH2DowFsMweulWP7FppV0RGbXam8wqnNK9ULrPfFQdMatzBktATFeA2z3MDZ9q7puA/YRERMaifs1p7e2w9dauNz0zvgSrHnJ9k9PpN8E9zm2FyJnwlY/N55v+HfL+Bm215geA0z4HK+8HL9/+nf/WTXDkha7jAT67wbUiZ6yztULhto6Q9m2zv19vwtO7qmlTV+lDVZlwdh4r5cHXD9DQYsNiMdc66vwa7O/N7evnsmRa3EgPU0SGmuGA6rxu1bh7oGy/OY84H+8AiJ3fFeR6B8LrVw/8z79hH8TNv6ChXwyFtr1QaCsio0J7Y0dAu2/oAtqB8g2BMA9hbvhUCE4GqyoeRERGi37Nabf/BE6+Bte+aT7/61WQcS0s/e++/4DnZpsLjuT80HxeecSsRPEJgqZy+Md1kLoGltzVv/Pfugn8wmHVwwN4laOcYUDVMTOgPfOO2aO2+2ra3fmGQMpqM6SddIW5oIvIBLXzWCn3/HkvAJ5Ci84Sgp9ct5Cl0xXcikw49naoOOjaH7fy0NC8Vx6h0FbtEURERou2BjOgLese0B7t+5eO1RuisiA0zXzTPVBX/QGsPlB70vz0svYk1JyEhsJexllvNo8vP+C+z8sXQid7CHTTIXQSePsNfHwiIjK0Dj5jVtZ29kTN+RG8+4O+Q9vi3eaq0LNu6toWNdP1GIvVfYGR850/XrRUmwuodLY9qM/v5UALxC3oCmkTloCXz7AOVWQ0arPZefD1A4DnwLZzuwV48PUDvHjrWrVKEJlovHwgbp75mPOv5rb2Rijd79paofbUyI7zIii0FREZCZ4C2soj9D4t7WD1Nvv0xC3oekRnmytEl+6/sNA2KtPzp4btzeYvuJqTHf2CTnYEunlQdxYcNvdz7G1Qfcx8uLFASApEpHuu1NUtnyIiw6+lGhrOQczcrm2xc82QsbUW/MJ6P/fg0zD5KghOdN2+65ew615obwD/KFjxq4Gdf/h58xGUAFlfhQW3jv7erQ67+cawcwGxkl29f+galNAV0qauhcDo4R2ryBjw3uFiGlo8zDV7MICGFhvvHy5mzezkoR+YiIxuPkGQvMJ8dGqqMFsLluyGsxuh8P2RG98AKbQVERlqbQ1Q9mGPFgdH6Tug9YHoLM8B7XDwCTAbt0fPct/nsJkrb3aGuZ3BbmeVrq3ZwwUNMwSozwc2u+8OjO2l7UK6uUK2+uiKiAy+tgbzq19417bO79vqew9t25vg6Etw1fPu+3LuMB+VR+DInyAovv/nz/surHwA/CPNEPQf15mB7YJbB/rKhl5dQVdf2rMbobXG83FefpC80gxp09aZv9v1O03kvHYcK3X2ru2LBdj4cSGXzkrE22uUf8AjIsMvMBomX2k+pnwK/rhgpEfUbwptRUQG00UFtJ4qaEdpOwGrt9lnz1OvPcOAxuKuMLdn24WWKs/XbCozH8U73fd19tF1qdLtCHRDkkd/BZaIyGjl27EwWFttV8Vn5+rM57sD4tifwScQpnyy92OiZkLMHLNP7ec29u/87nd+JC6BxXeYVbejIbRtb4Jz73ZV01Yd7f3YqMyuBcSSV5qvVUT6paXdTkFFQ78CWzBn2ftPV7D+l2+RGBlESnQwqR2PlOhgUqKC8PdV9CEiY49+comIXKi2eg8B7TFGLKANiAYvf7C39P8cL3/zvMFksZi3ugYnut6W0qml2rU6t3vbhYYiz9fsTx9dT20X1EdXROT8/CPMRSTLDpg/N8H8WRuScv7WCLm/h8yvmB/inY+j3XNP2/6eP5IfyhkGVOR2hLTvmLdT9rZKtX+E2eqgs5o2NGV4xyoyxtkdBgfOVLA5t5DtR0tobrMP+Bo2h0F+RQP5FQ1s77EvLizAGeZ2D3VDA30H5wWIiAwBhbYiIv1xMQFtzGzXgDYqa2iCxNBU+OoxaK7o/zkB0eZ5w8k/AuIXmo+e2pug9rTntgu1Z8DwMIHvq49uaKoZRIT1bLugProiIgBk3Wz2oE1abj7f9QvI/nrvx1cdg6IdcMUzrtvbGuD4XyD9GjPwrTgIH/zcDDL7cz6YFbiTrjR/Ppfug92/hLnfubjXNxBN5XB2A5x9xwxqG4s9H2exmouGdfamjVsIVi2CJDIQhmFwsqSOTQcL2XqwiKqGXj4U6YfpiWG0tjsorGqk3e7eT7q0tpnS2mb2nix32R4W6OsW5KZEBxMT6o9FbUxEZIQptBUR6am1zj2grT5OnwGtl2+PCtqFZt86r2H8BD80dfhD2MHkE9h7H117u9kP12OV7nn66NadNR/n66PrqUpXfXRFZKJY8mNoroT/nWk+n/klyPmh+f2GW8yvlz/RdXzu0+adFJHTXK9jscCRF+DdH5gVqYGxkPEvsOwe1+N6Ox/gw9/Chm+avdODk2DOt2HhfwzO6/TE3gZFOztC2rfNRT17+30fmtZVSZu6BvzDh25cIuNYaU0TWw4WsSm3kPyKBrf9QX7eLJsRz7YjxbS02c87A7cAQf7ePPiVpfh6e2F3OCipbnZW3BZ0+9rU5r6wWW1TG7n5VeTmu7bvCvD1IiXKPcxNjAzEy6q2XCIyPCyG0d9OMRNLXV0dYWFh1NbWEhoaOtLDEZGh4hbQ7u24jbM/AW2PCtrhDmili0sfXQ9Vui3VA7+mb0hXgNsz0FUfXREZIzSn9aDmZFdf2vzN0O4eGgHgHQipq7p600ZM04d5Iheovrmd948Uszm30C0gBfC2WlicEcvq7CRyMmLx9fbig+Ol3P3yXsDzzLzz/8a7r1/Ikmlx5/3zDcOgsr61I8Ct7xbqNlLd2P8KX2+rhcTIIJcgNzU6mOToYPx9VG0vMuqV7r+whchu2Ofad3+YKLTthSa4IuNQax2U7fdQQdsHt4B2oVkJqoB27Giu6qrI7Rno9tZH93y8fCFsiue2C2GT9d+GiIwamtNi/v4v2NIV1Nae6v3YmDldLQ8Sl6svushFaLPZ2X2ijM25hezOK/fYtmBWSgRrspNYkZlAaID7/GnnsVIefP0ADS02LBbzc/rOr8H+3ty+fm6fgW1f6pvbya+od6nKza9ooLSmua8yDicLEBse4LHVgqfXJSIjpC4fnpk+8HVgvnpsRO5oHRWh7WOPPcYDDzxAcXExs2bN4uGHH2bFCg+L13RobW3lpz/9KX/84x8pKSkhOTmZH/3oR3z1q191HvPKK6/w4x//mJMnTzJ16lTuvfderrnmmn6PSRNckTGutbargrZkL5Tt87wQSk9evuYbtrgFENtZQauAdlxrbzLfwHtqu9BbH93zsVjNBXw6K3N7Vul2rtQuIuPOQOa0N910E88995zb9szMTA4dOuS2/aWXXuILX/gC69ev529/+1u/xzQh57SGw6yk6Qxpi3ea7RY8CYiBSR2VtGmXQ1D88I5VZJxxGAaH8qvYlFvI+0eKaWhx/38vJSqINbOTWZWVSHx4YJ/XbLPZef9wMduPlVLf3EZIgC/Lp8exIjMBX++hq25tabdTWNng1mqhsLIRm6P/MUp4kGvf3M6v0SHqmysyIuryR/86MB1GPLR9+eWXufHGG3nsscdYvnw5Tz75JL///e85fPgwqame/1LWr19PaWkpP//5z0lPT6esrAybzcayZcsA2LlzJytWrOBnP/sZ11xzDa+++ir//d//zbZt28jJyenXuCbkBFdkrGqtNd+cdVbP9jug9etaJCx2gbkwVtQs8PIZ+jHL2ODSR7dn24VTvfTR7UNgrGvbhe79dNVHV2TMGuictra2lubmrp8hNpuNOXPm8O///u/cfffdLseePXuW5cuXM2XKFCIjIxXaetJQZC4cdvYdcyGx3t6MWX3MBdfSOqppY+eo3Y3IIDhbXs+m3EK2HCyirNZ9fhQR5MeqrERWZyeRHh86psNKu8NBcXWTS5Db+X1zW/8/7A/09SY52r3VQkKE+uaKiGlQQ9t9+/bx6KOP8swzHlaC7UVOTg7z58/n8ccfd26bOXMmV199Nffdd5/b8W+99Raf//znOXXqFJGRkR6vef3111NXV8ebb77p3HbllVcSERHBiy++2K9xTZgJrshY4xLQ7jW/1uT1fZ6XX1cFbedDAa1cDGcf3Tz3Kt2aPGitGfg13frodmu7oD66IsNmOOa0Pf3tb3/j2muv5fTp06SlpTm32+12Lr30Um6++Wbef/99ampqFNoC2Frg3PtdC4hV5PZ+bERGV0ibcpnueBAZJJX1LWw9VMTm3ELySurc9vv7eLF8RjxrspOYOzlq3AeRhmFQUd/itgBafkUDNY1t/b6Oj5eVxMhAt1YLyVHB+KlvrsiE4j2YFztz5gzPPfdcvye4bW1t7Nu3jzvuuMNl+7p169ixY4fHc15//XUWLlzI/fffzx/+8AeCgoL4zGc+w89+9jMCAgIAs9L21ltvdTnviiuu4OGHH+51LK2trbS2djUgr6szf+k4HA4cDvfeOyIyDFpqzB60ZfuxlO4zv/YjoDU6A9rY+RidAW1kpueAVv9/y8UIjDcfiZe472up6mqzUHMSS83JjjYMeVgaiz1fr63ebOtR9qHbLsPLz+yXGzYFwtMxwqZCuPk9oZPUwkMmFOsQv/EfjjltT08//TRr1651CWwBfvrTnxITE8PXvvY13n///T6vM27ntIYBVUfg7AYsZ9+Gc+9h6eVuB8M3FFJXY6Rebga1YZNdDxjLfw8iI6yp1cb2YyVsOVjER2cq6dklwGqxMH9KNKuzElk6LRZ/367IYUz/DOqnqGA/ooL9mDcpymV7fXMb+RWNFFQ0UFDZ4Py+1ENVcrvdwdnyBs6Wuy6SaAHiwgNIieoMc4NIiQ4mJSqYkAAVooiMNf2Zz/YrtN2/f3+//sBTp87T1N+DiooK7HY7cXGujcPj4uIoKSnp9c/Ytm0b/v7+vPrqq1RUVPDtb3+bqqoq58S6pKRkQNcEuO+++7jnnnvctpeXl9PSMoAGxSJyQSxttfhU5eJT+RHeVR/jU/Ux3g1n+jzP8PKnPTyT9sjZ2KJmm1/Dppm3PzoPAiqrh2zsIr2ypkFEGkSsdt1ua8K7IR+v+tN4NZzFu/6M83uvxnNYPPTRtdhboeqo+aBrxWQAw2LFEZiILWQy9uA07MGTsIVMwh4yCXvwJAyfoCF8kSLDLz7+wvqOjqY5bXfFxcW8+eabvPDCCy7bt2/fztNPP82BAwf6PZbxNKe1tNbgW/I+fsVb8SveileT54UjDSy0R82lLeFSWhMuoz16ftc8oBUoKxu+QYuMQzaHwcFzdezIq+TDMzW02d1v1p0SE8iy9ChypkYQ2hEg1tVU4V5/O3HF+EFMkh/zk/wAM9RttTkoqWmhqKaFoppm82t1C6V1rdh7JOIGUFLTTElNM3tOlrvsCwvwJiHcn6SIABLC/UnseIQH+ozpVhQi41l/5rP9Cm0XLlzYr//RDcO4oB8IPc8533UcDgcWi4U//elPhIWFAfA///M/fPazn+XRRx91VtsO5JoAd955J7fddpvzeV1dHSkpKcTExIyvW8lERoOWarOCtnQ/lrJ95tfak32eZnj5Q+zcjgra+WYf2siZeHv5DO5tAyLDYhKw0m2rYW/HqM939s21dO+hW3MSi4eVTi2GA6/Gc3g1ngPcK/GMwLiOdgtTMMLTO6p1O1owqI/uxGNvx/LubXC0o2XUzC9iXPo/YHX/SWp5+2bzuG6V3Ma1b0PiUvNJQyGWzf8GhdsAC6RchrHq/0FQt/Dy5OtYdt5t9hr3C8PIuQvm3NL//YNoNM1pu3v22WcJDw/n6quvdm6rr6/nhhtu4He/+x3R0dH9HsOwzmkHeyEPhw1KdmPp7E1bugeL4bkyzwhKhEnrMNLWQepavAOi8Ab6XtJIRPrDMAyOFdWy+WAR7x4uoq6p3e2Y+PAAVmclsSorkeQofUB8oVIS3bfZ7A5KaprcqnPPVXrum1vbbKO2uYGjxa7VuYF+3qREBTlbLXR+HxceiJdV8z+R0a5fOUdoaCjr1q3jO9/5znmP27p1Kz/96U/7/YdHR0fj5eXlVoFQVlbmVqnQKSEhgaSkJGdgC2a/MMMwOHfuHBkZGcTHxw/omgB+fn74+fm5bbdarUN+C57IuNZS3bVAWOejth8VTN7+EDPXpQetJSrTGSpoiiHjltUPIjPMR0+GAxqKnS0X3Prp9tJH19JUCk2lULzD/f8d39Cuvrnh3RZFC0+HkCT10R2Pdv4CirbDTYfM53+9CsueX8LS/3Y/1mKBud+GVQ93beq+f/O/mVu+cRYw4J9fwvLurfCpl8z9p98yj/nEHyFpBbTVYWkshc65VV/7B9lomtN2MgyDZ555hhtvvBFf365w/OTJk5w5c4ZPf/rTzm2dtxZ7e3tz7Ngxpk6d6na9YZvT1uXDszPBwwdJvfLyh68ecw1u686aPWnPvA35m8ze9Z54+0PSSrPdwaQrzDmBxaL5gMggK6xqZEtuIZsOFlJU1eS2PzTAh0tnmQuKzUwKVxXnEPG1WkmNCSU1xvXDNsMwKK9rcVsALb+igdom9765Ta02jhXVcqzI9Werj5eV5KggZ8/cFGff3CB8vdU3V2S06Fdou3jxYsrLy7n00kvPe1xFxQA+aQd8fX1ZsGABGzZs4JprrnFu37BhA+vXr/d4zvLly/nLX/5CQ0MDwcHmIgLHjx/HarWSnJwMwNKlS9mwYYNLX9t33nmHZcuWDWh8IjJAzVUdFbQDDWgD3AJaomZ6rPoSmdAsVjNIDUmCZPcqXZqrzEC3Os892O21j25dr3106eyj231xtIiOYDdskvrojlUHn4FVD0Fwgvk850fw7g88h7Z9qT0Ni+/oWthpxvWwq9uiW9t/bF435TLzuX+E+ejv/kE2mua0nd59913y8vL42te+5rJ9xowZ5Oa6Lq511113UV9fzyOPPEJKSsqAxjjomisGFtiCeXx9gblo2JmOBcSqj/V+fNQsZ0hL0grwCbi4MYuIRzWNrbx7uJgtuYUcKaxx2+/rbWXJtDjWZCexYGoMPl76QHekWCwWYsMCiA0LYMHUGJd9dU1tbkHu+frmni6r53RZvct2qwXiwgOdi591XwgtyF99c0WGW78SkRUrVvDUU0/1eVxMTAwrV3p4E3ket912GzfeeCMLFy5k6dKlPPXUU+Tn53PLLeZtcXfeeSeFhYU8//zzAHzxi1/kZz/7GTfffDP33HMPFRUV3H777Xz1q191tkb43ve+x8qVK/nVr37F+vXree2119i4cSPbtm0b0NhE5Dyaq7qC2bLOgPZ03+cpoBUZOgGR5iN+kfu+9kaoOdVtcbRuVbp1Z8FDH1169NF1YbFCSKprlW5nsBs+Vauzj1Yt1dBwzvw53Cl2LtTnmxWOfmHu5xx+3nwEJUDWV2HBrV0V2Atug+N/gSmfNBeKOvqi+T2Y/82V7oPW6+GZGWYlePKlsPoRCIrve/8QGE1z2k5PP/00OTk5ZGVluWz39/d32xYeHg7gtn1M+fNlZhsET/wjIa1j8bC0yyEkeViHJjKRtLTb+eBYKZsOFrLvZLlb/1QLMGdyFGuyk1g+I54gPwV2o11ooC9ZqZFkpUa6bG9ps1FQ2ehWnVtY1ej27+4woLi6ieLqJnadcO0HHhns5xbkpkQHExnsp4prkSFiMQzDvYv4MHvssce4//77KS4uJisri4ceesg5Ub7ppps4c+YMW7dudR5/9OhR/v3f/53t27cTFRXFddddx89//nNnaAvwf//3f9x1112cOnWKqVOncu+993Lttdf2e0x1dXWEhYVRW1urnrYiFxPQxs5zDWgjZyigFRlt7O1mcOupSrf2FNguYPGiwLheAt10CIhSH92RUlcAv0uFb5VDYEef1KZyeDwWvlngHpKV7oeQFDNMK9kD/7jODG0XdNzNVH0C3roJinaazxOWwGffBt8QqD8HT6VAzGy4+nXwj4KNt0BjKXxuQ9/7x6CBzmlra2tJSEjgkUce4Rvf+Eaf17/pppuoqanhb3/7W7/HNGRz2tL98McFF3cNi5fZHzltnRnUxi0Aq27LFRkqdofBR2cq2ZxbyLajxR57o06JC2V1diKrZiURHeo/AqOU4WKzOyiqbnKpyu382tLu4cP8XgT5ebuEuZ1f1TdX5OKNitB2NFJoKxNWc6V7D9q6M32f5x1oVmspoBUZX7r30fXUdqGXPrrn5eyj66HtgvroDq2Wang0Er6WZ/7dg/nv+kwG/FuN50rb7g48ZlbdfvED87+N30+BadfBsrvN/TvuNhcl++IOaKmBRyNg3e8hu+PW/5qT8HQGfLfe/LDgfPt9tKjNYBh1oW1QAkz9jBnSpq7u+785EbkohmFwqrSOTbmFbDlYRFVDq9sx0aH+rM5KYnVWIpPj9N53onMYBhV1LR5bLXjqm9ubzr65PVstJKlvrki/9StNuf/++/nyl79MfPzQ3KomIiPkogJaTxW0+uUrMu70p49uZ4Dbs+3CBffRneK5Sld9dC+efwQEJ0PZga7QtvyAWU3bn/Cse6DeXGVWaM//LvgEmtvm/TvsfQCaKsxK3pBUPC4daRjgH37+/UNAc9pR4Oq/Q/xFVuiKSJ/KapvZcrCQTbmFnC1vcNsf6OfNypkJrM5OIjstEqvugJEO1m59cxf26Jtb29E3t2erhbIB9s2NjwgkNaojyI3pCHWj1DdXpKd+hbZ33nknl112mXOC63A48Pf3Z9euXcybN29IBygig6Spoqu1gTOgPdv3eT0D2viFEDFdAa2ImAIiIWAxJCx239e9j25NjyrdurNmpWZP9laoOmI+enLpo5vuGuyGTVEf3f7Kuhl23QtJy83nu34B2V/3fOyxP8OkK812B6X7YPcvYe53zH2B0ebf/YFHYelPzG0HHjVD4c7WC7O/CR/+xqyq9I+EnT+F1DVd/1Z97R9kmtOOAgqGRIZMfXM77x8pZnNuIbn5VW77va0WFqXHsiY7iZxpsap2lAELC/QlOzWS7B59c5vbbJyrbCS/vN4l1C2qbvLYN7eoqomiqiY+6NE3NyrEz61nbmp0MBFB6psrE1O/QtueHRQMw8Bms7ltF5FRomdAW7LXXGSmLz5B7hW0CmhF5EL5BEFMtvnoqbOPbvcq3c72C7310TUc5t0AdWcgf5P7fmcf3Z6B7lT10e1uyY/NOy3+d6b5fOaXIOeH5vcbzEWzuPwJ8+uHv4UN3zQXjgpOgjnfhoX/0XWtq1+DLbfCk0nmv0/sPLM/bafFd0BLFTw/x3yeugo+8Yf+7x9kmtOKyHjTZrOzJ6+cTbmF7D5RRrvd/QPRWSkRrM5OYuXMBEIDdceKDL4AX28yEsLISHC9a6fd7qC4qtFZldsZ6BZUNNBqc/9vtbK+lcr6Vg6crnTZHuzv7dYzNzU6hNiwAPXNlXGtXz1trVYrH3zwAYsXm1U0drsdHx8f9u7dy/z584d8kCNBPW1lzGgqd29xcEEB7UKImKaAVkRGnuGAhqKuNgs92y+01g78mr6h7mFuZ9sF9dGdMDSnHQU9bW/YB3Hj8+9aZLg4DINDBdVszi3kvcNFNLTY3I5JjgpiTXYSq7OSiI8IHIFRivTOYRiU1Ta7tVnIr2igvrm939fx9baSHNUzzA0mMTJQleQyLmiFIJGxxCWg3dsR0Bb0fZ5PsIcKWgW0IjJKWawQkmw+Ui513WcYZmVmzzC3s0q3scTzNdvqoGy/+ejJpY9uj2A3NE19dEVEZFQ4W17P5o4FxUo99BCNCPLjsqxE1mQnkR4fqtvJZdSyWizEhwcSHx7IovRY53bDMJx9c3v2zq2oc78Lq83m4FRpHadK69yunxAR6NZqISU6iCA/9c2VsaPfoe2vf/1r4uLigK5byx544AFiYlwbU1ssFh555JFBHKLIBNVU5qGC9kIC2oUQkaGAVkTGB4vFbHUQEOW5j25bg9lewVOV7kX10e0e5nYLd32CBv81ypDSnFZExpLK+ha2Hipic24heSV1bvv9fLy4ZEY8q7OTmDc5Ci+r7hyRsctisRAe5Ed4kB+z06Jc9jW12iiobCC/vCvMLejom+swevbNNSisaqSwqpEPjpe67IsO8ffQaiGY8CBffdAxxtjsDp545zBbDhYBsDo7kVvWZXr8Obj+l2+5PG+3O0iNDuaJf11Jm83Oo28d4sPTFdQ1tREV4s91y6ZyxdwU5/EVdS389s2DHCyowgLMmRTFd67MIiLYb8BjGYh+tUeYNGlSv//jtVgsnDp16qIGNRqoPYIMq+4BbUlHBW3Dub7P8wk2bzHsDGhjF0DkNN3mKyLiib2to4+up7YLJ83wdqAC43pvu6A+uqOO5rRqjyAyFjS12th+tITNBws5cLqCHus4YbXA/CkxrMlOYun0OAJ8dQOtTFztdgeFlY1urRbOVXrum9ubYH8ftwXQUqODiQ0PwKr53Kj0/Nbj7Dxeys+/sAiAu17cw/IZ8dywMqPPc2958j0unZXIFy5Jp6XNxss7TnL57GQSIgI5WljDXS/u5ofXzmfBVPND/Z+8vBcL8F/XzMUw4Fevfoifjxc//Jf5Fz2W8+nXT/czZ85c1B8iIt00lrpX0PYnoPUN6VZBu7CjxUGGAloRkf7y8jV/bkZ4mDy59NHNcw12a0/23ke3qdR8FG133+cXZoa3ntouBCfq5/cI0Jx2EAVEg5c/2D0sGtgbL3/zPBFxY7M72H+qgk25hew8VuIxbJqWGMaa7CQuzUx0VneJTHQ+XlYmxYYwKTbEZbvDMCirafbYaqGhxb1vbkNLO4fPVXP4XLXLdr+Ovrk9Wy0kRQXh46W53Eh6+6MCbrk8k6gQfwC+cEk6v9t4pM+g9GhhDWfLG1g3JxkAf19vvnLZdOf+mckRzEmL4mBBlTO0La1p4rplU50fkl06K5GXtudd9Fj6oo/kRIaSM6Dd2y2gLez7PN8QiJ3fowetAloRkSHTrz66eZ6rdHvro9ta248+uh6qdNVHV8aC0FT46jForuj/OQHR5nkiApgtWo4V1bI5t5Cth4qobWpzOyY+PIDVHQuKpUQHj8AoRcYmq8VCfEQg8RGBLM5w7Ztb0+jeN7egooGKevcPIlttDk6W1nHSQ9/cxG59c1Oig0mNCSYlKphAP0VtQ62+uZ2KuhamxHfdRTQ1LpSy2mYaW9oJ8u+9d/HbBwpYlB7jDFh7arPZOVZUy6qsJOe2a5dM5v0jxeRkxGIAWw4VsbijH/PFjKUv+i9JZLA0lniooB1IQLuwW0CbroBWRGS0cOmjm+O+36WPbo9gtz7/wvrohqb1UqU7gn106/IV0Imr0FT9G4tcgKKqRjYfNPvUFlY1uu0PCfDh0swEVmcnkZkcoT6bIoPIYrEQEexHRLAfcya59s1tbG2noMK91UJxdaNbmxKHYXCuqpFzVY3s7Nk3N9TfY6uFsED1zR0szW02wGxr0SnI34w4m9psvQalLe12th4q4vb1czzuNwyDh/7+MYmRgSyfGe/cPis5kjf3F/AvD7wDwIzkcL64IuOixtIfCm1FLkRDsWs4W7bPvK22L76hZh+32AUKaEVExgvfYIiZbT56cvbR7R7mdrZdOOW5j67hgNrT5iN/o/v+oPje2y74Rw5NH926fHhm+sBvhf/qMYV6IiJAbVMb7x0uYlNuIUfO1bjt9/GysmRaHGuyk1iYHqPbrkVGQJCfDzOSwpmRFO6yvc1mp6iqya0691xlA20eWplU1LVQUdfC/lOuH3aHBPi4Bbkp0cHEhqlv7kB1tilobGknLNC8Q62x1QxPA8/T5/u9w0X4+3iR0636upNhGPzmjYOcq2zklzfkOP9NHIbBnX/axcrMBO67wSzg+OO7x/nhC7t4+OblFzyW/lBoezHs7bD1Vjj6gvl8xpdg1UNg9fDX+tZNcOQF19sdP7sBEpea3/+mx60u9laInAlf+bhrW97rsOO/ofqE2Sdv6X/DnFv6f75cmIsNaLtX0IZPVUArIjKR9KuProe2CzV50Oa+Sjhg3tnRWNJHH10PbRcupo9uc8XAAlswj2+uUGgrIhNWa7udncdL2ZxbyN6T5dh7lOp1rkC+OjuJS2bEX1Q1logMHV9vL499c+0Og7LaZvIr6t1aLTS02NyuU9/czqGCag4V9Oib6+NFSlSQa6uF6GASI9U3tzchAT5Eh/pzsrSOxEjzLrRTJXXEhPqf92fpWx8WsHZ2Ml5W179XwzD47ZsHOV5Uwy9vWOJyjfrmdkprm1m/eBL+Pl4AfGbRJP6y8xS1TW2EBfpe0Fj6Q6Htxfjg51C4Db5yyHz+16tg1y/MMNWTud+GVQ973vfdBtfnz82GGZ/ven76Ldj0bfjEHyFphflGrrG0/+dL/zQUubc4aCzu+zy/MPcetApo5SLY7A6eeOcwWw6aHxCszk7klnWZbr9cAB587SO2HCzEu9sv9PtuyCEzOQKA9b98y+X4druD1OhgnvjXlf06v6iqkUffOsTRwmr8fLy4evFkrls2dXBfsMhE5NJH9zLXfYYBzZVmz1xPbReaSj1e8rx9dL39zT66nqp0QyeBl8ICEZGLZXcYfHy2kk25hWw/UkJTm3twMzk2hDXZSVyWlUhMaMAIjFJEBoOX1UJCRCAJEYHkZMQ5txuGQXVjq9sCaAUVDVTWu99l1dpuJ6+kjrwS1w/sO6/vqTo34CIrOMeDdXOSeWlbHrNSzPetL23P48p5vRcLFFQ0cLigmts+7X533KNvHeJQQTX337iEkADXOXFYoC+JkYH8fc9ZbrjULMT4+96zRIf6OytrBzqW/tK/8sU4+IxZWRucYD7P+RG8+4PeQ9v+Kt4NlYdh1k1d27b/2Lxu55s6/wjz0d/zxd3FBLRxC1xbHIRPUUArg+qF9/M4VFDNU7eYwepdL+7hxW0ne1198lML0/jWFbM87nvtjitdnt/y5HtcOiuxX+fbHQY/eXkvy6bHcc/1CymubuLOP+0iOsSf1dlJbseLyCCxWCAw2nyct4+uhyrd3vro2lrM+UHlYQ9/Xh99dEVEpFeGYXCqtJ7NBwvZcrDQYygTHeLPqqxEVmcnMSUu1MNVRGS8sFgsRAb7Exnsz9xJ0S77GlvaKajsCHLLO0LdygZKqpvc+ubaHQbnKhs5V9kIx1w/sI/p6JvbM8wND/Ib6pc3anxpRQb1ze184/F3AViVlcQXLjHnrY/8MxeA730y23n82wcKyEqNJDnK9U710pom/r73LD5eVm78zWbn9tXZSc7z775uIU++c5gvPrwJwzCYGh/GPdct7NdYLka/Qtvnn39+QBf98pe/fEGDGVNaqqHhHMTM7doWO9d8o9RaawZ7PR1+3nwEJUDWV2HBrZ6DvoNPw+SrzNsYAdobzUCx9Xp4Zga01kDypbD6EbOvXV/nixnQluztam9Quq/31b678wt370EbPnVo+gWKdPP2RwXccnmmc0XLL1ySzu82Huk1tO2vo4U1nC1vYN2c5H4df66ygXOVjdxw6TS8vaykRAdz5dwU3vwwX6GtyEjqq49u7RnPVboX2kfXP8p92xikOa2IDKay2ma2dCwodqa83m1/oJ83K2bGszo7iezUKLyseg8hMtEF+fswIymCGUmuRXhtNjuFlY1u1bnnKhtpt7t/GF9e10J5XQv7evTNDQ3wcQtyU6ODiRmHfXO9vaz821VZ/NtVWW77uoe1nb6+dqbH68SFB/L2jz953j8rLSaEX3zJQyFFP8ZyMfoV2t50000uzztXuzMMw20bTJAJbltHOwK/8K5tnd+31buHtvO+CysfMBcIKdkD/7jODGwX3Op6XHsTHH0Jrur2pqKlGjDgyB/gs2+bb5w23gJv3Aif29D3+ROJYbhW0A44oF3g+gibooBWhl19czsVdS1Mie+qwpgaF0pZbTONLe0e++Js/LiQjR8XEhnsxxVzU7h2yWSPv5TfPlDAovQYZxjc1/mdP+a7/7x3GHCq1P2NiYiMEl6+EDnNfPRkOKC+sPe2C7310W2pHNoxDxPNaUXkYjW0tPP+kWI25xby8dkqt/3eVgsL02NZk51ETkYsfh39D0VEzsfX24vJcaFM7lGJb3cYlNY0ufXMza9ocC521V1dH31ze1bnJkYGubTJk9GlX6FteXm58/u8vDw+//nP88UvfpHPfvazxMXFUVpayl/+8hdefPFFXnrppSEb7Kji21FO3VZr3roIZoUtgG+I+/Fx87u+T1wCi+8wq257hrbH/gw+gTClW8rv0/FnzfuueesiwLJ74OkMswrXJ+j8549XhgENhe4tDnrr89edW0C7EMImK6CVUaG5o/dZcLdwNsjf/HHd1GZzC23XL57E19fOICTAl+NFNdz7yn6sFrh2yRSX41ra7Ww9VMTt6+f0+/zkqCDiIwJ4futxvnzZNIqqmnj7owKaPEwQRGQMsFghNMV8nLePbo8wt+ootLiHE2ON5rQiciHabHb25pWzKbeQXSfKPFa9zUqJYHV2EitnJhAa6OvhKiIiA+dltZAYGURiZBBLprn2za1qaHXrmZtf0UBVw8D65ib27JsbE0JKVBD+6ps74vr1LxAV1XVL3Oc//3m++c1vcueddzq3JSYmMm/ePIKDg/nhD3/Ipk2bBn+ko41/BAQnQ9mBrl5v5QcgJMVza4Seeut/mvt7yPwKWLv90/iHQ0gq5vqiPRg9mp54On888BjQ7oWmsr7P9Y9wbW8Qt0ABrYxqnU3lG1vanY3NOz9FDfTwizMjoetnzszkCK5fPpWNHxe6hbbvHS7C38eLnIzYfp/v7WXlnusW8sQ7h7nhkc1Ehfizbk4yb+zPH5wXKyKjx/n66Jbuhz8uGJlxDSLNaUWkvxyGweGCajblFvLe4WIaWtrdjkmODGLN7CRWZSWREBE4AqMUkYnKYrEQFeJPVIg/cye79s1taGl3q8rNrzD75vZIkLA7DAoqGynw0Dc3NizAY6uFMH0wNWwGnOzt2LGD//zP//S4b+HChdx7770XPagxI+tm2HUvJC03n+/6BWR/3fOxx/4Mk640q3BL98HuX8Lc77geU3UMinbAFc+4nz/7m/Dhb2DSFWaLhZ0/hdQ1XRW/fZ0/lhgG1J9zbW9Quu/CAtr4heaK2ApoZQwJCfAhOtSfk6V1JEaalfSnSuqICfX32BqhJ0sv/72/9WEBa2cn42U9/+0vPc9P7dG/5/cbj5CdOj76W4rIxKU5rYh4kl9ez+aDRWw+WEhpTbPb/vAgXy6blcia7CQyEsJ6nXeJiIyUYH8fZiZHMDPZvW/uuR59cwvO0ze3rLaZstpm9p0sd9keFujrDHC7h7oxof76mTjIBhzaxsbG8vLLL3P55Ze77XvppZeIiYkZlIGNCUt+bN5G+L8dzYxnfglyfmh+v+EW8+vlT5hfP/wtbPgmOGwQnARzvg0L/8P1erlPQ/IKzz3oFt9h3pb4fMdtzamr4BN/6P/5o1XPgLZzsbDm8r7P9Y9070GrgFbGiXVzknlpWx6zUsxftC9tz+PKeakej333UBEL02MI9PXmRHEtf95+kk8vTHM5pqCigcMF1dz2afdFi/o6/1RpHYkRgXh5Wdl1vJR3PjrHL2/ovQm7iMhYoDmtiHSqrG/h3UNFbD5YxIniWrf9fj5eLJ8ex+rsJOZPie7zA3ARkdHI19uLKXGhTPHQN7ekpsljqwVPbfFqm9qoza/iYL5r6yx/Hy+3MDclOpjEiED1zb1AFsPoeX/9+f3ud7/jX//1X7n00ku5+uqriY2NpaysjFdffZX33nuPJ598km984xtDNd5hU1dXR1hYGLW1tYSGhvZ9gvTNMKC+wL0H7QUFtAvN/r4KaGWcstkdPPHOYbYcLARgVVYS37oiEy+rlUf+mQt0rYj5H8/t5HRpHXaHQXSIP1fMS+GzS6e4LET2+41HOFpYw4NfWer2Z/V1/rNbjvH3vWdptzuYEhfCN9bOZFZK5FD/FYjIaHKh7RFu2Ofa138U0ZxWZGJrbrOx/WgJm3ML+fB0BY4e74qtFpg/JYY12UksnR7nbF8lIjJRdPbN7RnkFvTSN7c33h19eXu2WkiJDsZfizWe14BDW4B//OMf3Hvvvezbtw+bzYa3tzfz58/nRz/6EZ/+9KeHYpzDThPci+QW0O413/D1K6CN8lBBq4BWRERkxIzD0BY0pxWZaOwOB/tPVbApt5Adx0ppbbe7HTMtIYzV2UlcOiuByGD/ERiliMjoV9/cTkFlg1t1rqe+uecT19k3N8Y10A0NUN9cuMDQtpPD4aC8vJyYmBis4+wWEU1wB8AwoD7fQwVtRd/ndg9o4xeaX0NSFdCKiIiMJnX58Mx0sLf0/xwvf/jqMQj13NplNNGcVmT8MgyD48W1bM4tZOuhImoa29yOiQsPYE1WEquyk0iNDvZwFRER6Y/WdrNvbs8wt7DKc9/c3oQH+bq1WUiNDiY6ZHD75rbZ7Lx3uJgdx0qpb24jJMCXZdPjWJmZgK/3yFcBX1RoaxgGxcXFxMbG4u09vm4X0QS3F90D2s7+s2X7+xfQBkS7V9AqoBURERkb6vL79/u+U0D0mAhsQXNakfGouLqJzbmFbM4t5FxVo9v+YH8fLp2VwJrsJDKTI7R4jojIELI7HJRUN3cEufXOQPdcRSNNbe59c3sT6OtNcnSQS1VuanQwCRGBA+43vvNYKQ++foCGFhsWixl3dX4N9vfm9vVzWTItbqAvdVBdUGj79ttv85Of/IQPP/wQu93O7t27mT9/Pt/85je59NJL+dKXvjQUYx1WmuBi/pdad9a9gralsu9znQHtwm4BbYoCWhERkRHW1TO7CIDV2Yncsi7T40T3wdc+YsvBQpfFI+67IYfMbqsR7zxWyvPvHqewqpEgP2++tDKDTy0wFzOsqGvht28e5GBBFRZgzqQovnNlFhHBfgAUVTXy6FuHOFpYjZ+PF1cvnsx1y6YO4at3pTmtyPhS29TGe4eL2JRbyJFzNW77fbysLJkWx+rsRBalx+KjhXFEREaUYRhU1Le49czNr2jweGdEb3y8rCRGBroEuanRwSRHBePnoW/uzmOl3PPnveYYPFyvM7n6yXULWTp95ILbAZcSvPjii9xwww189rOf5eabb+Zb3/qWc9/UqVP53//933ExwZ1wnAHt3m4B7f5+BrQxHipoFdCKiIiMRi+8n8ehgmqeumUlAHe9uIcXt53khpUZHo//1MI0vnXFLI/79uSV8ds3D/KfV88lKzWSplYb1Y1dC1P8vzcPYgH+8N3VGAb86tUPefztQ/zwX+Zjdxj85OW9LJsexz3XL6S4uok7/7SL6BB/VmcnDfrr7klzWpHxobXdzgfHS9mcW8iek+XYe6woZgFmT4piTXYSl8yIJ8jfZ2QGKiIibiwWCzGhAcSEBrBgSozLvrrmNrc2C/kVDZTVNLsFre12B2fLGzhb3uB6fcwWON3D3PjwQB547QDgObDt3G4BHnz9AC/eunbEWiUMOLT92c9+xve//31+/etfY7fbXSa4s2bN4qGHHhrUAcoQMAyoO+Ohgraq73M7A9r4hRDbGdAmK6AVEREZI97+qIBbLs8kKsRcYOcLl6Tzu41Heg1tz+f5rcf50soM5kyKAiAkwIeQgK5ApLSmieuWTXWuun7prERe2p4HwLnKBs5VNnLDpdPw9rKSEh3MlXNTePPD/GEJbTWnFRm77A6D3LOVbMotZNuREo+31k6KCWHN7CQum5VIbFjACIxSREQuRmiAL7NSIpmVEumyvaXdzrkeQW5+RQNFVY3YenxwZwAlNc2U1DSzO698QH++ATS02Hj/cDFrZidf5Ku5MAMObU+dOsUnPvEJj/uCgoKora296EGNe8PZE64zoC3pVkFbtr9/AW1gbFflrAJaERGRMa++uZ2KuhamxHfdJj81LpSy2mYaW9o9VqBt/LiQjR8XEhnsxxVzU7h2yWSsFgstbTZOFNeysrWdrz22lcYWG9lpkXzrikzniuvXLpnM+0eKycmIxQC2HCpicXosYE5RzK9dk2uHAadK64fuL6AbzWlFxp5TpXVszi1ky8EiKurdF0aMDvFnVVYiq7OTmBKndiAiIuORv48X6QlhpCeEuWy32R0UVze5VecWVDbQ3Ga/oD/LYoHtx0rHTmgbHx/P0aNHWbNmjdu+jz/+mLS0tEEZ2Lg1lKsvGwbUnnatni3bBy3Vff8ZgXHuLQ6CkxTQioiIjCPNHdVowd3C2SB/czrY1GZzC23XL57E19fOICTAl+NFNdz7yn6sFrh2yRTqW9oxgE0fF/KLLy4mNNCX3/wzl/v/9hG/vCEHgFnJkby5v4B/eeAdAGYkh/PFFWZFb3JUEPERATy/9ThfvmwaRVVNvP1RAU2t/V+M4mJoTisyNpTVNrPlYBGbcws5U+7+oU6gnzeXzIhnTXYS2WlReFn1/kVEZCLqvHMrJTqYZd22G4ZBeV2LM8z9846TVDW09nqd7gwD6pv731t3sA04tP3iF7/I3XffzYwZM7jssssAswfFwYMHuf/++11uLRMPmisGFtiCeXxzhWto6wxoe1bQXkhAuxCCExXQiowzbTY77x0uZsexUuqb2wgJ8GXZ9DhWZiaMWE8eERlZnW0KGlvaCQv0Nb/vCEkDfd2nhRndKhhmJkdw/fKpbPy4kGuXTHFe6+rFk4gLDwTgxkun8dVHt9LSZsPXx4s7/7SLlZkJ3NcR4v7x3eP88IVdPHzzcry9rNxz3UKeeOcwNzyymagQf9bNSeaN/flD9xfQjea0IqNXQ0s7244Usym3kNyzVW49B72sFhalx7ImO4mcjFiPi8yIiIiAOb+LDQsgNiyABVNjyM2vYsexEozeGtq6nAshAb5DP8heDDi0vfvuuzl06BCXX345UVFm/7KrrrqK8vJyPvWpT3HHHXcM+iAFqC+AmryBB7RB8a7tDeIWKKAVmQB2HivlwdcP0NBiw2IxP+exWGD70RIef/sQt6+fy5JpI7cKpoiMjJAAH6JD/TlZWkdiZBAAp0rqiAn179fiPJZu84dgfx9iwwJctnUyMFsxlNY2s37xJPw7ApXPLJrEX3aeorapjbBAX1JjQvjFl3Kc5/1+4xGyU6Mu8lX2j+a0IqNLu93BnrwyNucW8sHxMtrtDrdjMpMjWJ2dxMrMBOcHTyIiIgOxbHoc24+W9OtYw4Dl00fuffOAQ1tfX19ee+01tmzZwoYNG6ioqCAyMpK1a9eydu3aoRijALx2dd/H9Axo4zsqaEVkQtl5rJR7/rzX+byrb6T5tbHFxt0v7+Un1y1k6Qj+AhKRkbFuTjIvbctjVkoEAC9tz+PKeZ5bML17qIiF6TEE+npzoriWP28/yacXdrUNuGpeCn/bfYYFU2IICfDhT++fYO7kaAJ8vQnwhcTIQP6+5yw3XGq2RPj73rNEh/o7w5ZTpXUkRgTi5WVl1/FS3vnonLO1wlDTnFZk5BmGweFz1WzKLeS9w8XUN7e7HZMcGcTq7CRWZSU6P2wSERG5UCszE3j87UM0ttjc7uTozoLZRmxFZsJwDc19DIbRn4LgLvn5+SQkJODj416NYbPZKCoqIjX1AhfNGkXq6uoICwujtraW0NBBbGJfuh/+uODirxOU4KEHrQJakYmuzWbnCw9t7PcvoBdvXatWCSITjM3u4Il3DrPlYCEAq7KS+NYVmXhZrTzyz1wAvvfJbAD+47mdnC6tw+4wiA7x54p5KXx26RSsHdW1dofB7zcdYeNH5wCYMymKb185y7kQ2dnyep585zDHi2sxDIOp8WF8c+1M58IRz245xt/3nqXd7mBKXAjfWDvTbYXgoaI5rcjIya9oYHNuIZsPFlJa0+y2PyzQ17mg2LSEMI8V/SIiIhfqg+Ol3P2yWejk6X1z52+du69fOKJ3qA44tPXy8mLnzp0sXrzYbd++fftYvHgxdvuFrco2moy60DZpBaSuVkArIue18eNzPPDaR/0+/htrZ7AmOxl/Xy/8fLycQYyIyHinOa3I8KpqaGHroWI25xZyorjWbb+fjxfLp8exOjuJ+VOi8bJaR2CUIiIyUfTWUtAwINjfe1S0FBxwe4TzZbytra34+fld1ICkF6sehrj5Iz0KERnldhwrdf6i6Y/fbTzK7zYedT7387bi7+uNv48Z4gb4euPv64W/T8fD1wt/H++u7zuOddnn60WAT7d9CoRFZBTSnFZk6DW32dhxtIRNB4v48FQ5jh7/21ktMG9KDGuyElk2I965wKGIiMhQWzo9jhdvXcv7h4vZ3m3x7uXT41gxShbv7tdvxaNHj3L48GHn861bt3Lu3DmXY1paWnjxxReZMmXK4I5QRET6VFLdxK68Mj46U9nvwNaTVpuDVlsb7vUvF697INw94PUU+vr7eA6EA3ruUyAsIgOgOa3I0LM7HOw/VcHm3EK2Hyultd29Yj0jIYzV2UlcNivB2U5FRERkuPl6e7FmdjJrZieP9FA86ldo+/LLL3PPPfcA5qrBva2mGx4ezv/+7/8O3uhERMQju8PB4YJqdp0oY9eJMvIrGi7oOtEh/qQnhNHSbqOlzW4+2m20tHd+P3i3Bg9LIOwMgd0D4QBfb/x8PAfCAS7PFQiLjFea04oMDcMwOF5cy+bcQrYeKqKmsc3tmLjwAFZnJbE6K5HUmJARGKWIiMjY0q+etrW1tdTU1GAYBlOmTOGvf/0r8+bNcznG19eX+Pj4cdMkftT1tL1hn9ojiExwdU1t7D1Zzq4TZew9WUZDi+2ir/mf6+ec91NFwzBotTloabM5Q1xnwNveFfI2O593BL7dQl/ntiEMhIeSn0u1r3sg3NlCwlMg7N5eQoGwyEjSnFY9bWVwFVc3mQuK5RZyrqrRbX+wvw+XzkpgdVYSmSkR+r0nIiIyAP2qtA0LCyMszFzl9/Tp0yQkJODr6zukAxMRmegMw+BMWT27TpSxO6+MI+eq3XrBgdkPbmZyBIvTY5k/OZo7X9hFY4vN4yqYnSxAkL83KzITzjsGi8XiDBwJuqiX46Y/gXCzy/MegbBbQDxEFcLtdlrb7dQ2Ddolnc4XCAf0CHi7h74BHttLdO3zVSAs4pHmtCIXr66pjXcPmwuKHT5X7bbfx8vKkmmxrM5OYuHUmFHRE1BERGQsGnCn97S0NACKioo4d+4cLS0tbsesXLny4kcmIjIBtbbb+ehMJbtOlLI7r5yy2maPxwX7e7NwaiyL02NYmB5LWGBX6HD7+rnc/fJeLOAxuLV0O24k30gNZSDsMAzaelb8dguAm9tsnquBJ0Ag7GmRuM7QN6DX9hJd+xQIy3ihOa1I/7W229l1ooxNuYXszSvD5uFT5NlpkazJTuKSmQkE+/uMwChFRETGlwGHtqdOneLGG2/kgw8+ALpW3rVYLBiGgcViwW4fG7e8joiAaPDyB7v7G4Neefmb54nIuFRW28zuvDJ2nyjjwOkKWm0Oj8elRgeTkxFLTkYsmSkReFmtHo9bMi2On1y3kAdfP0BDiw2LBQwD59cgf29uXz+XJdPihvJljSirxdLR49Z7WAPhZg8Bb38D4eY2u8fFWi7UcAfCvS0S594mwnN7CQXCMtw0pxU5P4dh8PHZSjbnFvL+kRKaWt3bMqXFBLMmO5lVWYnEhgWMwChFRETGrwGHtt/4xjfIz8/nqaeeIjMzU7eUDVRoKnz1GDRX9P+cgGjzPBEZF+wOg2NFNew6XsquE2WcLqv3eJyPl5XZk6LMoDY9lviIwH7/GUunx/HirWt5/3Ax24+VUt/cRkiAL8unx7EiM0G3Kl6EURkI99pTuKvf8FgMhAN6aQHh7yEgPl97CQXCg6/NZue9w8Xs6PbzZdn0OFaOoZ8vmtOKeHa6tI5NuYVsOVRERZ17oUlUiB+rs5JYlZXElLiQcdP/WUREZLTp10Jk3YWEhPDcc89x7bXXDtWYRgUt2iAig6mhpZ29J8vZfaKMvSfLqW1yX1UZIDLYj8Ud1bTzJkcT4Dvgz9ZEPOotEG5u89wCoq9AuHu/4cEMhIdSV+Vv7z2B+wqEned22+fn4zWhQoudx0p7reQPHkOV/JrTinQpr2tmy8EiNucWevwwOdDXm0tmxrMmO4nstCi8rBPnZ56IiMhIGXAakJSUhJfX2KigEBEZKYZhUFDRwK6OtgcH86txePiMzAJMSwwnJyOWxRmxpMeHTqjwR4bPcFcIu/YNtrnta+0lEO7Zb3gsVQifryfweQPizvYSYyAQ3nmslHv+vNf5vPPHWufXxhYbd7+8l59ct5Cl00d3cKs5rUx0jS3tbDtawqbcQj4+U+nWB9/LamHR1BhWZyexZFocfj76/0VERGQ4DbjS9v/+7//49a9/zT//+U8iIyOHalwjTlUJIjJQbTY7uWer2HWijN15ZRRXe06GAn29mT8lmpxpsSyaGktEsN8wj1Rk7OgZCDefZ5G4zn0jEQgPpd5aQPQVCLu0lxiEQLjNZucLD22kscXmcZHDThbM3tkv3rp2VLdK0JxWJqJ2u4O9eeVsyi3kg+OltNvd++jPTA5nTXYSKzMTXRY6FRERkeHVr0rbz3zmMy7Pz507x6RJk5g7dy7h4eEu+ywWC6+99tqgDVBEZDSrrG9hT14Zu06Usf9UBS29hEBJkUHOatqs1Eh8vDwvIiYiroarQri5j0XiWs4TCHvqNzyYgXDnmAabhY6WEZ4CYbdqYC8KqxppaHFfiKgnA2hosfH+4WLWzE4e9HFfDM1pZSIyDIPD56rZnFvIu4eLqW9udzsmKTKI1dlJrM5KJDFykH/YioiIyAXpV2hbV1fnUomRnp7u/L6+3vMCOiIi45HDMDhRXMuu42Y17YniWo/HeVktZKdFkpNuBrXJUcHDPFIR6Uv3QDh8iALh5n4sEtdbINzcS3uJwQqEDYYwELbA9mOloy601ZxWJpKCigY25xay+WAhJTXNbvvDAn25bFYiq7OTmJ4YNqpasYiIiEg/Q9utW7cO8TBEREavplYb+0+Vs+tEGXvyyqlubPV4XFigr7mIWHos86dEE+TvM8wjFZHRwqVCeJA5DKPXFhD9CYTP12940AJhA+qbPS+4OJKGek772GOP8cADD1BcXMysWbN4+OGHWbFihcdjb7rpJp577jm37ZmZmRw6dAiA3/3udzz//PMcPHgQgAULFvCLX/yCxYsXD92LkDGtuqGVrYfMBcWOe/hg2c/byrIZ8azOSmL+lGi8deePiIjIqKVlyUVEPCisajR7054oI/dsJTaH5w6O6fGhZlCbEce0xDCsqlIRkSFmtVgI8PUmYJgD4ee2HONoYc15+9l2slggJGBi9cJ8+eWX+f73v89jjz3G8uXLefLJJ7nqqqs4fPgwqampbsc/8sgj/PKXv3Q+t9lszJkzh8997nPObVu3buULX/gCy5Ytw9/fn/vvv59169Zx6NAhkpKShuV1yejX0mZjx7FSNuUWsv9UhdvCp1YLzJsczersJJZNjyfQT28BRURExoIBL0T205/+tNd9VquVsLAw5s6d22tVwVihRRtEJpZ2u4ND+VXsyitj9/EyzlU1ejzOz8eL+ZPNRcQWp8cSFeI/zCMVERkZGz8+xwOvfdTv4/9z/ZxR1x6hu8Ge0+bk5DB//nwef/xx57aZM2dy9dVXc9999/V5/t/+9jeuvfZaTp8+TVpamsdj7HY7ERER/Pa3v+XLX/5yv8alOe34ZHc4+PB0JZtzC9l+tMRjm5P0+FDWZCdx6axEzVdERETGoAF/zPrAAw9gs9lobTVvD/bx8aG93Wxm7+fnh81mw+FwMH/+fN544w1iYmIGd8QiIoOkprGVPXlm24N9p8ppavW8wE58eICzmnZ2WuSoXg1dRGSorMxM4PG3D9HYYjtvta0FCPL3ZkVmwnAN7YIM5py2ra2Nffv2cccdd7hsX7duHTt27OjXeJ5++mnWrl3ba2AL0NTURHt7O5GRkb0e09ra6nxNYIa2AA6HA4fD0a+xyOhkGAYniuvYcqiIdw8VUd3o3oIkNiyAVbMSWZWVQFpMiHO7/u1FRERGF6u17xZFAw5tt27dyuc//3nuuusu1q9fT3h4ODU1Nbz66qv84he/4LnnnqOpqYkbb7yR22+/nWefffZCxi4iMugMw+BkSR2788rYdaKMY73c5mu1WJiVEkFOhrmIWGp0sBbnEJEJz9fbi9vXz+Xul/diAY8/Pzt/Ut6+fu6o/4BrMOe0FRUV2O124uLiXLbHxcVRUlLS51iKi4t58803eeGFF8573B133EFSUhJr167t9Zj77ruPe+65x217eXk5LS0tfY5FRp/yulZ25FWxM6+S4lr3vvpBfl4snhzB0vRIMuKDzVZNRjNlZe6Lj4mIiMjoEB8f3+cxAw5tv/Od7/CDH/yAr3zlK85t4eHh3HzzzbS0tHDrrbeya9cu7rrrrvPediYiMhxa2mx8eLqSXSdK2ZNXTkW95zesIQE+LJoaQ05GHAumxhASoEXERER6WjItjp9ct5AHXz9AQ4sNi8VcdKzza5C/N7evn8uSaXF9X2yEDcWctucHfIZh9OtDv2effZbw8HCuvvrqXo+5//77efHFF9m6dSv+/r3f6n7nnXdy2223OZ/X1dWRkpJCTEyM2iOMIXVNbbx/pITNB4s4fK7abb+3l4WcjFhWZyWxcGr0qP+QRERERAZuwKHtRx991OttW5MnTyY3NxeArKwsamvdVywVERlqJTVN7D5hVtN+dKaSdrvnWwInx4Z0tD2IZUZSBF5WVdOKiPRl6fQ4Xrx1Le8fLmb7sVLqm9sICfBl+fQ4VmQmjJnwaDDntNHR0Xh5eblV1ZaVlblV3/ZkGAbPPPMMN954I76+nhdve/DBB/nFL37Bxo0bmT179nmv5+fnh5+fn9t2q9Xar9vwZOS02ezsOl7GptxC9uSVeVwEdXZaJKuzk7hkRoI+YBYRERnnBhzapqWl8fvf/54rr7zSbd9TTz3lnPxWVlYSHR198SMUEemD3eHg8Lkadh0vZXdeGWfLGzwe5+ttZe7kaBanm0FtbFjAMI9URGR88PX2Ys3s5FG90FhfBnNO6+vry4IFC9iwYQPXXHONc/uGDRtYv379ec999913ycvL42tf+5rH/Q888AA///nPefvtt1m4cGFfL0vGGIdhkHu2is25hbx3pNhjf/3U6GDWzk5iVVaS5i4iIiITyIBD2/vuu4/rrruO6dOn86lPfYqYmBjKy8v5xz/+walTp/jLX/4CwKZNm7j00ksHfcAiIgB1zW3s7VhEbO/Jchpa2j0eFx3qb/amTY9l7uRo/H3GRgWYiIgMrcGe0952223ceOONLFy4kKVLl/LUU0+Rn5/PLbfcAphtCwoLC3n++eddznv66afJyckhKyvL7Zr3338/P/7xj3nhhReYNGmSs5I3ODiY4ODgi/0rkBF0urSOTbmFbDlUREWde+umqBA/LpuVyJrsJKbEhaq3voiIyARkMQzjfAsAe/Thhx9y3333sXfvXoqLi0lISGDRokXceeedzJ07dwiGOfzq6uoICwujtrZW/b9ERgHDMDhb3sCuE6XsOlHGkXPVeLhrEAswMznC2fZgcmyI3uiIiIhHgz2nfeyxx7j//vspLi4mKyuLhx56iJUrVwJw0003cebMGbZu3eo8vra2loSEBB555BG+8Y1vuF1v0qRJnD171m37T37yE+6+++5+jUlz2tGjvK6ZrQeL2JRbyOmyerf9Ab5eXDIzgTXZScxOi1LbJhERkQnugkLbiUATXJGR19pu56MzlezOM/vTltV6XgU5yM+bhVNjyMmIZWF6LGGBnnsCioiITDSa046sxpZ2th0tYXNuIR+dqaTnGy8vq4WFU2NYnZ3EkmlxuiNIREREnAbcHkFEZCiV1zWz+0QZu0+U8eHpClptnhcRS40OdlbTZiZH4O2lxVVERERk5LXbHew7Wc6m3EI+OF5Km4e5zMykcFZnJ7EyM4HwIPeF40RERET6Fdp+5jOf4de//jUZGRl85jOfOe+xFouF1157bVAGJyLjn91hcKyoht0nzGraU6V1Ho/z8bIyOy3S7E+bEUdCROAwj1RERMY6zWllqBiGweFz1eaCYoeLqWt277WfGBnImqwkVmUnkRQZNAKjFBERkbGkX6FtfX09drsdMG+xUn9IEbkYDS3t7DvZtYhYbVObx+Mig/1YnG5W086bEk2Ar24OEBGRC6c5rQy2gooGNh8sZMvBIoqrm9z2hwX6ctmsRFZnJzE9MUz/zYmIiEi/qadtL9T/S2TwGIZBQWVjRzVtKYcKqrF7WkUMmJYYRk5GHDkZsUyND8WqNzciIiIXrD9zWpvdwRPvHGbLwSIAVmcncsu6TLys7q2H1v/yLZfn7XYHqdHBPPGvK/t1rYq6Fn775kEOFlRhAeZMiuI7V2YREezXr+uPBtUNrbx72FxQ7HhRrdt+P28rS6fHsyY7iflTotXCSURERC6IQtteKLQVuThtNju5+VXOtgeeqk/AXCl5wZQYFmfEsig9hshg/2EeqYiIyPjVnznt81uPs/N4KT//wiIA7npxD8tnxHPDyow+r3/Lk+9x6axEvnBJer+u9ZOX92IB/uuauRgG/OrVD/Hz8eKH/zK/X9cfKS1tNnYcK2XzwUL2nazA0eMtlNUCcydHszorieUz4gn0091BIiIicnEuaDZRUVHBgw8+yJ49eygoKODVV19l1qxZPPLII+Tk5LBkyZLBHqeIjAGV9S3syTMXEdt/uoLmNrvH4xIjA8nJiGNxeizZaZH4qAJFRERGgOa0prc/KuCWyzOJCjE/OP3CJen8buORPkPbo4U1nC1vYN2c5H5fq7SmieuWTXW2PLp0ViIvbc/r9/WHk93h4MPTlWzOLWT70RJa2t3nNenxoazOTuKyWYnO1ywiIiIyGAYc2u7fv581a9YQEhLCihUr2Lp1K62trQAUFhby0EMP8fLLLw/6QEVk9HEYBnnFtezqqKY9Uex+iyCAl9VCdmokizPM/rTJUcHDPFIRERFXmtOa6pvbqahrYUp8VxXu1LhQymqbaWxpJ8jfp9dz3z5QwKL0GGdY2Z9rXbtkMu8fKSYnIxYD2HKoiMXpsf26/nAwDIO8kjo25Ray9WAR1Y2tbsfEhgWwOsvsU5sWEzJsYxMREZGJZcCh7a233srSpUt57bXXsFgsvPjii859OTk5E2JyKzKRNbXa2H+qnN15Zew+Ue7xzQyYC290LiI2f0r0ed/0iYiIDDfNaU3NbTYAgrv9ng7yN98iNLXZev393dJuZ+uhIm5fP2dA15qVHMmb+wv4lwfeAWBGcjhfXOFe0evp+kOppKaJzbmFbM4tpKCy0W1/sL83KzPNoHZWSoR67ouIiMiQG3Bou2fPHv7617/i4+PjXH23U0xMDGVlZYM2OBEZHQqrGp29aXPPVmLrZRGx9PhQM6idFsu0xHC9oRERkVFLc1pTZ5uCxpZ2wgJ9ze9bzfA10Lf3twrvHS7C38eLnIyuKtm+ruUwDO780y5WZiZw3w05APzx3eP88IVdPHzz8j6vP9jqmtt4/3Axm3ILOVRQ7bbfx8vK4oxY1mQnsSg9Bl9vryEbi4iIiEhPAw5tg4KCqKur87gvPz+fqKioix6UiIwsm93BwYKuRcTOeag4AfDz8WLe5GhyMmJZnB5LdKh6uYmIyNigOa0pJMCH6FB/TpbWkRgZBMCpkjpiQv3Pe5fMWx8WsHZ2Ml7Wrr70fV2rtqmN0tpm1i+ehL+PGYB+ZtEk/rLzFLVNbc6gt7frD4Y2m51dJ8rYnFvI7hNlHj+Izk6NZHV2EitmJhASoDuFREREZGQMOLS94oor+PnPf86aNWsIDw8HwGKx0NzczCOPPMInPvGJwR6jiAyDmsZW9uSVs+tEGftOldPUURnTU1x4gLPtwZxJUao6ERGRMUlz2i7r5iTz0rY8ZqVEAPDS9jyunJfa6/EFFQ0cLqjmtk/PHtC1wgJ9SYwM5O97znLDpWZLhL/vPUt0qL9LYHu+618Ih2FwML+KTbmFvH+42Fn9211qdDBrspNYlZVIXHjgoPy5IiIiIhfDYhiG5/uce1FYWMjy5cupq6tj1apV/O1vf+PKK6/k8OHDWCwWPvjgA2Jjh+42puFSV1dHWFgYtbW1hIaG9n2CyBhjGAanSuvYdaKM3SfKOFpYg6cfBlaLhcyUCGc1bVpMMBa1PRARkTFOc9ouNruDJ945zJaDhQCsykriW1dk4mW18sg/cwH43iezncf/fuMRjhbW8OBXlg7oWgBny+t58p3DHC+uxTAMpsaH8c21M0lPCOvX9QfiTFk9m3IL2XKwkPK6Frf9kcF+rMpKZE12ElPiQjW/ERERkVFlwKEtQE1NDQ899BAbNmygoqKCyMhI1q5dy2233UZkZORQjHPYKbSV8ailzcaBM5XOoLai3v0NDJi3Ny6aGsPijFgWTI0hNMDX43EiIiJjmea0409FXQtbDhWyObeIU6Xu7S8CfL24ZEYCq7OTmDMpCi+rgloREREZnfoV2t57771ccsklLF68mICAgOEY14ibaBNcGb9KaprYfaKM3XllHDhdSbvd4fG4STEhZjVtRiwzk8MHvYeciIjISNOcdnzOaRtb29l+tIRNuYV8dLrS7c4hq8XCwvQY1mQlsWR6nLOfroiIiMho1q/Q1sfHB4fDgbe3N/PmzWP58uWsWLGCZcuWjYvbxjyZCBNcGZ/sDgdHztWw60QZu06Ucra8weNxPl5W5k2OYnFH2wP1bxMRkfFOc9rxM6e12R3sPVnO5txCdh4vpc3m/qH0jKRwVmcncWlmAuFBfiMwShEREZEL16/QtrGxkQ8++IDt27ezfft2PvjgA+rr67FYLEydOpVLLrmESy65hOXLlzN9+vThGPeQG68TXBmf6prb2JtXzu68MvbkldPQ0u7xuOhQf+ciYnMnR6vSREREJhTNacf2nNYwDI4U1rA5t5B3DxVR1+w+30mMDGRNVhKrspJIigoagVGKiIiIDI4L6mlrGAYff/wx27dvZ8eOHWzfvp38/HwAoqOjKS0tHfSBDrfxNMGV8ccwDM6WNziraY+cq8bh4f9kCzAjObwjqI1jSlyIFtkQERHpoDnt2HCusoHNuUVsPlhIcXWT2/6wQF8unZXAmuwkpieGa64jIiIi48IFhbbdnT59mm3btvGXv/yFf/7znwDY7fZBGdxIGg8TXBlf2mx2Puq2iFhpbbPH44L8vFkwNYacjFgWTo3R7YAiIiL9oDnt6FLT2Mq7h4rYlFvEsaIat/2+3laWTY9ndXYiC6bE4O2lXvwiIiIyvngP5GC73c6HH37I9u3b2bZtG9u3b6e0tJRJkyaxdOlS/t//+38sW7ZswIN47LHHeOCBByguLmbWrFk8/PDDrFixwuOxW7duZdWqVW7bjxw5wowZMwB49tlnufnmm92OaW5uxt/ff8DjExkpFXUt7M4rY9fxUj48U0lru+c3jylRQSzOMKtpZ6VE6I2LiIjIeQzVnFYuTku7nZ3HSticW8jekxU4etSWWIC5k6NZk53EshlxBPn5jMxARURERIZBv0LbH//4x2zfvp3du3djs9mYP38+y5Yt4wtf+ALLli0jPj7+ggfw8ssv8/3vf5/HHnuM5cuX8+STT3LVVVdx+PBhUlNTez3v2LFjLtUCMTExLvtDQ0M5duyYyzYFtjLa2R0Gx4tqnNW0J0vrPB7n42UlOy2SnI5FxBIj1bNNRESkL0M5p5ULY3cYHDhTwebcQrYfLaG5zf0D6vT4UFZnJ3HZrESiQjSfFxERkYmhX+0RrFYrQUFB3HTTTXz3u98lIyNj0AaQk5PD/Pnzefzxx53bZs6cydVXX819993ndnxnpW11dTXh4eEer/nss8/y/e9/n5qamgse11i9lUzGnsaWdvadqmDXiVL25JVT29Tm8bjIYD8Wp8eyOCOWeZOjCfQbUKG8iIjIhDeUc9rRarjmtG02O+8dLmbHsVLqm9sICfBl2fQ4VmYm4OvtuvCpYRjkldSxObeQrYeKqGpodbtebFgAq7ISWZ2VxKTYkCEbt4iIiMho1a/U57e//S07d+7kn//8J4899hiJiYksW7aM5cuXs2zZMubNm4eX18BXoW9ra2Pfvn3ccccdLtvXrVvHjh07znvuvHnzaGlpITMzk7vuusutZUJDQwNpaWnY7Xbmzp3Lz372M+bNm9fr9VpbW2lt7Zow1tWZFY4OhwOHwzHQlybSK8MwKKxqZNeJcvbklXGwoBq7p1XEgIyEMHLSY1iUHkt6QijWbgtr6L9LERGZqKzWC2sDNFRz2olu57FSHnz9AA0tNiwWMAywWGD70RIef/sQt6+fy5JpcZTUNLHlYBGbcwvJr2hwu06QnzcrM80FxWalRrrMe0REREQmmgEvRFZcXOyywu6BAwfw8fFh0aJFLFu2jGXLlvHJT36yX9cqKioiKSmJ7du3u/QN+8UvfsFzzz3n1t4AzLYI7733HgsWLKC1tZU//OEPPPHEE2zdupWVK1cC8MEHH5CXl0d2djZ1dXU88sgjvPHGG3z00Ue9VlTcfffd3HPPPW7bjx8/TkiIPt2Xi9Nud3CsuIGPCmo5kF9LWZ17RQmAv4+VrKRQ5qSGMTsljPBA9WoTERHpaTDaGAzmnHY0G+pK253HSrnnz3sB8PSmwtKxPTU62GNQ6+NlZXF6DKuzk1icEetWlSsiIiIyUQ04tO2pubmZbdu28Zvf/IY333wTAJvN1q9zO0PbHTt2sHTpUuf2e++9lz/84Q8cPXq0X9f59Kc/jcVi4fXXX/e43+FwMH/+fFauXMlvfvMbj8d4qrRNSUmhurpa7RHkglQ1tLInr4w9eeXsP13hsUcbQEJEIIvTY8jJiGVWSoTerIiIiPThQittz+di5rSj2VCGtm02O194aCONLTaPge35ZKdGsjo7iUtmxhMa4Duo4xIREREZDy6oKWZNTQ3bt293Pvbu3UtzczNWq5VZs2b1+zrR0dF4eXlRUlLisr2srIy4uLh+X2fJkiX88Y9/7HW/1Wpl0aJFnDhxotdj/Pz88PPz83juULwxkPHHYRjkFdey+0QZu06Ucby41uNxXlYLWamRLE6PJScjluSoICy6/U9ERGTYDdacdqJ673AxDS39D7ajgv34zKJJrMpKJC48cAhHJiIiIjL29Su0PXnypMuE9ujRozgcDgIDA1m8eDG33XabsxfYQD7B9/X1ZcGCBWzYsIFrrrnGuX3Dhg2sX7++39f58MMPSUhI6HW/YRgcOHCA7Ozsfl9TpD+aWm18eLprETFPC2kAhAX6sig9hpyMOBZMiSbIX20PREREhttQzWknqh3HSp09bPtiAWYkh/P5S9KHfFwiIiIi40G/QtvOPrDx8fEsW7aMr3/96yxfvpx58+bh7X1xK9jfdttt3HjjjSxcuJClS5fy1FNPkZ+fzy233ALAnXfeSWFhIc8//zwADz/8MJMmTWLWrFm0tbXxxz/+kVdeeYVXXnnFec177rmHJUuWkJGRQV1dHb/5zW84cOAAjz766EWNVQSgqKqR3XlmNW3u2Sra7Z4XBJsaF8riDLOadlpiOF5WVdOKiIiMpKGc005E9c1t/QpswexrW9/cPqTjERERERlP+jU7ffbZZ7nkkkuYMmXKoA/g+uuvp7Kykp/+9KcUFxeTlZXFG2+8QVpaGmAuEpGfn+88vq2tjR/84AcUFhYSEBDArFmz+Oc//8knPvEJ5zE1NTV885vfpKSkhLCwMObNm8d7773H4sWLB338Mv7Z7A4OFVSz60Qpu0+UUVDZ6PE4P28r8yZHkzMtjkXpMcSEBgzzSEVEROR8hnJOOxGFBPj2v9LWYh4vIiIiIv1z0QuRjVdDvdKujG61TW3s6aim3XeynMZWz/3a4sICnNW0s9Oi8PPRImIiIiIyegzlnHbjx+d44LWP+n38f66fw5rZyYM6BhEREZHxSveBiWD2PT5VWm9W0+aVcfRcjcdVkK0WmJkcQU5GHDkZsaTFBGsRMREREZmQVmYm8Pjbh2hssXmcN3WyAEH+3qzI7H0NChERERFxpdBWJqyWdjsHTlew60QZu/PKqKhr8XhcsL8Pi9JjWJwey8L0GEJ1a5+IiIgIvt5e3L5+Lne/vBcLeAxuOz/avn39XHy9dUeSiIiISH8ptJUJpbSmybmI2EdnKmmzeV5ELC0mmJyMOBZnxJKZHI6X1TrMIxUREREZ/ZZMi+Mn1y3kwdcP0NBic/a47fwa5O/N7evnsmRa3EgPVURERGRMUU/bXqin7fhgdzg4cq6G3SfMoPZMeb3H43y8rMydHMXi9FgWZ8QSHx44zCMVERERGXzDNadts9l5/3Ax24+VUt/cRkiAL8unx7EiM0EVtiIiIiIXQJW2Mu7UNbex72Q5u06UsfdkOfXN7R6Piw7xdy4iNndSFP6++t9BwNadCgAAKctJREFURERE5EL4enuxZnayFhoTERERGSRKqWTMMwyDs+UNzrYHhwuqcXgoILcAM5LCnUHtlLhQLSImIiIiIiIiIiKjjkJbGZPabHY+OlPpXESstKbZ43GBft4smBJDTkYsi9JjCA/yG+aRioiIiIiIiIiIDIxCWxkzKupanNW0H56uoLXd7vG45KggcjLM3rRZKZF4e2kRMRERERERERERGTsU2l4Em93BE+8cZsvBIgBWZydyy7pMvKzuIeGDr33EloOFLgHifTfkkJkcQZvNzqNvHeLD0xXUNbURFeLPdcumcsXcFOexFXUt/PbNgxwsqMICzJkUxXeuzCIi2KwcffStg+w4VkpTi40APy9WzEzg62tn4jOGA0uHYXC8qIZdx82g9mRpncfjvK0WstOinEFtUmTQMI9URERERERERERk8Ci0vQgvvJ/HoYJqnrplJQB3vbiHF7ed5IaVGR6P/9TCNL51xSy37Q6HQWSwH7/8Ug4JEYEcLazhrhd3Ex3iz4KpMQD8vzcPYgH+8N3VGAb86tUPefztQ/zwX+YD8OkFaXxt9Qz8fb2paWzl3lf285cdJ/niCs9jGa0aW9rZd6qC3R1tD2qb2jweFxHkx+KMGBanxzJ/SgyBfvpPWURERERERERExgclXRfh7Y8KuOXyTKJC/AH4wiXp/G7jkV5D2974+3rzlcumO5/PTI5gTloUBwuqnKFtaU0T1y2bSoCv+U926axEXtqe5zwnNSbE5ZpWi4XCqsYLel3D7VxlA7tOmNW0B/OrsDvcFxEDyEgIc1bTZiSEYdUiYiIiIiIiIiIiMg4ptL1A9c3tVNS1MCU+1LltalwoZbXNNLa0E+Tv43bOxo8L2fhxIZHBflwxN4Vrl0z2GDy22ewcK6plVVaSc9u1Sybz/pFicjJiMYAth4pYnB7rct7L2/N4cVsezW12QgN8+NqaGYP3ggdRu91B7tmqjv60pRRVNXk8zt/HiwVTolmcEcui9FhnOC4iIiIiIiIiIjKeKbS9QM1tNgCCu4WzQf7mX2dTm80ttF2/eBJfXzuDkABfjhfVcO8r+7Fa4NolU1yOMwyDh/7+MYmRgSyfGe/cPis5kjf3F/AvD7wDwIzkcLfWB9cvT+f65enkl9ez+WCRs9/taFDd0Nq1iNipCpo6/v56SogIdFbTZqdG4uvtNcwjFRERERERERERGVkKbS9QZ5uCxpZ2wgJ9ze9bzSAy0Nf9rzUjIcz5/czkCK5fPpWNHxe6hLaGYfCbNw5yrrKRX96Q46zCdRgGd/5pFyszE7jvhhwA/vjucX74wi4evnm525+VGhPClLhQHnz9I351w5JBesUD4zAMTpbUdbQ9KOV4Ua3H46wWC1mpEeRkxLE4I5aUqCAsansgIiIiIiIiIiITmELbCxQS4EN0qD8nS+tIjAwC4FRJHTGh/h5bI/TUM5g0DIPfvnmQ40U1/PKGJS7XqG9up7S2mfWLJ+HvY1aefmbRJP6y8xS1TW3O0Lg7m93Ra9uBodLcZuPDUxXs6lhErKqh1eNxYYG+LJwaQ05GLAumxrhUK4uIiIiIiIiIiEx0Cm0vwro5yby0LY9ZKREAvLQ9jyvnpXo89t1DRSxMjyHQ15sTxbX8eftJPr0wzbn/0bcOcaigmvtvXEJIgGuIGRboS2JkIH/fc5YbLjVbIvx971miQ/0JC/Sluc3Ge4eLWT4jniA/b86U1fPitjwWTIkeolfepbi6iV0nStl9ooyPz1bRbnd4PG5KXKiz7cH0xHC8rKqmFRERERERERER8cRiGIYx0oMYjerq6ggLC6O2tpbQ0FCPx9jsDp545zBbDhYCsCoriW9dkYmX1coj/8wF4HufzAbgP57byenSOuwOg+gQf66Yl8Jnl07BarFQWtPEl//fFny8rC5h5ursJOf5Z8vrefKdwxwvrsUwDKbGh/HNtTNJTwijpc3G3X/eR15JLe02B+FBvlwyM4EbL53mrMwdLDa7g0MF1WZ/2uOlFFQ2ejzOz9vK3MnR5HQsIhYbFjCo4xARERGRvvVnTisiIiIio49C215ogtultqmNPXll7D5Rxt6T5c7evT3FhgWY1bTpscyZFIXfIAfGIiIiIqPZY489xgMPPEBxcTGzZs3i4YcfZsWKFR6Pvemmm3juuefctmdmZnLo0CHn81deeYUf//jHnDx5kqlTp3LvvfdyzTXX9HtMmtOKiIiIjE1qjyBuDMPgdFm9cxGxo+dq8JTsWy3momo5GbHkZMSRFhOsRcRERERkQnr55Zf5/ve/z2OPPcby5ct58sknueqqqzh8+DCpqe7tsx555BF++ctfOp/bbDbmzJnD5z73Oee2nTt3cv311/Ozn/2Ma665hldffZXrrruObdu2kZOTMyyvS0RERERGhiptezHRqhJa2u0cOF1htj04UUZFXYvH44L9vVk4NZacjFgWTo0h1MMiaCIiIiITTU5ODvPnz+fxxx93bps5cyZXX3019913X5/n/+1vf+Paa6/l9OnTpKWZ6x5cf/311NXV8eabbzqPu/LKK4mIiODFF1/s17gm2pxWREREZLxQpe0EVlbbzK4TZew+UcqBM5W02TwvIpYWE8zi9FhypsWRmRyOl9U6zCMVERERGb3a2trYt28fd9xxh8v2devWsWPHjn5d4+mnn2bt2rXOwBbMSttbb73V5bgrrriChx9++KLHLCIiIiKjm0LbCcTuMDhaWM2u42XszivjdFm9x+N8vKzMmRRl9qfNiCU+PHCYRyoiIiIydlRUVGC324mLi3PZHhcXR0lJSZ/nFxcX8+abb/LCCy+4bC8pKRnwNVtbW2ltbXU+r6urA8DhcOBweP6AXkRERESGl7UfBZEKbce5+uZ29p0sZ9eJUvacLKe+ud3jcVEhfmY1bUYc8yZH4e+r/zREREREBqJnb3/DMPrV7//ZZ58lPDycq6+++qKved9993HPPfe4bS8vL6elxXP7KxEREREZXvHx8X0eo2RunDEMg/yKho62B2UcKqjG4aFtsQWYnhRuVtOmxzI1PlSLiImIiIhcgOjoaLy8vNwqYMvKytwqZXsyDINnnnmGG2+8EV9f17UC4uPjB3zNO++8k9tuu835vK6ujpSUFGJiYtTTVkRERGQMUWg7DrTZ7Hx0ptK5iFhpTbPH4wL9vFkwJZqcjDgWpccQHuQ3zCMVERERGX98fX1ZsGABGzZs4JprrnFu37BhA+vXrz/vue+++y55eXl87Wtfc9u3dOlSNmzY4NLX9p133mHZsmW9Xs/Pzw8/P/c5ntVq7ddteCIiIiIyOii0HWFtNjvvHS5mx7FS6pvbCAnwZdn0OFZmJuDr7dXreZX1Lc5q2v2nK2htt3s8LjkyiMXTYslJj2VWaiQ+Xpqsi4iIiAy22267jRtvvJGFCxeydOlSnnrqKfLz87nlllsAswK2sLCQ559/3uW8p59+mpycHLKystyu+b3vfY+VK1fyq1/9ivXr1/Paa6+xceNGtm3bNiyvSURERERGjkLbEbTzWCkPvn6AhhYbFgsYBlgssP1oCY+/fYjb189lyTTz9jeHYXC8qMYZ1OaV1Hm8prfVQnZaFIszzKA2KSpoOF+SiIiIyIR0/fXXU1lZyU9/+lOKi4vJysrijTfeIC0tDTAXG8vPz3c5p7a2lldeeYVHHnnE4zWXLVvGSy+9xF133cWPf/xjpk6dyssvv0xOTs6Qvx4RERERGVkWw/DQ8FSoq6sjLCyM2traIen/tfNYKff8eS8Anv4BOrvLfm7pFKob29hzsoyaxjaP1woP8mVxeiyLM2KZPyWaID+fQR+viIiIiIw9Qz2nFREREZGhoUrbEdBms/Pg6wcAz4Ft9+1/3nnK4/6MhDAWp8eSMy2WjIQwrFpETEREREREREREZFxQaDsC3jtcTEOLbUDn+Pt4MX9KNIszYlmcHktUiP8QjU5ERERERERERERGkkLbEbDjWKmzh21/zEqJ4Jc35Jx3YTIREREREREREREZH6wjPYCJqL65rd+BLYCX1aLAVkREREREREREZIJQaDsCQgJ86W8LWovFPF5EREREREREREQmBoW2I2DZ9Lh+V9oaBiyfHje0AxIREREREREREZFRQ6HtCFiZmUCwvzd9FdtagGB/b1ZkJgzHsERERERERERERGQUUGg7Any9vbh9/VyAXoPbzu23r5+rfrYiIiIiIiIiIiITiELbEbJkWhw/uW4hQf7eAM4et51fg/y9ufv6hSyZptYIIiIiIiIiIiIiE4nFMPrbXXViqaurIywsjNraWkJDQ4fsz2mz2Xn/cDHbj5VS39xGSIAvy6fHsSIzQRW2IiIiInJRhmtOKyIiIiKDy3ukBzDR+Xp7sWZ2MmtmJ4/0UERERERERERERGQUUHsEERERERERERERkVFEoa2IiIiIiIiIiIjIKKLQVkRERERERERERGQUUWgrIiIiIiIiIiIiMoootBUREREREREREREZRRTaioiIiIiIiIiIiIwiCm1FRERERERERERERhGFtiIiIiIiIiIiIiKjiEJbERERERERERERkVFEoa2IiIiIiIiIiIjIKKLQVkRERERERERERGQUUWgrIiIiIiIiIiIiMoootBUREREREREREREZRRTaioiIiIiIiIiIiIwiCm1FRERERERERERERhGFtiIiIiIiIiIiIiKjiEJbERERERERERERkVFEoa2IiIiIiIiIiIjIKKLQVkRERERERERERGQUUWgrIiIiIiIiIiIiMoootBUREREREREREREZRRTaioiIiIiIiIiIiIwiCm1FRERERERERERERhGFtiIiIiIiIiIiIiKjiEJbERERERERERERkVFEoa2IiIiIiIiIiIjIKKLQVkRERERERERERGQUUWgrIiIiIiIiIiIiMoootBUREREREREREREZRRTaioiIiIiIiIiIiIwiCm1FRERERERERERERhGFtiIiIiIiIiIiIiKjiEJbERERERERERERkVFEoa2IiIiIiIiIiIjIKKLQVkRERERERERERGQUUWgrIiIiIiIiIiIiMoqMitD2scceY/Lkyfj7+7NgwQLef//9Xo/dunUrFovF7XH06FGX41555RUyMzPx8/MjMzOTV199dahfhoiIiIhMYAOZ0wK0trbyox/9iLS0NPz8/Jg6dSrPPPOMyzEPP/ww06dPJyAggJSUFG699VZaWlqG8mWIiIiIyCjgPdIDePnll/n+97/PY489xvLly3nyySe56qqrOHz4MKmpqb2ed+zYMUJDQ53PY2JinN/v3LmT66+/np/97Gdcc801vPrqq1x33XVs27aNnJycIX09IiIiIjLxXMic9rrrrqO0tJSnn36a9PR0ysrKsNlszv1/+tOfuOOOO3jmmWdYtmwZx48f56abbgLgoYceGo6XJSIiIiIjxGIYhjGSA8jJyWH+/Pk8/vjjzm0zZ87k6quv5r777nM7fuvWraxatYrq6mrCw8M9XvP666+nrq6ON99807ntyiuvJCIighdffLFf46qrqyMsLIza2lqXcFhEREREpKeBzmnfeustPv/5z3Pq1CkiIyM9XvPf/u3fOHLkCJs2bXJu+4//+A92797dZxVvJ81pRURERMamEW2P0NbWxr59+1i3bp3L9nXr1rFjx47znjtv3jwSEhJYs2YNW7Zscdm3c+dOt2teccUVfV5TRERERGSgLmRO+/rrr7Nw4ULuv/9+kpKSmDZtGj/4wQ9obm52HnPJJZewb98+du/eDcCpU6d44403+OQnPzl0L0ZERERERoURbY9QUVGB3W4nLi7OZXtcXBwlJSUez0lISOCpp55iwYIFtLa28oc//IE1a9awdetWVq5cCUBJScmArglmT7HW1lbn87q6OgAcDgcOh+OCXp+IiIiIDD6rdVQsy+B0IXPaU6dOsW3bNvz9/Xn11VepqKjg29/+NlVVVc6+tp///OcpLy/nkksuwTAMbDYb3/rWt7jjjjt6HYvmtCIiIiKjX3/msyPe0xbAYrG4PDcMw21bp+nTpzN9+nTn86VLl1JQUMCDDz7oDG0Hek2A++67j3vuucdte3l5uRZ7EBERERlF4uPjR3oIHg1k/ulwOLBYLPzpT38iLCwMgP/5n//hs5/9LI8++igBAQFs3bqVe++9l8cee4ycnBzy8vL43ve+R0JCAj/+8Y89XldzWhEREZHRrz/z2RENbaOjo/Hy8nKrQCgrK3OrVDifJUuW8Mc//tH5PD4+fsDXvPPOO7nt/7d370FeVvUfwN+7ILsQsBb32BXw0sgEpCypyNToT4M0EXHykoUpXjJJEUZTU0zwVppImhhmSFYWodlNMjatxLSbQVmaMjqK4hJBwWYEm+z+/nDaWkFE2cuz9HrN7AzP+Z7n+Z7jMOf74e35np0+vem6rq4uVVVV6dOnj/O/AAB4TW+mph0wYEAGDhzYFNgmr5yB29jYmBdeeCH77LNPZsyYkUmTJuX0009PkgwfPjz/+Mc/cuaZZ+aSSy7Z5g4NNS0AwK6hXUPbLl26pLq6OjU1NZk4cWJTe01NTSZMmLDDz1m2bFkGDBjQdD169OjU1NRk2rRpTW1LlizJwQcf/JrPKCsrS1lZ2VbtpaWlhfsKHgAAxfFmatoxY8Zk0aJFeemll9K9e/ckyVNPPZXS0tJUVlYmSTZu3LhVHdqpU6c0NjbmtX6XsJoWAGDX0O7HI0yfPj2TJk3KqFGjMnr06Nx6661ZuXJlzjrrrCSv7BZYtWpV7rjjjiTJnDlzMnjw4Lzzne9MfX19vva1r+Xuu+/O3Xff3fTMqVOn5r3vfW8++9nPZsKECfnud7+bH//4x3nooYfaZY4AAOza3mhNe9JJJ+WKK67IqaeempkzZ2bt2rW54IILMnny5HTt2jVJMn78+MyePTv7779/0/EIM2bMyNFHH51OnTq121wBAGh97R7annDCCVm3bl1mzZqV2traDBs2LIsXL86gQYOSJLW1tVm5cmVT//r6+px//vlZtWpVunbtmne+85259957c+SRRzb1Ofjgg/PNb34zl156aWbMmJG99torCxcuzIEHHtjm8wMAYNf3Rmva7t27p6amJuecc05GjRqVXr165fjjj8+VV17Z1OfSSy9NSUlJLr300qxatSp9+vTJ+PHjc9VVV7X5/AAAaFslja/13ar/cXV1damoqMiGDRuc/wUAQIekpgUA6JgcbAUAAAAAUCBCWwAAAACAAhHaAgAAAAAUiNAWAAAAAKBAhLYAAAAAAAUitAUAAAAAKBChLQAAAABAgQhtAQAAAAAKRGgLAAAAAFAgQlsAAAAAgAIR2gIAAAAAFIjQFgAAAACgQIS2AAAAAAAFIrQFAAAAACgQoS0AAAAAQIEIbQEAAAAACkRoCwAAAABQIEJbAAAAAIACEdoCAAAAABSI0BYAAAAAoECEtgAAAAAABSK0BQAAAAAoEKEtAAAAAECBCG0BAAAAAApEaAsAAAAAUCBCWwAAAACAAhHaAgAAAAAUiNAWAAAAAKBAhLYAAAAAAAUitAUAAAAAKBChLQAAAABAgQhtAQAAAAAKRGgLAAAAAFAgQlsAAAAAgAIR2gIAAAAAFIjQFgAAAACgQIS2AAAAAAAFIrQFAAAAACgQoS0AAAAAQIEIbQEAAAAACkRoCwAAAABQIEJbAAAAAIACEdoCAAAAABSI0BYAAAAAoECEtgAAAAAABSK0BQAAAAAoEKEtAAAAAECBCG0BAKAFzJ07N0OGDEl5eXmqq6uzdOnS7fbfvHlzLrnkkgwaNChlZWXZa6+9Mn/+/GZ91q9fnylTpmTAgAEpLy/P0KFDs3jx4tacBgAABdC5vQcAAAAd3cKFC3Peeedl7ty5GTNmTObNm5cjjjgijz/+ePbYY49t3nP88cfnz3/+c7785S9n7733zpo1a/Lyyy83vV5fX5/3ve996du3b+66665UVlbm+eefT48ePdpqWgAAtJOSxsbGxvYeRBHV1dWloqIiGzZsSM+ePdt7OAAAFNiBBx6YkSNH5pZbbmlqGzp0aI455phcc801W/W/7777cuKJJ+aZZ57J2972tm0+84tf/GKuu+66/OlPf8puu+32psalpgUA6JgcjwAAADuhvr4+jz76aMaOHdusfezYsXn44Ye3ec/3vve9jBo1Ktdee20GDhyYd7zjHTn//PPzz3/+s1mf0aNHZ8qUKenXr1+GDRuWq6++Olu2bGnV+QAA0P4cjwAAADth7dq12bJlS/r169esvV+/flm9evU273nmmWfy0EMPpby8PPfcc0/Wrl2bs88+O3/961+bzrV95pln8sADD+TDH/5wFi9enBUrVmTKlCl5+eWXc9lll23zuZs3b87mzZubruvq6pIkDQ0NaWhoaInpAgCwk0pLX38frdAWAABaQElJSbPrxsbGrdr+raGhISUlJfn617+eioqKJMns2bPzwQ9+MDfffHO6du2ahoaG9O3bN7feems6deqU6urqvPjii7nuuuteM7S95pprMnPmzK3a//KXv2TTpk07OUMAAFpC//79X7eP0BYAAHZC796906lTp6121a5Zs2ar3bf/NmDAgAwcOLApsE1eOQO3sbExL7zwQvbZZ58MGDAgu+22Wzp16tSsz+rVq1NfX58uXbps9dyLL74406dPb7quq6tLVVVV+vTp40xbAIAORGgLAAA7oUuXLqmurk5NTU0mTpzY1F5TU5MJEyZs854xY8Zk0aJFeemll9K9e/ckyVNPPZXS0tJUVlY29bnzzjvT0NDQ9BW6p556KgMGDNhmYJskZWVlKSsr26q9tLR0h76GBwBAMajcAABgJ02fPj233XZb5s+fnyeeeCLTpk3LypUrc9ZZZyV5ZQfsySef3NT/pJNOSq9evXLqqafm8ccfz4MPPpgLLrggkydPTteuXZMkH//4x7Nu3bpMnTo1Tz31VO69995cffXVmTJlSrvMEQCAtmOnLQAA7KQTTjgh69aty6xZs1JbW5thw4Zl8eLFGTRoUJKktrY2K1eubOrfvXv31NTU5JxzzsmoUaPSq1evHH/88bnyyiub+lRVVWXJkiWZNm1aRowYkYEDB2bq1Km58MIL23x+AAC0rZLGxsbG9h5EEdXV1aWioiIbNmxw/hcAAB2SmhYAoGNyPAIAAAAAQIEIbQEAAAAACkRoCwAAAABQIEJbAAAAAIACEdoCAAAAABSI0BYAAAAAoECEtgAAAAAABSK0BQAAAAAoEKEtAAAAAECBCG0BAAAAAApEaAsAAAAAUCBCWwAAAACAAhHaAgAAAAAUiNAWAAAAAKBAhLYAAAAAAAUitAUAAAAAKBChLQAAAABAgQhtAQAAAAAKpBCh7dy5czNkyJCUl5enuro6S5cu3aH7fv7zn6dz587Zb7/9mrUvWLAgJSUlW/1s2rSpFUYPAAAAANBy2j20XbhwYc4777xccsklWbZsWd7znvfkiCOOyMqVK7d734YNG3LyySfnsMMO2+brPXv2TG1tbbOf8vLy1pgCAAAAAECLaffQdvbs2TnttNNy+umnZ+jQoZkzZ06qqqpyyy23bPe+j33sYznppJMyevTobb5eUlKS/v37N/sBAAAAACi6dg1t6+vr8+ijj2bs2LHN2seOHZuHH374Ne+7/fbb8/TTT+fTn/70a/Z56aWXMmjQoFRWVuaoo47KsmXLWmzcAAAAAACtpXN7vvnatWuzZcuW9OvXr1l7v379snr16m3es2LFilx00UVZunRpOnfe9vD33XffLFiwIMOHD09dXV0+//nPZ8yYMfnd736XffbZZ5v3bN68OZs3b2663rBhQ5Jk/fr1aWhoeDPTAwCgFVRUVKSkpKS9h9EhNDY2Jknq6uraeSQAAPy3Hj16bLembdfQ9t9ePcDGxsZtDnrLli056aSTMnPmzLzjHe94zecddNBBOeigg5qux4wZk5EjR+amm27KjTfeuM17rrnmmsycOXOr9kGDBu3oNAAAaAMbNmxIz54923sYHcLf//73JElVVVU7jwQAgP/2ejVtSeO///d7O6ivr0+3bt2yaNGiTJw4sal96tSpWb58eX72s581679+/fq89a1vTadOnZraGhoa0tjYmE6dOmXJkiX5v//7v22+1xlnnJEXXnghP/zhD7f5+qt32jY0NOSvf/1revXq1SY7Oerq6lJVVZXnn3/eP0KAFmV9AVpLe60vr7crgf9oaGjIiy++2Gb/zXzmAK3F+gK0lqLWtO2607ZLly6prq5OTU1Ns9C2pqYmEyZM2Kp/z54989hjjzVrmzt3bh544IHcddddGTJkyDbfp7GxMcuXL8/w4cNfcyxlZWUpKytr1rb77ru/gdm0jJ49e/oAAlqF9QVoLdaX4iotLU1lZWWbv6+/E0Brsb4AraVo60u7H48wffr0TJo0KaNGjcro0aNz6623ZuXKlTnrrLOSJBdffHFWrVqVO+64I6WlpRk2bFiz+/v27Zvy8vJm7TNnzsxBBx2UffbZJ3V1dbnxxhuzfPny3HzzzW06NwAAAACAN6rdQ9sTTjgh69aty6xZs1JbW5thw4Zl8eLFTWfJ1tbWZuXKlW/omevXr8+ZZ56Z1atXp6KiIvvvv38efPDBHHDAAa0xBQAAAACAFtOuZ9ryH5s3b84111yTiy++eKtjGgB2hvUFaC3WF17N3wmgtVhfgNZS1PVFaAsAAAAAUCCl7T0AAAAAAAD+Q2gLAAAAAFAgQtuCO+SQQ3Leeee19zCAXZh1BoDW5rMGaG3WGWBXI7RtISUlJdv9OeWUU97Uc7/97W/niiuuaNnBAruM8ePH5/DDD9/ma4888khKSkry29/+to1HBXRUrVXPJMngwYMzZ86cFhsrrUNNC7QHNS3QUnalerZzm73TLq62trbpzwsXLsxll12WJ598sqmta9euzfr/61//ym677fa6z33b297WcoMEdjmnnXZajj322Dz33HMZNGhQs9fmz5+f/fbbLyNHjmyn0QEdzRutZ9j1qGmB9qCmBVrKrlTP2mnbQvr379/0U1FRkZKSkqbrTZs2Zffdd8+3vvWtHHLIISkvL8/Xvva1rFu3Lh/60IdSWVmZbt26Zfjw4fnGN77R7Lmv/orH4MGDc/XVV2fy5Mnp0aNH9thjj9x6661tPFugKI466qj07ds3CxYsaNa+cePGLFy4MMccc8zrrjMA/7a9eqZ///558MEHU11dnfLy8uy5556ZOXNmXn755ab7L7/88uyxxx4pKyvL29/+9px77rlJXqlnnnvuuUybNq1plwPFpKYF2oOaFmgpu1I9K7RtQxdeeGHOPffcPPHEExk3blw2bdqU6urq/OAHP8gf/vCHnHnmmZk0aVJ++ctfbvc5119/fUaNGpVly5bl7LPPzsc//vH86U9/aqNZAEXSuXPnnHzyyVmwYEEaGxub2hctWpT6+vqcfvrpb2qdAXi1H/3oR/nIRz6Sc889N48//njmzZuXBQsW5KqrrkqS3HXXXbnhhhsyb968rFixIt/5zncyfPjwJK98Nb6ysjKzZs1KbW1tsx0QdDxqWqClqWmBttDR6lmhbRs677zzcuyxx2bIkCF5+9vfnoEDB+b888/Pfvvtlz333DPnnHNOxo0bl0WLFm33OUceeWTOPvvs7L333rnwwgvTu3fv/PSnP22bSQCFM3ny5Dz77LPN1oH58+fn2GOPfdPrDMCrXXXVVbnooovy0Y9+NHvuuWfe97735Yorrsi8efOSJCtXrkz//v1z+OGHZ4899sgBBxyQM844I8krX43v1KlTevTo0bTLgY5LTQu0BjUt0No6Wj3rTNs2NGrUqGbXW7ZsyWc+85ksXLgwq1atyubNm7N58+a85S1v2e5zRowY0fTnf2/zXrNmTauMGSi+fffdNwcffHDmz5+fQw89NE8//XSWLl2aJUuWvOl1BuDVHn300fz6179u2omQvFLLbNq0KRs3bsxxxx2XOXPmZM8998z73//+HHnkkRk/fnw6d1Zu7mrUtEBrUNMCra2j1bN22rahV3+gXH/99bnhhhvyyU9+Mg888ECWL1+ecePGpb6+frvPefUveygpKUlDQ0OLjxfoOE477bTcfffdqaury+23355BgwblsMMOe9PrDMCrNTQ0ZObMmVm+fHnTz2OPPZYVK1akvLw8VVVVefLJJ3PzzTena9euOfvss/Pe9743//rXv9p76LQwNS3QWtS0QGvqaPWsrQ/taOnSpZkwYUI+8pGPJHnlL8+KFSsydOjQdh4Z0NEcf/zxmTp1au6888585StfyRlnnJGSkhLrDNBiRo4cmSeffDJ77733a/bp2rVrjj766Bx99NGZMmVK9t133zz22GMZOXJkunTpki1btrThiGkrPmuAlqKmBVpTR6tnhbbtaO+9987dd9+dhx9+OG9961sze/bsrF692gcP8IZ17949J5xwQj71qU9lw4YNOeWUU5JYZ4CWc9lll+Woo45KVVVVjjvuuJSWlub3v/99HnvssVx55ZVZsGBBtmzZkgMPPDDdunXLV7/61XTt2jWDBg1KkgwePDgPPvhgTjzxxJSVlaV3797tPCNais8aoKWoaYHW1NHqWccjtKMZM2Zk5MiRGTduXA455JD0798/xxxzTHsPC+igTjvttPztb39rOjQ9sc4ALWfcuHH5wQ9+kJqamrz73e/OQQcdlNmzZzcVsbvvvnu+9KUvZcyYMRkxYkTuv//+fP/730+vXr2SJLNmzcqzzz6bvfbaK3369GnPqdDCfNYALUlNC7SWjlbPljQ2Nja2+rsAAAAAALBD7LQFAAAAACgQoS0AAAAAQIEIbQEAAAAACkRoCwAAAABQIEJbAAAAAIACEdoCAAAAABSI0BYAAAAAoECEtgAAAAAABSK0Beggvv71r+eAAw5IRUVFevbsmaFDh+b000/PmjVr3vCzSkpK8rnPfa7p+pRTTsmwYcOarpcvX57LL788GzdubJGxAwBAoqYF2FFCW4AO4DOf+UwmTZqU97znPVm4cGEWLlyYyZMn5ze/+U1efPHFnX7+jBkzcueddzZdL1++PDNnzlTgAgDQYtS0ADuuc3sPAIDXd9NNN+WUU07J9ddf39R2xBFH5IILLkhDQ8NOP3+vvfba6WcAAMD2qGkBdpydtgAdwPr16zNgwIBtvlZa+p+lfPDgwfnEJz6R6667LgMHDky3bt0yYcKE1NbWbvf5//1VsgULFuTUU09NkvTp0yclJSUZPHhwy0wEAID/WWpagB0ntAXoAKqrq/PFL34xt912W1avXr3dvvfcc0/uueee3HLLLbnlllvyq1/9Kscee+wOv9cHPvCBXHrppUmS++67L4888kjuueeenRo/AACoaQF2nOMRADqAuXPnZuLEiTnjjDOSJEOGDMn48eMzbdq0rXYM/P3vf8/ixYuz++67J0kqKytz+OGHZ8mSJRk7duzrvlefPn2avlpWXV2d3r17t+hcAAD436SmBdhxdtoCdADDhg3LH//4x9x7772ZOnVqKioqcuONN2bEiBFZvnx5s76HHnpoU3GbJIcddlh69uyZX/ziF207aAAA+C9qWoAdJ7QF6CC6dOmSI488MnPmzMmyZcty3333ZePGjZk1a1azfn379t3q3r59+77uGWAAANDa1LQAO0ZoC9BBjRs3Lu9617vyxBNPNGtfs2bNVn3XrFnzmr/0AQAA2ouaFmDbhLYAHcCf//znrdr++c9/5vnnn0///v2btf/kJz/Jhg0bmq7vv//+1NXV5cADD9zh9+vSpUuSZNOmTW9yxAAA0JyaFmDH+UVkAB3A8OHDM378+IwbNy4DBgzIiy++mJtuuilr167N1KlTm/Xt0aNHjjjiiFx00UVZv359LrzwwhxwwAEZN27cDr/f0KFDkyQ333xzjjnmmHTr1i3Dhw9v0TkBAPC/RU0LsOOEtgAdwOWXX57vf//7mT59ev7yl7+kd+/eGTFiRO6///4ceuihzfpOnDgxlZWVOeuss/K3v/0thx9+eObNm/eG3m///ffP5Zdfnttuuy3XXnttqqqq8uyzz7bgjAAA+F+jpgXYcSWNjY2N7T0IAFrG4MGDc9RRR+ULX/hCew8FAADeFDUtgDNtAQAAAAAKRWgLAAAAAFAgjkcAAAAAACgQO20BAAAAAApEaAsAAAAAUCBCWwAAAACAAhHaAgAAAAAUiNAWAAAAAKBAhLYAAAAAAAUitAUAAAAAKBChLQAAAABAgQhtAQAAAAAK5P8BPQUQKhq+w+4AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1400x600 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting analysis plot saved.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "splits = [\"Train\", \"Val\", \"Test\"]\n",
+    "configs = [\"A\", \"B\"]\n",
+    "colors = {\"A\": \"steelblue\", \"B\": \"darkorange\"}\n",
+    "markers = {\"A\": \"o\", \"B\": \"s\"}\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(14, 6), sharey=False)\n",
+    "\n",
+    "# 4-class plot\n",
+    "ax = axes[0]\n",
+    "for config in configs:\n",
+    "    f1_scores = [results[config][s.lower()][\"f1\"] for s in splits]\n",
+    "    ax.plot(splits, f1_scores, marker=markers[config], color=colors[config],\n",
+    "            linewidth=2, markersize=8, label=f\"Config {config}\")\n",
+    "    for i, (s, v) in enumerate(zip(splits, f1_scores)):\n",
+    "        ax.annotate(f\"{v:.4f}\", (s, v), textcoords=\"offset points\",\n",
+    "                    xytext=(0, 10), ha=\"center\", fontsize=9, color=colors[config])\n",
+    "\n",
+    "ax.set_title(\"4-Class Engagement Classification\\nTrain / Val / Test Weighted F1\",\n",
+    "             fontsize=12, fontweight=\"bold\")\n",
+    "ax.set_ylabel(\"Weighted F1\", fontsize=11)\n",
+    "ax.set_xlabel(\"Split\", fontsize=11)\n",
+    "ax.set_ylim(0.45, 0.70)\n",
+    "ax.legend(fontsize=10)\n",
+    "ax.spines[\"top\"].set_visible(False)\n",
+    "ax.spines[\"right\"].set_visible(False)\n",
+    "ax.grid(axis=\"y\", alpha=0.3)\n",
+    "\n",
+    "# Binary plot\n",
+    "ax = axes[1]\n",
+    "for config in configs:\n",
+    "    f1_scores = [results_bin[config][s.lower()][\"f1\"] for s in splits]\n",
+    "    ax.plot(splits, f1_scores, marker=markers[config], color=colors[config],\n",
+    "            linewidth=2, markersize=8, label=f\"Config {config}\")\n",
+    "    for i, (s, v) in enumerate(zip(splits, f1_scores)):\n",
+    "        ax.annotate(f\"{v:.4f}\", (s, v), textcoords=\"offset points\",\n",
+    "                    xytext=(0, 10), ha=\"center\", fontsize=9, color=colors[config])\n",
+    "\n",
+    "ax.set_title(\"Binary Engagement Classification\\nTrain / Val / Test Weighted F1\",\n",
+    "             fontsize=12, fontweight=\"bold\")\n",
+    "ax.set_ylabel(\"Weighted F1\", fontsize=11)\n",
+    "ax.set_xlabel(\"Split\", fontsize=11)\n",
+    "ax.set_ylim(0.65, 0.80)\n",
+    "ax.legend(fontsize=10)\n",
+    "ax.spines[\"top\"].set_visible(False)\n",
+    "ax.spines[\"right\"].set_visible(False)\n",
+    "ax.grid(axis=\"y\", alpha=0.3)\n",
+    "\n",
+    "plt.suptitle(\"XGBoost Fitting Analysis — Underfitting/Overfitting Spectrum\\n(Pushshift Reddit, 276M Training Rows)\",\n",
+    "             fontsize=13, fontweight=\"bold\", y=1.02)\n",
+    "plt.tight_layout()\n",
+    "\n",
+    "plt.savefig(\"../outputs/figures/xgboost_fitting_analysis.png\", dpi=150, bbox_inches=\"tight\")\n",
+    "plt.show()\n",
+    "print(\"Fitting analysis plot saved.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6102a7e0-8d94-4640-957c-71abc7060661",
+   "metadata": {},
+   "source": [
+    "### Fitting Analysis Interpretation\n",
+    "\n",
+    "Both the 4-class and binary models exhibit the same characteristic pattern: train F1 is lower than val F1, which is lower than or comparable to test F1. This is the signature of underfitting rather than overfitting as an overfit model would show the opposite, with train F1 substantially exceeding val and test. Both configurations sit firmly in the high-bias region of the bias-variance spectrum.\n",
+    "\n",
+    "The upward slope from train to val is driven by temporal distribution shift. The training set spans 2012–2016, covering Reddit's early growth through mainstream expansion which is a noisy, heterogeneous period where engagement patterns varied widely across communities still establishing their norms. The 2017 validation and 2018 test sets represent a more behaviorally stable platform where subreddit cultures are more consistent and posting patterns more predictable, making them inherently easier to classify despite never being seen during training.\n",
+    "\n",
+    "Config B consistently outperforms Config A across both tasks and all splits. The performance gap is more pronounced in the binary task, where Config B achieves a test weighted F1 of 0.7440 versus Config A's 0.7280. The slight drop from val to test in both binary configs suggests mild temporal degradation as the model moves further from the training period, but the drop is small enough to indicate reasonable generalization.\n",
+    "\n",
+    "The binary task substantially outperforms the 4-class task across all configurations and splits — Config B test F1 of 0.7440 versus 0.5866. This gap reflects the inherent difficulty of distinguishing four fine-grained engagement tiers from pre-publication features alone. Collapsing to a binary high/low distinction removes the ambiguous boundary between classes like crowd-pleaser and debate-starter, which the feature importance analysis showed are the hardest to separate without access to post content."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c2b9190-649d-4226-b54d-70fdf5ddaa1f",
+   "metadata": {},
+   "source": [
+    "### 4-Class vs Binary Results Comparison\n",
+    "\n",
+    "The table below summarizes weighted F1 across all configurations and splits for both the 4-class and binary label tasks. The binary task consistently outperforms the 4-class task by approximately 15 percentage points on test weighted F1, reflecting the reduced complexity of a two-class decision boundary versus distinguishing four fine-grained engagement tiers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a5f75580-cccd-4ef8-9d21-2d42de1ac0fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                4-Class WF1  Binary WF1  Delta (Bin-4Cls)\n",
+      "Config   Split                                           \n",
+      "Config A Train       0.5283      0.7087            0.1804\n",
+      "         Val         0.5759      0.7435            0.1675\n",
+      "         Test        0.5689      0.7280            0.1590\n",
+      "Config B Train       0.5767      0.7375            0.1608\n",
+      "         Val         0.6089      0.7642            0.1554\n",
+      "         Test        0.5866      0.7440            0.1574\n"
+     ]
+    }
+   ],
+   "source": [
+    "rows = []\n",
+    "for config in [\"A\", \"B\"]:\n",
+    "    for split in [\"train\", \"val\", \"test\"]:\n",
+    "        rows.append({\n",
+    "            \"Config\":          f\"Config {config}\",\n",
+    "            \"Split\":           split.capitalize(),\n",
+    "            \"4-Class WF1\":     round(results[config][split][\"f1\"], 4),\n",
+    "            \"Binary WF1\":      round(results_bin[config][split][\"f1\"], 4),\n",
+    "            \"Delta (Bin-4Cls)\": round(results_bin[config][split][\"f1\"] - results[config][split][\"f1\"], 4),\n",
+    "        })\n",
+    "\n",
+    "comparison_df = pd.DataFrame(rows).set_index([\"Config\", \"Split\"])\n",
+    "print(comparison_df.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83f88df8-13da-4e74-9ccf-d82669460ede",
+   "metadata": {},
+   "source": [
+    "### Milestone 4 Requirement: Speedup Analysis Markdown\n",
+    "\n",
+    "To quantify the benefit of distributed computing, we measure speedup using the VADER selftext sentiment preprocessing stage as the representative operation. This stage applies a Python UDF computing compound sentiment scores across all 535,480,818 rows which is a compute-intensive workload representative of the broader preprocessing pipeline.\n",
+    "\n",
+    "**Baseline Measurement (Single Thread):**\n",
+    "A single-threaded benchmark was run on a sample of 10,000 rows to measure throughput at 5,788 rows/second. Extrapolating to the full dataset of 535,480,818 rows yields an estimated single-thread runtime of 431.9 minutes (25,914 seconds).\n",
+    "\n",
+    "**Scaled Measurement (16 Workers):**\n",
+    "The full selftext sentiment UDF was executed on the complete 535,480,818 row dataset using Spark's `local[*]` mode with 16 cores as parallel workers. Total wall-clock runtime: 38 minutes 28 seconds (2,308 seconds).\n",
+    "\n",
+    "**Metrics:**\n",
+    "\n",
+    "| Executors | Time (sec) | Speedup | Efficiency |\n",
+    "|-----------|------------|---------|------------|\n",
+    "| 1         | 25,914 (estimated) | 1.00x | 100% |\n",
+    "| 16        | 2,308      | 11.23x  | 70.2%      |\n",
+    "\n",
+    "**Speedup** = T₁ / T₁₆ = 25,914 / 2,308 = **11.23x**\n",
+    "\n",
+    "**Efficiency** = Speedup / n = 11.23 / 16 = **70.2%**\n",
+    "\n",
+    "**Amdahl's Law Analysis:**\n",
+    "The theoretical maximum speedup with 16 processors is 16x (100% efficiency), achievable only if the workload is perfectly parallelizable with no serial fraction. Our observed speedup of 11.23x yields an implied parallel fraction of approximately 96.4% using Amdahl's Law:\n",
+    "\n",
+    "Speedup = 1 / ((1 - p) + p/n) → solving for p: p ≈ 0.964\n",
+    "\n",
+    "The remaining ~3.6% serial fraction corresponds to task scheduling overhead, Python UDF initialization per partition, and VADER analyzer instantiation at the module level. \n",
+    "\n",
+    "Note: The single-thread baseline is estimated from a 10,000-row benchmark sample rather than a full single-thread run. Running the full pipeline single-threaded would require approximately 7 hours of wall time and is not feasible within the project's timeline. The benchmark-based estimate should be a reasonable benchmark given the way VADER operates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "033d12b8-9944-4e76-8b13-5fdd21fab457",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Milestone 3 v2: Temporal Leakage Fix + Honest Baseline

## TL;DR

The original Milestone 3 pipeline had a temporal aggregate leakage bug that inflated reported test performance by **10–14 weighted-F1 points** across all four model configurations. This PR diagnoses the bug, rebuilds the affected portion of the pipeline with strict train-only aggregation, and produces a corrected baseline that — for the first time — honestly measures forward-in-time generalization. The corrected results are lower but trustworthy, and the diagnostic process itself surfaced a finding that strongly motivates the M4 NLP enrichment.

## The Bug

Author and subreddit aggregate features (`author_mean_score`, `author_post_count`, `subreddit_post_count`, `subreddit_median_score`, `subreddit_median_comments`) were computed via `groupBy().agg()` over the full 2012–2018 dataset *before* the temporal train/val/test split. Every validation and test row therefore had access to summary statistics that incorporated information from its own time period — including, in the worst case (`author_mean_score`), a direct contribution of the row's own score to its author's mean.

## Severity (cold-start diagnostic)

Before the fix, a temporal diagnostic measured how many val/test rows had authors or subreddits unseen in the training period:

| Split | Unknown Author | Unknown Subreddit |
|---|---|---|
| Val (2017)  | 28.81% | 7.09%  |
| Test (2018) | **48.62%** | **18.97%** |

Nearly half of the test set's authors had no legitimate training-period history. Under correct methodology, these rows should have null aggregate features. The leaky pipeline gave them lookup access to the very statistics they should not have known.

## What Was Rebuilt

The fix is structural, not cosmetic: the leakage cannot be patched in-place because it lives in the *ordering* of operations relative to the split.

**Before (v1):** features → aggregates → persist → split → scale
**After (v2):** features → persist → **split** → train-only aggregates → join to all splits → persist per-split

Specifically:

- **Per-row feature engineering** (title structural, post type, temporal) is computed on the unsplit dataset — these are row-local and not leakage-prone.
- **Temporal split happens before any aggregate is computed**, so train-only statistics cannot see val/test rows.
- **Author and subreddit aggregates are computed on `train_split` only**, persisted to disk to break Spark lineage, then left-joined to all three splits.
- **Cold-start flags** (`is_new_author`, `is_new_subreddit`) are added based on join-null status.
- **Aggregate nulls are not imputed**. They are passed through to XGBoost, which handles missing values natively via its learned default-direction mechanism.
- **`VectorAssembler(handleInvalid="keep")`** preserves cold-start rows with NaN entries in the feature vector — the v1 default of `"skip"` would have silently dropped up to 48.6% of test rows.
- **`StandardScaler` is removed** from the XGBoost pipeline. Tree models are scale-invariant; scaling would have computed mean/std over the cold-start NaNs and contaminated the feature statistics.

## Non-Obvious Engineering Issues Encountered

Several issues surfaced during the rebuild that are worth documenting:

- **Spark shared-lineage join failure.** The first train-only aggregation attempt produced an impossible 86.24% cold-start rate on training data (correct value: 0% by construction). Root cause: the aggregate DataFrame and the split DataFrame both derived from the same `df_features_base` plan, and the `on="author"` join produced ambiguous column-provenance resolution that silently returned nulls for matching keys. Fix: persist the aggregate table to disk and reload it before joining, severing the shared lineage. The same pattern was applied prophylactically to the subreddit aggregate join.
- **Duplicate `id` in the sentiment lookup.** The dataset's single known duplicate post id (documented in M2) propagated into the v1 VADER artifact and caused a left-join fan-out, inflating the test split from 144,949,019 to 144,949,021 rows. Fix: `dropDuplicates(["id"])` on the sentiment lookup before joining.
- **`overwrite` + stale file listing.** Re-running the sentiment-lookup write to an existing directory caused `SparkFileNotFoundException` during the join, because Spark's cached file listing pointed at part-files that `mode("overwrite")` had replaced with differently-named files. Fix: write to a fresh path with an explicit `shutil.rmtree` defense, plus eager materialization (`.count()`) before any downstream lazy plan binds to the listing.
- **Out-of-memory crashes during XGBoost training.** Distributed XGBoost in Spark `local[*]` mode materializes the training data as in-memory DMatrix structures within a single JVM. The full 276M-row training set exceeded the node's memory capacity, killing the JVM mid-fit. Mitigation: 30% stratified sample on `label_4class_idx` (preserves class proportions to four decimal places), yielding 82,930,798 training rows.
- **Binary classification objective conflict.** Initial binary training crashed with a labels/preds shape mismatch (`5183178 vs 10366356`). XGBoost auto-selected `binary:logistic` for the two-class problem, which produces one prediction per row, while the explicit `num_class=2` parameter allocated prediction space for two — exactly the 2× mismatch in the error. Fix: remove `num_class` from binary configurations entirely; `binary:logistic` is the correct objective and does not use it.

## Results: Corrected Baseline vs. Leaky v1

| Task | v1 Test WF1 (leaky) | **v2 Test WF1 (corrected)** | Δ |
|---|---|---|---|
| 4-class Config A | 0.5689 | **0.4514** | −0.118 |
| 4-class Config B | 0.5866 | **0.4451** | −0.142 |
| Binary Config A   | 0.7280 | **0.6260** | −0.102 |
| Binary Config B   | 0.7440 | **0.6149** | −0.129 |

## Key Findings From the Corrected Pipeline

**Configuration ranking inverts on test.** In v1, Config B (aggressive) outperformed Config A (conservative) across the board. With the leakage removed, Config A now beats Config B on test for both tasks, even as Config B retains the higher train weighted F1. This is a textbook signature of overfitting to a spurious feature: deeper trees and lighter regularization absorbed more of the leaked aggregate signal, signal that does not generalize once removed.

**The train→test gap tracks cold-start prevalence almost linearly** (0% / 28.8% / 48.6% cold-start authors → monotonically declining F1). The test underperformance is not classical overfitting but a structural property of forward-in-time prediction on a growing platform.

**Five features show zero importance across all four models**: three are genuinely uninformative title-structural features (`has_question`, `has_exclamation`, `title_is_allcaps`); two are the cold-start flags themselves (zero variance on train by construction, since every train row has `is_new_author = 0`). XGBoost's native NaN handling routes cold-start rows through learned default branches without needing the explicit flags. The flags are retained for methodological transparency; the three structural features will be dropped in subsequent feature-set work.

## What Persists From This PR

- `data/processed/features_base_v2/` — per-row engineered features on the unsplit dataset
- `data/processed/{train,val,test}_features_v2/` — leakage-corrected splits with train-only aggregates and cold-start flags
- `data/processed/sentiment_lookup_v2b/` — deduplicated VADER sentiment lookup
- `data/processed/{train,val,test}_features_nlp_v2/` — splits with VADER sentiment attached
- `data/processed/{train,val,test}_model_v2/` — assembled feature vectors + indexed labels (model-ready)
- `data/processed/train_sample30_v2/` — 30% stratified training sample (82,930,798 rows, class proportions preserved to four decimals)
- `models/xgb_{4class,binary}_config{A,B}_v2/` — four trained XGBoost models on the corrected feature set
- `outputs/xgboost_v2_evaluation_results.json` — per-class precision/recall/F1 across train/val/test for all four models
- `outputs/figures/` — feature importance plots (4-class and binary) and fitting analysis plot

## Out of Scope for This PR

The notebook is locked at the leakage-corrected baseline. The TF-IDF and SVD enrichment work that motivated the rebuild is staged below the M3 Conclusion section as a continuation, but will be developed in follow-up commits to this branch ahead of M4. The canonical from-scratch VADER cells were preserved in place; the present pass joins precomputed sentiment from the prior run for iteration speed, with a markdown note documenting the equivalence for full reproducibility.

Closes #35 